### PR TITLE
mu4e~header-line-format: use same font as in buffer

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -638,7 +638,7 @@ after the end of the search results."
 	      (if width
 		(truncate-string-to-width name width 0 ?\s t)
 		name)
-	      'face (if arrow 'bold 'fixed-pitch)
+	      'face (when arrow 'bold)
 	      'help-echo help
 	      'mouse-face (when sortable 'highlight)
 	      'keymap (when sortable map)


### PR DESCRIPTION
Use face `bold' for the sorted column but leave the face unspecified
for other columns.  This is how tabulated-list does it to; it only
uses fixed-pitch for whitespace between columns.

The problem with using fixed-pitch is that uses "Monospace" which
might be a different monospace font than what is used for `default'.
These fonts might have a different width causing columns in the header
and the buffer not to be aligned.

Inheriting `fixed-pitch' from`default' instead of specifying the font
does not work as that causes the `fixed-pitch'ed parts of the
header-line not to be raised like the rest anymore.  One (that is
every user) could also manually copy the font family from`default'.

Simply not specifying the font fixes all that.
