### PR TITLE
mu4e-header-highlight-face: inherit region

### DIFF
--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -344,7 +344,7 @@ flag set)."
   :group 'mu4e-faces)
 
 (defface mu4e-header-highlight-face
-  '((t :inherit default :weight bold :underline t))
+  '((t :inherit region :weight bold :underline t))
   "Face for the header at point."
   :group 'mu4e-faces)
 


### PR DESCRIPTION
This should make it more intuitive to see that actions are performed
on the region as well as the current line (which usually is not part
of the region).

By the way: I noticed that many faces use `:bold t` and `:italic t` I think you have to use `:weight bold` and `:slant italic` instead. (Though I would prefer these faces _not_ being bold and/or italic - so I should have kept quiet :-)
