### PR TITLE
.travis.yml: add basic Travis recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ mu
 mug2
 .desktop
 *html
-.*
+.deps
+.libs
 autom4te*
 Makefile
 Makefile.in

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: c
+compiler:
+  - gcc
+env:
+  global:
+    - BUILD_PKGS="libtool autoconf automake texinfo"
+    - BUILD_LIBS="libgmime-2.6-dev libxapian-dev guile-2.0-dev libwebkitgtk-dev"
+    - TEST_PKGS="pmccabe"
+  matrix:
+    - EVM_EMACS=emacs-24.1-bin
+    - EVM_EMACS=emacs-24.2-bin
+    - EVM_EMACS=emacs-24.3-bin
+before_install:
+  - git submodule update --init --recursive
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq ${BUILD_PKGS} ${BUILD_LIBS} ${TEST_PKGS}
+install:
+  - sudo mkdir /usr/local/evm
+  - sudo chown $(id -u):$(id -g) /usr/local/evm
+  - curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash
+  - export PATH="$HOME/.evm/bin:$PATH"
+  - evm install $EVM_EMACS --use
+script:
+  - autoreconf -i
+  - ./configure
+  - make
+  - make check


### PR DESCRIPTION
This sets up a simple build and make check test against 3 versions of
Emacs as installed by evm.

Currently it fails due to one of the unit tests being broken.
