### PR TITLE
Fix regex in retag function that matches any tag with a '-' in it

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -207,7 +207,7 @@ store your org-contacts."
     (dolist (tag (split-string-and-unquote retag) taglist)
       (cond ((string-match "\\+\\(.+\\)" tag)
 	      (setq taglist (push (match-string 1 tag) taglist)))
-	((string-match "\\-\\(.+\\)" tag)
+	((string-match "^\\-\\(.+\\)" tag)
 	  (setq taglist (delete (match-string 1 tag) taglist)))
 	(t
 	  (setq taglist (push tag taglist)))))


### PR DESCRIPTION
This allows tags of the form "example-name" to be added as expected and "-example-name" to remove as expected.
