### PR TITLE
mu4e-utils: Detect if update process asks for a password.

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -682,6 +682,9 @@ FUNC (if non-nil) afterwards."
 (defconst mu4e~update-mail-name "*mu4e-update-mail*"
   "Name of the process to update mail.")
 
+(defvar mu4e~get-mail-ask-password "mu4e get-mail: Enter password: "
+  "Query string for `mu4e-get-mail-command' password.")
+
 (defvar mu4e~get-mail-password-regexp "^Remote: Enter password: $"
   "Regexp to match a password query in the `mu4e-get-mail-command' output.")
 
@@ -695,7 +698,9 @@ into the process buffer."
     (let ((inhibit-read-only t))
       ;; Check whether process asks for a password and query user
       (when (string-match mu4e~get-mail-password-regexp msg)
-        (process-send-string proc (concat (read-passwd "Password: ") "\n")))
+        (process-send-string proc (concat
+                                   (read-passwd mu4e~get-mail-ask-password)
+                                   "\n")))
       (insert msg))))
 
 (defun mu4e-update-mail (&optional buf)


### PR DESCRIPTION
Offlineimap (or other mail fetchers) may query the user for a
password. This patch adds a process filter to the `mu4e-update-mail'
process and checks if the process asks for a password (Currently only
matches "^Remote: Enter password: $"). It then reads the password from
the user.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
