### PR TITLE
Add an 'untrash' action

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -496,6 +496,7 @@ after the end of the search results."
 (mu4e~headers-defun-mark-for read)
 (mu4e~headers-defun-mark-for trash)
 (mu4e~headers-defun-mark-for unflag)
+(mu4e~headers-defun-mark-for untrash)
 (mu4e~headers-defun-mark-for unmark)
 (mu4e~headers-defun-mark-for unread)
 
@@ -571,6 +572,7 @@ after the end of the search results."
       (define-key map (kbd "u")            'mu4e-headers-mark-for-unmark)
       (define-key map (kbd "+")            'mu4e-headers-mark-for-flag)
       (define-key map (kbd "-")            'mu4e-headers-mark-for-unflag)
+      (define-key map (kbd "=")            'mu4e-headers-mark-for-untrash)
       (define-key map (kbd "&")            'mu4e-headers-mark-custom)
 
       (define-key map (kbd "*")              'mu4e-headers-mark-for-something)

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -119,6 +119,7 @@ The following marks are available, and the corresponding props:
    `read'      n	mark the message as read
    `trash'     y	thrash the message to some folder
    `unflag'    n	mark this message for unflagging
+   `untrash'   n	remove the 'trashed' flag from a message
    `unmark'    n	unmark this message
    `unread'    n	mark the message as unread"
   (interactive)
@@ -137,6 +138,7 @@ The following marks are available, and the corresponding props:
 	      (read      '("!" . "read"))
 	      (trash     `("d" . ,target))
 	      (unflag    '("-" . "unflag"))
+              (untrash   '("=" . "untrash"))
 	      (unmark    '(" " . nil))
 	      (unread    '("?" . "unread"))
 	      (otherwise (mu4e-error "Invalid mark %S" mark))))
@@ -232,6 +234,7 @@ as well."
 		   ("!read"	. read)
 		   ("+flag"	. flag)
 		   ("-unflag"	. unflag)
+                   ("=untrash"	. untrash)
 		   ("unmark"	. unmark)))
 	  (marks
 	    (if allow-something
@@ -304,6 +307,7 @@ If NO-CONFIRMATION is non-nil, don't ask user for confirmation."
 		  (read    (mu4e~proc-move docid nil    "+S-u-N"))
 		  (trash   (mu4e~proc-move docid (mu4e~mark-check-target target) "+T-N"))
 		  (unflag  (mu4e~proc-move docid nil    "-F-N"))
+                  (untrash (mu4e~proc-move docid nil    "-T"))
 		  (unread  (mu4e~proc-move docid nil    "-S+u-N"))
 		  (otherwise (mu4e-error "Unrecognized mark %S" mark)))))
 	    mu4e~mark-map))

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -558,6 +558,7 @@ FUNC should be a function taking two arguments:
 
       (define-key map (kbd "+") 'mu4e-view-mark-for-flag)
       (define-key map (kbd "-") 'mu4e-view-mark-for-unflag)
+      (define-key map (kbd "=") 'mu4e-view-mark-for-untrash)
 
       (define-key map (kbd "*")             'mu4e-view-mark-for-something)
       (define-key map (kbd "<kp-multiply>") 'mu4e-view-mark-for-something)


### PR DESCRIPTION
My mail setup involves IMAP clients that seem to love to set the 'trashed' flag on messages. These are irritating, so I added 'untrash', which is simply 'unflag' that removes the 'trashed' flag. I used the = key for the usual no good reason. 

I'm not in any way married to this approach; if my IMAP server and various other clients worked better, it wouldn't even be necessary.
