### PR TITLE
Fix find so it has a summary. Add -S abbreviation.

### DIFF
--- a/mu/mu-config.c
+++ b/mu/mu-config.c
@@ -202,6 +202,9 @@ config_options_group_find (void)
 	GOptionEntry entries[] = {
 		{"fields", 'f', 0, G_OPTION_ARG_STRING, &MU_CONFIG.fields,
 		 "fields to display in the output", "<fields>"},
+		{"summary-len", "S", 0, G_OPTION_ARG_INT, &MU_CONFIG.summary_len,
+		 "use up to <n> lines for the summary, or 0 for none (0)",
+		 "<len>"},
 		{"sortfield", 's', 0, G_OPTION_ARG_STRING,
 		 &MU_CONFIG.sortfield,
 		 "field to sort on", "<field>"},
@@ -350,7 +353,7 @@ config_options_group_view (void)
 {
 	GOptionGroup *og;
 	GOptionEntry entries[] = {
-		{"summary-len", 0, 0, G_OPTION_ARG_INT, &MU_CONFIG.summary_len,
+		{"summary-len", "S", 0, G_OPTION_ARG_INT, &MU_CONFIG.summary_len,
 		 "use up to <n> lines for the summary, or 0 for none (0)",
 		 "<len>"},
 		{"terminate", 0, 0, G_OPTION_ARG_NONE, &MU_CONFIG.terminator,


### PR DESCRIPTION
mu-find has all the code for --summary-len but it doesn't actually recognize the command line argument. I added the argument to find. In addition I added a -S (capital S) abbreviation for --summary-len. This affected both mu-find and mu-view.
