### PR TITLE
Better dialog to save attachments.

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -905,14 +905,26 @@ If ATTNUM is nil ask for the attachment number."
 	  (index (plist-get att :index))
 	  (retry t) (fpath))
     (while retry
-      (setq fpath (expand-file-name
-		   (read-directory-name
-		     (mu4e-format "Save as ") path nil nil fname)))
+      (setq fpath (mu4e-view-request-attachment-path fname path))
       (setq retry
 	(and (file-exists-p fpath)
 	  (not (y-or-n-p (mu4e-format "Overwrite '%s'?" fpath))))))
     (mu4e~proc-extract
       'save (mu4e-message-field msg :docid) index fpath)))
+
+(defun mu4e-view-request-attachment-path (fname path)
+  "Ask the user where to save FNAME (default is PATH/FNAME)."
+  (let ((fpath (expand-file-name
+                (read-file-name
+                 (mu4e-format "Save as ")
+                 path
+                 nil
+                 nil
+                 fname)
+                path)))
+    (if (file-directory-p fpath)
+        (expand-file-name fname fpath)
+      fpath)))
 
 (defun mu4e-view-save-attachment-multi (&optional msg)
   "Offer to save multiple email attachments from the current message.


### PR DESCRIPTION
This commit replaces the call to `read-directory-name' by a call to
`read-file-name' when asking the user about the target location for
saving an attachment. This new dialog is better suited because:

1/ the user is currently saving a file, not a directory: he might want
   to complete over existing files (e.g., to replace an existing file
   with a new one just received).

2/ the current dialog was asking for a directory but then, if the user
   enters a directory, mu4e proposes him to "override" the directory
   with a file. This is not going to work obviously. In the new dialog,
   it is also possible to enter a directory name instead of a file name.
   In this case, a new file is created under the chosen directory name.
