### PR TITLE
mu4e-cited-4-face: inherit font-lock-keyword-face

### DIFF
--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -422,7 +422,7 @@ flag set)."
   :group 'mu4e-faces)
 
 (defface mu4e-cited-4-face
-  '((t :inherit font-lock-pseudo-keyword-face :bold nil :italic t))
+  '((t :inherit font-lock-keyword-face :bold nil :italic t))
   "Face for cited message parts (level 4)."
   :group 'mu4e-faces)
 


### PR DESCRIPTION
The previously inherited face font-lock-pseudo-keyword-face does not
exist in emacs-24.2 (anymore?).
