### PR TITLE
Update configure script when libuuid is missing on debian.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,10 @@ AC_CHECK_HEADERS([locale.h langinfo.h])
 AC_SYS_LARGEFILE
 
 # check for some libs
-AC_CHECK_LIB([uuid], [uuid_generate_random],[],AC_MSG_ERROR([libuuid not found]))
+AC_CHECK_LIB([uuid], [uuid_generate_random],[],
+   AC_MSG_ERROR([
+      libuuid not found. In debian/ubuntu the package would be 'uuid-dev'.
+   ]))
 AC_CHECK_LIB([z], [inflateEnd], [],AC_MSG_ERROR([zlib not found]))
 
     


### PR DESCRIPTION
It took me forever to figure out that, on my ubuntu-based machine (actually Linux Mint), the package to install libuuid was `uuid-dev`.

There is understandably confusion around this, since there appear to be many uuid-related libraries one could install, and `apt-get build-dep` did not install this, probably because the version which Mint ships is out of date: http://stackoverflow.com/questions/1089741/how-do-i-obtain-use-libuuid

I'm unsure in which version libuuid was added as a dependency?
