### PR TITLE
Headers sorted by "nil" at first

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1226,7 +1226,8 @@ sortfield, change the sort-order) or nil (ask the user)."
 	      (t
 		(if (eq sortfield mu4e~headers-sort-field)
 		  (if (eq mu4e~headers-sort-direction 'ascending)
-		    'descending 'ascending)))
+		      'descending 'ascending)
+		  'descending))
 	      (mu4e-read-option "Direction: "
 		'(("ascending" . 'ascending) ("descending" . 'descending))))))
     (setq


### PR DESCRIPTION
In mu4e-headers, whenever I click on a header that's not currently used for sorting, it's first sorted by "nil". This fixes it, by defaulting to `descending`.
