### PR TITLE
org-mu4e.el - update for new ox exporter

### DIFF
--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -151,7 +151,7 @@ and images in a multipart/related part."
 
 (defun org~mu4e-mime-convert-to-html ()
   "Convert the current body to html."
-  (unless (fboundp 'org-export-string)
+  (unless (fboundp 'org-export-string-as)
     (mu4e-error "require function 'org-export-string not found."))
   (unless (executable-find "dvipng")
     (mu4e-error "Required program dvipng not found"))
@@ -163,7 +163,7 @@ and images in a multipart/related part."
 	    (raw-body (buffer-substring begin end))
 	    (tmp-file (make-temp-name (expand-file-name "mail"
 					temporary-file-directory)))
-	    (body (org-export-string raw-body 'org
+	    (body (org-export-string-as raw-body 'org
 		    (file-name-directory tmp-file)))
 	    ;; because we probably don't want to skip part of our mail
 	    (org-export-skip-text-before-1st-heading nil)
@@ -176,7 +176,7 @@ and images in a multipart/related part."
 	    ;; to hold attachments for inline html images
 	    (html-and-images
 	      (org~mu4e-mime-replace-images
-		(org-export-string raw-body 'html
+		(org-export-string-as raw-body 'html
 		  (file-name-directory tmp-file))
 		tmp-file))
 	    (html-images (cdr html-and-images))


### PR DESCRIPTION
- org-mu4e.el (org~mu4e-mime-convert-to-html): org-export-string ->
  org-export-string-as

Simple fix, add the -as to org-export-string
