### PR TITLE
Add quotes to exec command in mu find

### DIFF
--- a/mu/mu-cmd-find.c
+++ b/mu/mu-cmd-find.c
@@ -145,7 +145,7 @@ exec_cmd (MuMsg *msg, MuMsgIter *iter, MuConfig *opts,  GError **err)
 	gboolean rv;
 
 	escpath = g_strescape (mu_msg_get_path (msg), NULL);
-	cmdline = g_strdup_printf ("%s %s", opts->exec, escpath);
+	cmdline = g_strdup_printf ("%s '%s'", opts->exec, escpath);
 
 	rv = g_spawn_command_line_sync (cmdline, NULL, NULL, &status, err);
 


### PR DESCRIPTION
I came across this when I was trying to find messages and show it in less `mu find whatever --exec "less"`.

If messages are found in paths containing spaces like `~/Mail/account/[Gmail] All Messages/`, less is called with the parts and won't find the files.
