### PR TITLE
Potential fix for issue #433: make check fails on Scientific Linux 6

### DIFF
--- a/lib/mu-str.c
+++ b/lib/mu-str.c
@@ -839,7 +839,7 @@ mu_str_asciify_in_place (char *buf)
 	g_return_val_if_fail (buf, NULL);
 
 	for (c = buf; c && *c; ++c) {
-		if (!isprint(*c) && !isspace (*c))
+		if ((!isprint(*c) && !isspace (*c)) || !isascii(*c))
 			*c = '.';
 	}
 


### PR DESCRIPTION
The problem was the final "hello world" test in test-mu-str.c . The condition `!isprint() && !ispace()` is false for the invalid utf8 characters. However `!isascii()` is true, at least with glibc 2.12 , so the code below fixes the `make check` problem for me.
