### PR TITLE
mu4e: always consider text/calendar message parts as attachments

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -419,6 +419,7 @@ at POINT, or if nil, at (point)."
 		    isattach
 		    (string-match "^\\(image\\|audio\\)" mtype)
 		    (string= "message/rfc822" mtype)
+		    (string= "text/calendar" mtype)
 		    (and (string-match "^application" mtype)
 		      (not (string-match "signature" mtype))))))
 	      (mu4e-message-field msg :parts)))


### PR DESCRIPTION
Some Microsoft clients send icalendar body parts without a "type" property, effectively making them hidden in mu4e.  This small patch makes them show up as an attachment in message view.  

Comments and suggestions for changes welcome.

Thanks much,
Sasha
