### PR TITLE
mu4e-actions.el: make git apply patch history aware

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -170,7 +170,10 @@ store your org-contacts."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun mu4e-action-git-apply-patch (msg)
   "Apply the git [patch] message."
-  (let ((path (read-directory-name "Target directory: " nil "~/" t) ))
+  (let ((path (ido-read-directory-name "Target directory: "
+                                       (car ido-work-directory-list)
+                                       "~/" t)))
+    (add-to-list 'ido-work-directory-list path)
     (shell-command
       (format "cd %s; git apply %s"
 	path


### PR DESCRIPTION
As you are often applying a series of patches to a tree it doesn't
make sense to move the user to default-directory every time.

However there is another use case which I'm struggling to work with at
the moment which is dealing with a whole thread of patches. On most
mailing lists there tends to be a series of patches and it would be
useful to mark the whole thread (T->ag?) and action a whole set of
messages at once. Doing this manually for a 40-50 patch series is a
bit of a pain ;-)

I suspect the action should receive a list of messages so some
pre-processing can be done, for example sorting based on subject to
patches are applied in correct order.

Any idea for the best way to do this with mu4e?
