### PR TITLE
Better `M-<` and `M->` when composing a message.

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -611,7 +611,7 @@ end of the buffer."
   (let ((old-position (point))
         (message-position (save-excursion (message-goto-body) (point))))
     (end-of-buffer)
-    (when (re-search-backward "^-- $" message-position t)
+    (when (re-search-backward message-signature-separator message-position t)
       (previous-line))
     (when (equal (point) old-position)
       (end-of-buffer))))


### PR DESCRIPTION
This commit provides the following 2 functions that help the user go to
interesting positions at the beginning and end of the message being
composed. These 2 functions are bound to the standard `M-<` and `M->`
keys (or more precisely, to the keys where 'beginning-of-buffer and
'end-of-buffer are bound).

mu4e-compose-goto-top: Go to the beginning of the message or buffer.
  Go to the beginning of the message or, if already there, go to the
  beginning of the buffer.

mu4e-compose-goto-bottom Go to the end of the message or buffer.
  Go to the end of the message (before signature) or, if already there,
  go to the end of the buffer.
