### PR TITLE
Fix for marking without mu4e-split-view

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1365,7 +1365,7 @@ docid. Otherwise, return nil."
       ;; attempt to highlight the new line, display the message
       (mu4e~headers-highlight docid)
       ;; update message view if it was already showing
-      (when (window-live-p mu4e~headers-view-win)
+      (when (and mu4e-split-view (window-live-p mu4e~headers-view-win))
 	(mu4e-headers-view-message))
       docid)))
 


### PR DESCRIPTION
Otherwise the window changes, as soon as I mark
