### PR TITLE
removed 'nocolor' option. Added 'color' option

### DIFF
--- a/mu/mu-config.c
+++ b/mu/mu-config.c
@@ -79,11 +79,28 @@ set_group_mu_defaults (void)
 
 	/* check for the MU_NOCOLOR env var; but in any case don't
 	 * use colors unless we're writing to a tty */
-	if (g_getenv (MU_NOCOLOR) != NULL)
-		MU_CONFIG.nocolor = TRUE;
 
-	if (!isatty(fileno(stdout)) || !isatty(fileno(stderr)))
+	if( MU_CONFIG.color == MuColorOpt_always)
+		MU_CONFIG.nocolor= FALSE;
+	else if( MU_CONFIG.color == MuColorOpt_never)
 		MU_CONFIG.nocolor = TRUE;
+	else if (!isatty(fileno(stdout)) || !isatty(fileno(stderr)))
+		MU_CONFIG.nocolor = TRUE;
+	else if (g_getenv (MU_NOCOLOR) != NULL)
+		MU_CONFIG.nocolor = TRUE;
+}
+
+static gboolean config_options_set_color (const gchar  *option_name, const gchar  *value, gpointer data, GError **error)
+{
+	if( g_strcmp0( value, "never") == 0) 
+		MU_CONFIG.color = MuColorOpt_never;
+	else if( g_strcmp0( value, "auto") == 0) 
+		MU_CONFIG.color = MuColorOpt_auto;
+	else if( g_strcmp0( value, "always") == 0) 
+		MU_CONFIG.color = MuColorOpt_always;
+	else
+		return FALSE;
+	return TRUE;
 }
 
 static GOptionGroup*
@@ -101,8 +118,8 @@ config_options_group_mu (void)
 		 "specify an alternative mu directory", "<dir>"},
 		{"log-stderr", 0, 0, G_OPTION_ARG_NONE, &MU_CONFIG.log_stderr,
 		 "log to standard error (false)", NULL},
-		{"nocolor", 0, 0, G_OPTION_ARG_NONE, &MU_CONFIG.nocolor,
-		 "don't use ANSI-colors in output (false)", NULL},
+		{"color", 0, 0, G_OPTION_ARG_CALLBACK, &config_options_set_color,
+		 "colorize output (never|auto|always)", "<mode>"},
 		{"verbose", 'v', 0, G_OPTION_ARG_NONE, &MU_CONFIG.verbose,
 		 "verbose output (false)", NULL},
 

--- a/mu/mu-config.h
+++ b/mu/mu-config.h
@@ -86,6 +86,12 @@ typedef enum _MuConfigCmd MuConfigCmd;
 	((C) > MU_CONFIG_CMD_UNKNOWN && (C) < MU_CONFIG_CMD_NONE)
 
 
+enum MuColorOpt {
+	MuColorOpt_auto, 
+	MuColorOpt_never, 
+	MuColorOpt_always
+};
+
 /* struct with all configuration options for mu; it will be filled
  * from the config file, and/or command line arguments */
 
@@ -102,8 +108,8 @@ struct _MuConfig {
 	gboolean	 version;	/* request mu version */
 	gboolean	 log_stderr;	/* log to stderr (not logfile) */
 	gchar**		 params;	/* parameters (for querying) */
-	gboolean	 nocolor;        /* don't use use ansi-colors
-					 * in some output */
+	enum MuColorOpt color;		/* colorize output (enum)*/
+	gboolean	nocolor;		/* colorize output (boolean)*/
 	gboolean	 verbose;	/* verbose output */
 
 	/* options for indexing */


### PR DESCRIPTION
The 'color' option can be either one of "auto", "never" or "always".

"--color=never" equals "--nocolor"
"--color=auto" was the default behaviour of mu.
"--color=always" makes it so the output can be colored when piping to other programs.
