### PR TITLE
Moved citation regexps to a variable

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -1094,7 +1094,7 @@ used in the view and compose modes."
 	  ;; prefixes, starting with 0 for 'no citation'
 	  (beginning-of-line 1)
 	  ;; consider only lines that heuristically look like a citation line...
-	  (when (looking-at "[[:blank:]]*[^[:blank:]\n]*[[:blank:]]*>")
+	  (when (looking-at mu4e-cited-regexp)
 	    (let* ((level (how-many ">" (line-beginning-position 1)
 			    (line-end-position 1)))
 		    (face

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -181,6 +181,11 @@ view buffer."
   :type 'boolean
   :group 'mu4e)
 
+(defcustom mu4e-cited-regexp "^[[:blank:]]*[^[:blank:]\n]*[[:blank:]]*>"
+  "Regular expression that determines whether a line is a citation."
+  :type 'string
+  :group 'mu4e)
+
 (defcustom mu4e-completing-read-function 'ido-completing-read
   "Function to be used to receive input from the user with
 completion. This is used to receive the name of the maildir

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -779,7 +779,7 @@ Also number them so they can be opened using `mu4e-view-go-to-url'."
   (save-excursion
     (let ((inhibit-read-only t))
       (goto-char (point-min))
-      (flush-lines "^[:blank:]*>")
+      (flush-lines mu4e-cited-regexp)
       (setq mu4e~view-cited-hidden t))))
 
 


### PR DESCRIPTION
Currently there are descrepancies between highlighted and flushed lines. Ex, this citation format

AB> Text
AB> Text
