### PR TITLE
fix up a couple of menu entries

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -577,10 +577,12 @@ with @kbd{M-x mu4e}. @t{mu4e} does some checks to ensure everything is set up
 correctly, and then shows you the @t{mu4e} main view. Its major mode is
 @code{mu4e-main-mode}.
 
+
+
 @menu
-* Overview:MV Overview.
+* Overview: MV Overview. 
 * Basic actions::
-* Bookmarks:MV Bookmarks.
+* Bookmarks: MV Bookmarks.
 * Miscellaneous::
 @end menu
 
@@ -685,7 +687,7 @@ message, followed by a footer line. The major-mode for the headers view is
 @code{mu4e-headers-mode}.
 
 @menu
-* Overview:HV Overview.
+* Overview: HV Overview.
 * Keybindings::
 * Marking messages::
 * Sort order and threading::
@@ -926,13 +928,13 @@ view window, which shows the message headers, followed by the message
 body. Its major mode is @code{mu4e-view-mode}.
 
 @menu
-* Overview:MSGV Overview.
-* Keybindings:MSGV Keybindings.
+* Overview: MSGV Overview.
+* Keybindings: MSGV Keybindings.
 * Opening and saving attachments::
 * Viewing images inline::
 * Displaying rich-text messages::
-* Crypto:MSGV Crypto.
-* Actions:MSGV Actions.
+* Crypto: MSGV Crypto.
+* Actions: MSGV Actions.
 @end menu
 
 @node MSGV Overview
@@ -1510,10 +1512,10 @@ You can also influence the sort order and whether threads are shown or not;
 see @ref{Sort order and threading}.
 
 @menu
-* Queries::Searching for messages
-* Bookmarks::Remembering queries
-* Maildir searches::Queries for maildirs
-* Other search functionality::Some more tricks
+* Queries:: Searching for messages.
+* Bookmarks:: Remembering queries.
+* Maildir searches:: Queries for maildirs.
+* Other search functionality:: Some more tricks.
 @end menu
 
 @node Queries


### PR DESCRIPTION
A couple of menu entries could not be followed to their respective nodes (at least when I was using the Emacs Info reader): this change fixed it for me.
