### PR TITLE
* mu4e/Makefile: allow configuring the lispdir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,8 +60,10 @@ AC_ARG_ENABLE([mu4e],
    AS_HELP_STRING([--disable-mu4e],[Disable building mu4e]))
 AS_IF([test "x$enable_mu4e" != "xno"], [
   AM_PATH_LISPDIR
-  AS_IF([test "x$lispdir" != "xno"],
-  	      [emacs_version="`$EMACS --version | head -1`"])
+  AS_IF([test "x$lispdir" != "xno"], [
+    emacs_version="`$EMACS --version | head -1`"
+    lispdir="${lispdir}/mu4e/"
+  ])
   AS_CASE([$emacs_version],[*23*|*24*|*25*],[build_mu4e=yes],
           [AC_WARN([emacs is too old to build mu4e (need emacs >= 23.x)])])
 ])

--- a/mu4e/Makefile.am
+++ b/mu4e/Makefile.am
@@ -21,8 +21,6 @@ SUBDIRS=
 info_TEXINFOS=mu4e.texi
 mu4e_TEXINFOS=fdl.texi
 
-lispdir=${prefix}/share/emacs/site-lisp/mu4e/
-
 dist_lisp_LISP=			\
 	mu4e-about.el		\
 	mu4e-actions.el		\


### PR DESCRIPTION
`lispdir` is no longer hardcoded in the Makefile.

Users can set the desired `lispdir` at configure time, with `./configure
--with-lispdir='...'`; or at install time with `make lispdir='...' install`.

The default install path is the folder `mu4e/` inside whatever AM_PATH_LISP
finds, which is probably what the original default intended.

This change fixes #320.
