### PR TITLE
Add --quick to index

### DIFF
--- a/man/mu-easy.1
+++ b/man/mu-easy.1
@@ -47,6 +47,12 @@ or 'spam' folders) by creating a file called \fI.noindex\fR in the directory.
 When \fBmu\fR sees such a file, it will exclude this directory and its
 sub-directories from indexing.
 
+You can also define which directories \fBmu index\fR should visit when using the
+\fI--quick\fR option. By creating files called \fI.quickindex\fR in \fBall\fR
+the directories that you want indexed (from Maildir down to the specific directory)
+you can limit a quick index to only those directories. This is useful for quick
+incremental indexes of directories that you know updates regularly.
+
 .SH SEARCHING YOUR E-MAIL
 
 After you have indexed your mail, you can start searching it. By default, the

--- a/man/mu-index.1
+++ b/man/mu-index.1
@@ -33,6 +33,12 @@ directory and all of its subdirectories will be ignored. This can be useful to
 exclude certain directories from the indexing process, for example directories
 with spam-messages.
 
+If the \fI--quick\fT option is specified and there is a file called
+\fI.quickindex\fR in a directory, that directory will get included in the quick
+index. In this case, the subdirectories has to be marked explicitly as
+well. Also note that you have to mark your Maildir with a
+\fI.quickindex\fR for it to start indexing at all.
+
 The first run of \fBmu index\fR may take a few minutes if you have a lot of
 mail (ten thousands of messages).  Fortunately, such a full scan needs to be
 done only once; after that it suffices to index the changes, which goes much
@@ -58,6 +64,11 @@ and not here, as they apply to multiple mu commands.
 starts searching at \fI<maildir>\fR. By default, \fBmu\fR uses whatever the
 \fBMAILDIR\fR environment variable is set to; if it is not set, it tries
 \fI~/Maildir\fR. See the note on mixing sub-maildirs below.
+
+.TP
+\fB\-\-quick\fR
+performs a quick index, only indexing directories marked with
+\fI.quickindex\fR. Leaves the rest of the index untouched.
 
 .TP
 \fB\-\-reindex\fR

--- a/src/mu-cmd-index.c
+++ b/src/mu-cmd-index.c
@@ -330,7 +330,8 @@ cmd_index (MuIndex *midx, MuConfig *opts, MuIndexStats *stats,
 			   show_progress ?
 			   (MuIndexMsgCallback)index_msg_cb :
 			   (MuIndexMsgCallback)index_msg_silent_cb,
-			   NULL, &idata);
+			   NULL, opts->quick,
+			   &idata);
 
 	if (!opts->quiet) {
 		print_stats (stats, TRUE, !opts->nocolor);

--- a/src/mu-cmd-server.c
+++ b/src/mu-cmd-server.c
@@ -751,7 +751,8 @@ cmd_index (MuStore *store, MuQuery *query, GSList *args, GError **err)
 
 	}
 	mu_index_stats_clear (&stats);
