### PR TITLE
Update mu4e.texi for Fedora command

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -281,7 +281,7 @@ $ sudo yum install emacs
 $ sudo yum install html2text xdg-utils
 
 # optional: only needed for msg2pdf and mug (toy gtk+ frontend)
-$ sudo apt-get install webkitgtk3-devel
+$ sudo yum install webkitgtk3-devel
 @end example
 
 @subsection Building from a release tarball


### PR DESCRIPTION
The currently pescribed installation for webkitgtk3-devel on Fedora is:

```
sudo apt-get install webkitgtk3-devel
```

Instead, it should be:

```
sudo yum install webkitgtk3-devel
```
