### PR TITLE
end beginning-of-body line with \n

### DIFF
--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -243,7 +243,7 @@ separator is never written to the message file. Also see
   (save-excursion
     ;; make sure there's not one already
     (mu4e~draft-remove-mail-header-separator)
-    (let ((sepa (propertize mail-header-separator
+    (let ((sepa (propertize (concat mail-header-separator "\n")
 		  'intangible t
 		  ;; don't make this read-only, message-mode
 		  ;; seems to require it being writable in some cases


### PR DESCRIPTION
`message-goto-body`, which is used by `message` and by extension
`mu4e` searches for `(concat "\n" mail-header-separator "\n")`.
It the trailing newline is missing, then everything that relies
on that function will fail.  This fixes #428 and #432.
