### PR TITLE
Added hook called when about to update mail

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -799,11 +799,17 @@ The messages are inserted into the process buffer."
 ;;   - (optionally) check password requests
 (defvar mu4e~update-buffer-name nil
   "Internal, store the name of the buffer process when updating.")
+(defvar mu4e-pre-update-mail-hook nil
+  "Hook run immediately prior to mail collection by
+`mu4e-update-mail-and-index'. This can be used to configure the
+mail fetching and indexing process each time, for example to
+periodically change the scope of mail collection.")
 (defun mu4e-update-mail-and-index (run-in-background)
   "Get a new mail by running `mu4e-get-mail-command'. If
 run-in-background is non-nil (or called with prefix-argument), run
 in the background; otherwise, pop up a window."
   (interactive "P")
+  (run-hooks 'mu4e-pre-update-mail-hook)
   (unless mu4e-get-mail-command
     (mu4e-error "`mu4e-get-mail-command' is not defined"))
   (let* ((process-connection-type t)


### PR DESCRIPTION
Added new hook `mu4e-pre-update-mail-hook` that is called when mu4e is about to update mail (via `mu4e-update-mail-and-index` or with the 'U' command). This allows the hook function to make last-minute customisations before mail is collected.

One use for this is to change the contents of `mu4e-get-mail-command` so that mu4e can perform a quick mail collection most of the time by choosing a folder subset, but periodically collect mail from all folders.

An example use of this from my own configuration is below, which swaps between two different configurations when using `mbsync` to collect email.

``` lisp
(defvar sh/last-mu4e-update-time (float-time)
  "The last time (established with `float-time') that mail was
    fetched by mu4e.")

(defconst sh/mu4e-full-update-after (* 60 60)
  "The number of seconds that, after which, a full mail retrieval
    will be performed by mu4e. Intermediate mail retrieval will
    fetch a subset of folders and so will be both quicker and use
    less network bandwidth.")

(defconst sh/mu4e-get-mail-command-quick "mbsync quick"
  "The mail retrieval command that mu4e will use for quick mail
    retrieval. This quick form is used until
    `sh/mu4e-full-update-after' seconds have elapsed, when
    `sh/mu4e-get-mail-command-full' will be used instead.")

(defconst sh/mu4e-get-mail-command-full "mbsync full"
  "The mail retrieval command that mu4e will use for full mail
    retrieval. This quick form is used each time
    `sh/mu4e-full-update-after' seconds have elapsed. At other
    times `sh/mu4e-get-mail-command-quick' will be used instead.")

(defun sh/mu4e-quick-full-update-switcher ()
  "Hook function that will set the mu4e mail fetching command to
    one that completes quickly but, periodically, switch to one
    that performs a full sync. The quick fetch only covers a subset
    of folders but completes much quicker and uses less network
    traffic."
  (if (< (- (float-time) sh/last-mu4e-update-time) sh/mu4e-full-update-after)
      (setq mu4e-get-mail-command sh/mu4e-get-mail-command-quick)
    (setq mu4e-get-mail-command sh/mu4e-get-mail-command-full)
    (setq sh/last-mu4e-update-time (float-time))))

;; Use our hook to automatically switch between quick and full mail
;; retrieval.
(add-hook 'mu4e-pre-update-mail-hook
      'sh/mu4e-quick-full-update-switcher)
```
