### PR TITLE
Fix encrypted multiparts and attachments indexing

### DIFF
--- a/lib/mu-msg-part.c
+++ b/lib/mu-msg-part.c
@@ -542,7 +542,7 @@ handle_mime_object (MuMsg *msg,
 	else if (GMIME_IS_MULTIPART (mobj))
 		return handle_multipart
 			(msg, GMIME_MULTIPART (mobj),
-			 parent, opts, index, func, user_data);
+			 opts, index, func, user_data);
 	return TRUE;
 }
 


### PR DESCRIPTION
Pull request #483 (Patches for #186) does not handle encrypted multiparts properly.  It
used to just verify the signature and not process the parts of the
multipart.  This commit resolves this issue.

Additionally it did not index attachments properly and in the case of a
multipart directly containing more than one multiparts resulted on non
unique indexing of attachments/parts.  This commit resolves this issue
as well.

NOTE: Please review, carefully, the changes in `get_text_from_mime_msg`.  The changes should not change its behavior, however I am not sure that this behavior is OK already.  The function used to take an index as a parameter and never use it.  Are we sure we don't need this index?
