### PR TITLE
mu4e: set symbol prop definition-name in defun macros

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -422,15 +422,14 @@ after the end of the search results."
 
 (defmacro mu4e~headers-defun-mark-for (mark)
   "Define a function mu4e~headers-mark-MARK."
-  (let ((funcname (intern (concat "mu4e-headers-mark-for-" (symbol-name mark))))
-	 (docstring (concat "Mark header at point with " (symbol-name mark) ".")))
-     `(defun ,funcname () ,docstring
-	(interactive)
-	(mu4e-headers-mark-and-next (quote ,mark)))))
+  (let ((funcname (intern (format "mu4e-headers-mark-for-%s" mark)))
+	(docstring (format "Mark header at point with %s." mark)))
+    `(progn
+       (defun ,funcname () ,docstring
+	 (interactive)
+	 (mu4e-headers-mark-and-next ',mark))
+       (put ',funcname 'definition-name ',mark))))
 
-;; define our mark functions; there must be some way to do this in a loop but
-;; since `mu4e~headers-defun-mark-func' is a macro, the argument must be a
-;; literal value.
 (mu4e~headers-defun-mark-for refile)
 (mu4e~headers-defun-mark-for something)
 (mu4e~headers-defun-mark-for delete)

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -1099,18 +1099,14 @@ user that unmarking only works in the header list."
 
 (defmacro mu4e~view-defun-mark-for (mark)
   "Define a function mu4e-view-mark-for-MARK."
-  (let ((funcname (intern (concat "mu4e-view-mark-for-" (symbol-name mark))))
-	 (docstring (format "Mark the current message for %s."
-		      (symbol-name mark))))
-    `(defun ,funcname () ,docstring
-       (interactive)
-       (mu4e~view-in-headers-context
-	 (mu4e-headers-mark-and-next (quote ,mark))))))
-
-;; would be cool to do something like the following, but somehow, I can't get
-;; the quoting right...
-;; (dolist (mark '(move trash refile delete flag unflag unmark deferred))
-;;   (mu4e~view-defun-mark-for mark))
+  (let ((funcname (intern (format "mu4e-view-mark-for-%s" mark)))
+	(docstring (format "Mark the current message for %s." mark)))
+    `(progn
+       (defun ,funcname () ,docstring
+	 (interactive)
+	 (mu4e~view-in-headers-context
+	  (mu4e-headers-mark-and-next ',mark)))
+       (put ',funcname 'definition-name ',mark))))
 
 (mu4e~view-defun-mark-for move)
 (mu4e~view-defun-mark-for trash)


### PR DESCRIPTION
This allows `find-function' to find the definition.  While the
definition doesn't contain much useful information jumping there
instead of the beginning of the file is still better because the macro
used to define them is defined right above.

Also remove the comments about wanting to define the commands in a
loop.  One shouldn't do that; it would again make it impossible to
find the definition.
