### PR TITLE
Spelling fix for smtp-mail-queue-dir

### DIFF
--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -158,7 +158,7 @@ clicked."
   "Toggle sending mail mode, either queued or direct."
   (interactive)
   (unless (file-directory-p smtpmail-queue-dir)
-    (mu4e-error "`smtp-queue-dir' does not exist"))
+    (mu4e-error "`smtpmail-queue-dir' does not exist"))
   (setq smtpmail-queue-mail (not smtpmail-queue-mail))
   (message
     (concat "Outgoing mail will now be "


### PR DESCRIPTION
- mu4e/mu4e-main.el (mu4e~main-toggle-mail-sending-mode): correct
  error message to say `smtpmail-queue-dir' instead of
  `smtp-queue-dir'

Signed-off-by: jmickey j@codemac.net
