### PR TITLE
Widen search results

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -369,6 +369,7 @@ after the end of the search results."
       (define-key map "s" 'mu4e-headers-search)
       (define-key map "S" 'mu4e-headers-search-edit)
       (define-key map "/" 'mu4e-headers-search-narrow)
+      (define-key map "\\" 'mu4e-headers-search-widen)
 
       (define-key map "j" 'mu4e~headers-jump-to-maildir)
 
@@ -993,6 +994,12 @@ the last search expression."
     (mu4e-error "There's nothing to filter"))
   (mu4e-headers-search
     (format "(%s) AND %s" mu4e~headers-last-query filter)))
+
+
+(defun mu4e-headers-search-widen ()
+  "Widen the current search by removing any narrowing query."
+  (interactive)
+  (mu4e-headers-search (mu4e~headers-pop-query 'past)))
 
 
 (defun mu4e-headers-change-sorting (&optional dont-refresh)


### PR DESCRIPTION
I _love_ `mu4e-headers-search-narrow` but I was really starting to miss its complement. I use a "combined inbox" bookmark that I often narrow to `flag:unread` temporarily, then like to pop back to normal. Thanks to mu4e's structure, this was incredibly trivial to implement (heck, this is probably better implemented already, I just didn't see it.)
