### PR TITLE
lib/mu-str.c: squash white space ctrl chars to spaces (#390)

### DIFF
--- a/lib/mu-str.c
+++ b/lib/mu-str.c
@@ -1056,15 +1056,19 @@ mu_str_remove_ctrl_in_place (char *str)
 		if (!iscntrl(*cur))
 			continue;
 
-		/* control char detected... */
-		gstr = g_string_sized_new (strlen (str));
-		for (cur = str; *cur; ++cur)
-			if (!iscntrl (*cur))
-				g_string_append_c (gstr, *cur);
-		memcpy (str, gstr->str, gstr->len); /* fits */
-		g_string_free (gstr, TRUE);
-
-		break;
+		if (isspace(*cur)) {
+			/* squash special white space into a simple space */
+			*cur = ' ';
+		} else {
+			/* remove other control characters */
+			gstr = g_string_sized_new (strlen (str));
+			for (cur = str; *cur; ++cur)
+				if (!iscntrl (*cur))
+					g_string_append_c (gstr, *cur);
+			memcpy (str, gstr->str, gstr->len); /* fits */
+			g_string_free (gstr, TRUE);
+			break;
+		}
 	}
 
 	return str;


### PR DESCRIPTION
When processing multiple lines for a subject line separated by TAB
characters we don't want to eliminate the control character totally but
replace it with a simple space. I've left the control handling as before
for non-white space characters.

Signed-off-by: Alex Bennée alex@bennee.com
