### PR TITLE
mu-sexp-convert: Fix conversion of elisp times.

### DIFF
--- a/contrib/mu-sexp-convert
+++ b/contrib/mu-sexp-convert
@@ -89,7 +89,7 @@ into a list of pairs
 
 (define (etime->time_t t)
   "Convert elisp time object T into a time_t value."
-  (logior (ash (car t) 16) (car t)))
+  (logior (ash (car t) 16) (car (cdr t))))
 
 (define (sexp->xml)
   "Convert string INPUT to XML, return the XML (string)."


### PR DESCRIPTION
Previously, the first element was used where the second should have been.

In essence, whereas the algorithm is `T[0]<<16 & T[1]`, the code was previously performing `T[0]<<16 & T[0]`.

The timestamp produced was therefore inaccurate by up to about 18 hours.
