### PR TITLE
Fix 'Â' letters in a message view

### DIFF
--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -175,10 +175,10 @@ part, but this can be changed by setting
     (with-temp-buffer
       (insert body)
       (goto-char (point-min))
-      (while (re-search-forward "[Â Â’]" nil t)
+      (while (re-search-forward "[ ’]" nil t)
 	(replace-match
 	  (cond
-	    ((string= (match-string 0) "Â’") "'")
+	    ((string= (match-string 0) "’") "'")
 	    (t		                       ""))))
       (buffer-string))))
 


### PR DESCRIPTION
Hi,

a message view removes all cyrillic letters 'б'. It seems like regexp in mu4e-message-body-text was wrong. 
