### PR TITLE
Fix errors with GCC 4.7.0

### DIFF
--- a/src/mu-store.cc
+++ b/src/mu-store.cc
@@ -28,6 +28,7 @@
 #include <stdexcept>
 
 #include <errno.h>
+#include <unistd.h>
 
 #include "mu-store.h"
 #include "mu-store-priv.hh" /* _MuStore */


### PR DESCRIPTION
When compiling mu with gcc 4.7.0 the following errors occur:

mu-store.cc:77:21: error: 'F_OK' was not declared in this scope
mu-store.cc:77:25: error: 'access' was not declared in this scope

This simple patch seems to fix that