-	rv = mu_index_run (index, path, FALSE, &stats, index_msg_cb, NULL, NULL);
+	rv = mu_index_run (index, path, FALSE, &stats, index_msg_cb, NULL, FALSE,
+			   NULL);
 	if (rv != MU_OK && rv != MU_STOP) {
 		print_error (MU_ERROR_INTERNAL, "indexing failed");
 		goto leave;

--- a/src/mu-config.c
+++ b/src/mu-config.c
@@ -144,6 +144,8 @@ config_options_group_index (void)
 	GOptionEntry entries[] = {
 		{"maildir", 'm', 0, G_OPTION_ARG_FILENAME, &MU_CONFIG.maildir,
 		 "top of the maildir", NULL},
+		{"quick", 'q', 0, G_OPTION_ARG_NONE, &MU_CONFIG.quick,
+		 "only index directories marked with .quickindex (false)", NULL},
 		{"reindex", 0, 0, G_OPTION_ARG_NONE, &MU_CONFIG.reindex,
 		 "index even already indexed messages (false)", NULL},
 		{"rebuild", 0, 0, G_OPTION_ARG_NONE, &MU_CONFIG.rebuild,

--- a/src/mu-config.h
+++ b/src/mu-config.h
@@ -103,6 +103,7 @@ struct _MuConfig {
 	gboolean        rebuild;	/* empty the database before indexing */
 	gboolean        autoupgrade;    /* automatically upgrade db
 					 * when needed */
+	gboolean        quick;          /* only index indicated directories */
 	int             xbatchsize;     /* batchsize for xapian
 					 * commits, or 0 for
 					 * default */

--- a/src/mu-index.c
+++ b/src/mu-index.c
@@ -313,6 +313,7 @@ MuError
 mu_index_run (MuIndex *index, const char* path,
 	      gboolean reindex, MuIndexStats *stats,
 	      MuIndexMsgCallback msg_cb, MuIndexDirCallback dir_cb,
+	      gboolean quick_index,
 	      void *user_data)
 {
 	MuIndexCallbackData cb_data;
@@ -336,6 +337,7 @@ mu_index_run (MuIndex *index, const char* path,
 	rv = mu_maildir_walk (path,
 			      (MuMaildirWalkMsgCallback)on_run_maildir_msg,
 			      (MuMaildirWalkDirCallback)on_run_maildir_dir,
+			      quick_index,
 			      &cb_data);
 
 	mu_store_flush (index->_store);
@@ -392,7 +394,7 @@ mu_index_stats (MuIndex *index, const char* path,
 
 	return mu_maildir_walk (path,
 				(MuMaildirWalkMsgCallback)on_stats_maildir_file,
-				NULL,&cb_data);
+				NULL, FALSE, &cb_data);
 }
 
 struct _CleanupData {

--- a/src/mu-index.h
+++ b/src/mu-index.h
@@ -125,6 +125,7 @@ typedef MuError (*MuIndexDirCallback) (const char* path, gboolean enter,
  * @mu_index_stats_clear before calling this function
  * @param cb_msg a callback function called for every msg indexed;
  * @param cb_dir a callback function called for every dir entered/left or NULL
+ * @param quick_index whether a quick index was requested
  * @param user_data a user pointer that will be passed to the callback function
  *
  * @return MU_OK if the stats gathering was completed succesfully,
@@ -133,7 +134,8 @@ typedef MuError (*MuIndexDirCallback) (const char* path, gboolean enter,
  */
 MuError mu_index_run (MuIndex *index, const char* path, gboolean force,
 		      MuIndexStats *stats, MuIndexMsgCallback msg_cb,
-		      MuIndexDirCallback dir_cb, void *user_data);
+		      MuIndexDirCallback dir_cb, gboolean quick_index,
+		      void *user_data);
 
 /**
  * gather some statistics about the Maildir; this is usually much faster

--- a/src/mu-maildir.h
+++ b/src/mu-maildir.h
@@ -105,6 +105,7 @@ typedef MuError (*MuMaildirWalkDirCallback)
  * @param path the maildir path to scan
  * @param cb_msg the callback function called for each msg
  * @param cb_dir the callback function called for each dir
+ * @param quick_index a flag to indicate if a quick index was requested
  * @param data user data pointer
  *
  * @return a scanner result; MU_OK if everything went ok,
@@ -112,7 +113,8 @@ typedef MuError (*MuMaildirWalkDirCallback)
  * case of error
  */
 MuError mu_maildir_walk (const char *path, MuMaildirWalkMsgCallback cb_msg,
-			 MuMaildirWalkDirCallback cb_dir, void *data);
+			 MuMaildirWalkDirCallback cb_dir, gboolean quick_index,
+			 void *data);
 /**
  * recursively delete all the symbolic links in a directory tree
  *

--- a/www/cheatsheet.org
+++ b/www/cheatsheet.org
@@ -20,6 +20,18 @@ If =mu= did not guess the right Maildir, you can set it explicitly:
     directories with spam-messages), put a file called =.noindex= in the directory
     to exlude, and it will be ignored when indexing (including its children)
 
+*** Declaring which directories are part of a quick index
+
+    You can declare which directories should be part of a quick index by putting
+    =.quickindex = files in those directories. When =mu-index= is invoked with
+    =--quick=, only those folders will be indexed. The rest of the index will stay
+    untouched.
+    
+    Note that the whole directory tree has to be marked as quick indexable (the
+    reverse of .noindex):
+
+#+html:<pre> $ touch ~/Maildir/.quickindex ~/Maildir/inbox/.quickindex ~/Maildir/inbox/cur/.quickindex</pre>
+
 ** Finding messages
 
    After you have indexed your messages, you can search them. Here are some


### PR DESCRIPTION
Only index directories marked with .quickindex

The use case is this:
- Indexing my full Maildir on my old desktop takes 5 minutes to get through 230k of emails
- Most of that mail is in archived directories which rarely (if ever) change
- I want all my mail to be part of my index, for searching purposes (so .noindex is not an option)
- I want to be able to index only specific directories that I know changes daily
