### PR TITLE
New flexible method of customising completing-read

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -322,7 +322,7 @@ name. If the special shortcut 'o' (for _o_ther) is used, or if
 maildirs under `mu4e-maildir'."
   (let ((prompt (mu4e-format "%s" prompt)))
     (if (not mu4e-maildir-shortcuts)
-      (ido-completing-read prompt (mu4e-get-maildirs))
+      (funcall mu4e-completing-read-function prompt (mu4e-get-maildirs))
       (let* ((mlist (append mu4e-maildir-shortcuts '(("ther" . ?o))))
 	      (fnames
 		(mapconcat
@@ -336,7 +336,7 @@ maildirs under `mu4e-maildir'."
 		  mlist ", "))
 	      (kar (read-char (concat prompt fnames))))
 	(if (member kar '(?/ ?o)) ;; user chose 'other'?
-	  (ido-completing-read prompt (mu4e-get-maildirs) nil nil "/")
+	  (funcall mu4e-completing-read-function prompt (mu4e-get-maildirs) nil nil "/")
 	  (or (car-safe
 		(find-if (lambda (item) (= kar (cdr item))) mu4e-maildir-shortcuts))
 	    (mu4e-warn "Unknown shortcut '%c'" kar)))))))

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -176,6 +176,19 @@ view buffer."
   :type 'boolean
   :group 'mu4e)
 
+(defcustom mu4e-completing-read-function 'ido-completing-read
+  "Function to be used to receive input from the user with
+completion. This is used to receive the name of the maildir
+to switch to via `mu4e~headers-jump-to-maildir'.
+
+Suggested possible values are:
+ * `completing-read':      built-in completion method
+ * `ido-completing-read':  dynamic completion within the minibuffer
+ * `helm-comp-read':       dynamic completion within popup window"
+  :type 'function
+  :options '(completing-read ido-completing-read helm-comp-read)
+  :group 'mu4e)
+
 ;; crypto
 (defgroup mu4e-crypto nil
   "Crypto-related settings."


### PR DESCRIPTION
(note -- this replaces my original request https://github.com/djcb/mu/pull/253)

Added the customisation option 'mu4e-completing-read-function' which can
be used to choose which method of input-with-completion will be used by
mu4e. This variable is set to the function which mu4e will use.

By default, mu4e will use ido (via 'ido-completing-read'), but any
compatible completing-read function can be used instead. Interesting
choices would include 'helm-comp-read' for Helm-based completion, and
'completing-read' for the built-in basic completion system.
