### PR TITLE
mu4e-view-search-narrow now prompts user for input

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -876,7 +876,7 @@ all messages in the subthread at point in the headers view."
 (defun mu4e-view-search-narrow ()
   "Run `mu4e-headers-search-narrow' in the headers buffer."
   (interactive)
-  (mu4e~view-in-headers-context (mu4e-headers-search-narrow nil)))
+  (mu4e~view-in-headers-context (call-interactively 'mu4e-headers-search-narrow)))
 
 (defun mu4e-view-search-edit ()
   "Run `mu4e-headers-search-edit' in the headers buffer."


### PR DESCRIPTION
Hi. Prior to this patch pressing '/' when looking at a message would append "and nil" to the search string, which is wrong. This patch makes the call interactive, so the user is prompted for the input. It does this unconditionally, which maybe isn't right in case mu4e-view-search-narrow itself was called non-interactively. It's better than passing nil, though.
