### PR TITLE
mu4e: update window stays inside mu4e boundaries

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -814,7 +814,7 @@ Also scrolls to the final line, and update the progress throbber."
 screen to display buffer BUF."
   (let ((win 
 	  (split-window
-	    (frame-root-window)
+	    nil
 	    (- (window-height (frame-root-window)) height))))
     (set-window-buffer win buf)
     (set-window-dedicated-p win t)


### PR DESCRIPTION
In the current version, the update window spans the whole bottom of the frame instead of just the bottom of the mu4e window.  On larger screens, this consumes a lot of space, most of which isn't actually used.  The original behavior was that the update window only occupied the bottom of the mu4e window which was more conservative.  This pull request restores that behavior.
