### PR TITLE
Fix intra-array separator in address fields output by mu-sexp-convert

### DIFF
--- a/contrib/mu-sexp-convert
+++ b/contrib/mu-sexp-convert
@@ -156,7 +156,7 @@ into a list of pairs
 				     (if (string? (cdr addr))
 				       (format #f "\"email\": \"~a\""
 					 (string->json (cdr addr))) "")))
-			expr " ")
+			expr ", ")
 		      "]"))
 		  ((string= parent "parts") "[]") ;; todo 
 		  ;; convert the crazy emacs time thingy to time_t...


### PR DESCRIPTION
It is now "`,`" rather than "` `"; the old behavior would produce invalid JSON whenever the "from", "to", "cc", or "bcc" fields contained multiple entires.
