### PR TITLE
Don't replace ascii characters < ' ' with '.' in `mu_str_asciify_in_place`

### DIFF
--- a/lib/mu-str.c
+++ b/lib/mu-str.c
@@ -839,7 +839,7 @@ mu_str_asciify_in_place (char *buf)
 	g_return_val_if_fail (buf, NULL);
 
 	for (c = buf; c && *c; ++c) {
-		if (!isascii(*c) || *c < ' ')
+		if (!isascii(*c))
 			*c = '.';
 	}
 


### PR DESCRIPTION
Fix for issue #351.

Not sure if this introduces other problems.  I presume there was a reason for replacing some ascii character with periods as well.
