### PR TITLE
Drop misplaced braces

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -28,7 +28,7 @@ Documentation License.''
 
 @titlepage
 @title @t{mu4e} - an e-mail client for emacs
-@subtitle{version  @value{mu-version}}
+@subtitle version  @value{mu-version}
 @author Dirk-Jan C. Binnema
 
 @c The following two commands start the copyright page.


### PR DESCRIPTION
'make' fails to build docs:

```
mu4e.texi:31: Misplaced {
mu4e.texi:31: Misplaced }
```

Not sure if it's the best way to fix ;-)
