### PR TITLE
fix main search shortcut typo

### DIFF
--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -118,7 +118,7 @@ clicked."
 	"\n\n"
 	(propertize "  Basics\n\n" 'face 'mu4e-title-face)
 	(mu4e~main-action-str "\t* [j]ump to some maildir\n" 'mu4e-jump-to-maildir)
-	(mu4e~main-action-str "\t* enter a [/]earch query\n" 'mu4e-search)
+	(mu4e~main-action-str "\t* enter a [s]earch query\n" 'mu4e-search)
 	(mu4e~main-action-str "\t* [C]ompose a new message\n" 'mu4e-compose-new)
 	"\n"
 	(propertize "  Bookmarks\n\n" 'face 'mu4e-title-face)


### PR DESCRIPTION
The main menu was typo-ed (see below), due to the change in https://github.com/djcb/mu/commit/957c5ceaef3a9542a14a93051bd8493ff4b8638a

```
* [j]ump to some maildir
* enter a [/]earch query
* [C]ompose a new message
```

Since the bookmark key itself didn't change from "s", this seems like a typo.
