### PR TITLE
Added variable mu4e-confirm-quit.

### DIFF
--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -128,6 +128,11 @@ see `mu4e-headers-visible-lines' and
 view buffer."
   :group 'mu4e-view)
 
+(defcustom mu4e-confirm-quit t
+  "Whether to confirm to quit mu4e."
+  :type 'boolean
+  :group 'mu4e)
+
 ;; crypto
 (defgroup mu4e-crypto nil
   "Crypto-related settings."

--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -82,8 +82,10 @@
 (defun mu4e-quit()
   "Quit the mu4e session."
   (interactive)
-  (when (y-or-n-p (mu4e-format "Are you sure you want to quit?"))
-    (mu4e~stop)))
+  (if mu4e-confirm-quit
+	  (when (y-or-n-p (mu4e-format "Are you sure you want to quit?"))
+		(mu4e~stop))
+	(mu4e~stop)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
This short change will allow the mu4e user to disable the confirmation message when quitting mu4e.
