### PR TITLE
* mu-proc: Don't rename when moving inside a Maildir

### DIFF
--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -376,9 +376,9 @@ The flags are any of `deleted', `flagged', `new', `passed', `replied' `seen' or
 The server reports the results for the operation through
 `mu4e-update-func'.
 
-If the the variable `mu4e-change-filenames-when-moving' is non-nil,
-the move generates new names for the target files; this helps
-certain tools (such as mbsync).
+If the the variable `mu4e-change-filenames-when-moving' is
+non-nil, moving to a different maildir generates new names for
+the target files; this helps certain tools (such as mbsync).
 
 The results are reported through either (:update ... )
 or (:error ) sexp, which are handled my `mu4e-update-func' and
@@ -394,10 +394,12 @@ or (:error ) sexp, which are handled my `mu4e-update-func' and
 		(if (stringp flags) flags (mu4e-flags-to-string flags)))))
 	  (path
 	    (when maildir
-	      (format " maildir:%s" (mu4e~proc-escape maildir)))))
+	      (format " maildir:%s" (mu4e~proc-escape maildir))))
+          (rename
+            (if (and maildir mu4e-change-filenames-when-moving) "true" "false")))
     (mu4e~proc-send-command "cmd:move %s %s %s %s"
       idparam (or flagstr "") (or path "")
-      (format "newname:%s" (if mu4e-change-filenames-when-moving "true" "false")))))
+      (format "newname:%s" rename))))
 
 (defun mu4e~proc-index (path my-addresses)
   "Update the message database for filesystem PATH, which should


### PR DESCRIPTION
`mbsync` expects messages moving inside a Maildir (from `new` to `cur`, for example) to mantain its basename.

This change tries to fix issue #321. It might be more sensible than the change proposed there. I can't see this negatively affecting other users, as it is my impression that the whole `mu4e-change-filenames-when-moving` was introduced to satisfy `mbsync`.

What do you think?
