### PR TITLE
Drop misplaced braces

### DIFF
--- a/guile/mu-guile.texi
+++ b/guile/mu-guile.texi
@@ -28,7 +28,7 @@ Documentation License.''
 
 @titlepage
 @title @t{mu-guile} - extending @t{mu} with Guile Scheme
-@subtitle{version  @value{mu-version}}
+@subtitle version  @value{mu-version}
 @author Dirk-Jan C. Binnema
 
 @c The following two commands start the copyright page.


### PR DESCRIPTION
When building with guile support, make fails to build documentation

```
mu-guile.texi:31: misplaced {
mu-guile.texi:31: misplaced }
```

Seems to be the same issue as #121
