### PR TITLE
mu4e: fix unread face property decision

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1,6 +1,7 @@
 ;;; mu4e-headers.el -- part of mu4e, the mu mail user agent
 ;;
 ;; Copyright (C) 2011-2012 Dirk-Jan C. Binnema
+;; Copyright (C) 2013 Tibor Simko
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
@@ -419,7 +420,7 @@ if provided, or at the end of the buffer otherwise."
 		  (truncate-string-to-width str width 0 ?\s t)) " ")))))
       ;; now, propertize it.
       (setq line (propertize line 'face
-		   (case (car-safe (mu4e-message-field msg :flags))
+		   (case (car-safe (reverse (mu4e-message-field msg :flags)))
 		     ('draft           'mu4e-draft-face)
 		     ('trash           'mu4e-trashed-face)
 		     ((unread new)     'mu4e-unread-face)


### PR DESCRIPTION
When un unread message contained attachment or was signed, it was not
coloured with unread face in the headers buffer, because the face decision
process was based upon the first flag of the message, while the unread
flag usually came last.

This commit fixes the problem by simply looking at the last flag instead
of the first flag when taking the face attribution decision.  In this way
all unread messages are preferentially given the unread face regardless
of other flags they may have.  (Simple but works; could be further improved
by not assuming any flag order.)
