### PR TITLE
Automatically scroll the mail fetch status window

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -670,19 +670,24 @@ successful, call FUNC (if non-nil) afterwards."
 Currently the filter only checks if the command asks for a password
 by matching the output against `mu4e~get-mail-password-regexp'.
 The messages are inserted into the process buffer."
-  (save-current-buffer
-    (when (process-buffer proc)
-      (set-buffer (process-buffer proc)))
-    (let ((inhibit-read-only t))
-      ;; Check whether process asks for a password and query user
-      (when (string-match mu4e~get-mail-password-regexp msg)
-        (if (process-get proc 'x-interactive)
-            (process-send-string proc
-	      (concat (read-passwd mu4e~get-mail-ask-password) "\n"))
-	  ;; TODO kill process?
-          (mu4e-error "Unrecognized password request")))
-      (when (process-buffer proc)
-        (insert msg)))))
+  (when (string-match mu4e~get-mail-password-regexp msg)
+    (if (process-get proc 'x-interactive)
+        (process-send-string proc
+                             (concat (read-passwd mu4e~get-mail-ask-password) "\n"))
+      ;; TODO kill process?
+      (mu4e-error "Unrecognized password request")))
+  (when (process-buffer proc)
+    (let ((inhibit-read-only t)
+          (process-window (get-buffer-window (process-buffer proc))))
+      ;; Insert at end of buffer. Leave point alone.
+      (save-excursion
+        (set-buffer (process-buffer proc))
+        (goto-char (point-max))
+        (insert msg))
+      ;; Auto-scroll unless user is interacting with the window.
+      (when (not (eq (selected-window) process-window))
+        (with-selected-window process-window
+          (goto-char (point-max)))))))
 
 (defun  mu4e-update-index ()
   "Update the mu4e index."


### PR DESCRIPTION
My workflow is to run the fetch process on demand without an update
interval. In my case, I use offlineimap. This pops up the status window,
which shows only the top-most lines of offlineimap output. I made these
changes to auto-scroll the window so that I can get a feel for what
offlineimap is up to.

Since I made message insertion more clever, and password prompting was
unrelated, I unnested it. I then added auto-scrolling to the status
window. Finally, I found that when the status window was selected, point
would move out from under me to the end of the buffer. Changing
save-current-buffer to save-excursion left point alone.

To test this, I ran M-u from `*mu4e-headers*` and watched the window
scroll automatically. Then I ran it with the window selected and
the automatic scrolling stopped until I deselected the window.
