### PR TITLE
Allow passing extra options to gnuplot in mu:plot-histogram

### DIFF
--- a/guile/mu/plot.scm
+++ b/guile/mu/plot.scm
@@ -57,7 +57,7 @@ list of cons-pairs (X . Y)."
 	 (gnuplot (open-pipe "gnuplot -p" OPEN_WRITE)))
     (display (string-append
 	       "reset\n"
-	       "set term " (if text-only "dumb" "qt") "\n"
+	       "set term " (if text-only "dumb" "wxt") "\n"
 	       "set title \"" title "\"\n"
 	       "set xlabel \"" x-label "\"\n"
 	       "set ylabel \"" y-label "\"\n"


### PR DESCRIPTION
It seems like this might be a useful feature in general. The original use case was to pass `'("set xtics rotate by -45")` to gnuplot so that I could read all of the labels on a histogram with a lot of bins. Let me know what you think!
