### PR TITLE
Add ability to specify range of URLs to visit

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -1100,6 +1100,7 @@ actions
 -------
 g            go to (visit) numbered URL (using `browse-url')
              (or: <mouse-1> or M-RET with point on url)
+             C-u g visits multiple URLs
 e            extract (save) attachment (asks for number)
              (or: <mouse-2> or S-RET with point on attachment)
              C-u e extracts multiple attachments


### PR DESCRIPTION
- mu4e/mu4e-view.el (mu4e-view-go-to-url): Add the ability to visit
  multiple URLs by specifying a numeric range.
- mu4e/mu4e.texi (The message view: Keybindings): Document ability to
  visit multiple URLs.

`mu4e-view-go-to-url' now behaves like`mu4e-view-save-attachment'. You
can specify multiple URLs to visit at once by prefixing the visit
command by <C-u>; so C-u g asks you for a range of URLs to visit (for
example, 1 3-6 8). The range "‘a’" is a shortcut for all URLs.
