### PR TITLE
[mu4e] Add newlines to signature verficiation verdict

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -1170,7 +1170,8 @@ or message-at-point."
 	(switch-to-buffer buf)
 	(erase-buffer)
 	(insert output)
-	(goto-char (point-min))
+    (replace-string "; " "\n" nil (point-min) (point-max))
+    (goto-char (point-min))
 	(local-set-key "q" 'kill-buffer-and-window)))
     (select-window win)))
 


### PR DESCRIPTION
This pull request replaces all occurances of the string `;` with newlines. This creates a nicer visual for signature verification.
