### PR TITLE
mu4e-shr2text does not anymore retrieve images.

### DIFF
--- a/mu4e/mu4e-contrib.el
+++ b/mu4e/mu4e-contrib.el
@@ -46,7 +46,8 @@
 `mu4e-html2text-command' in a new enough emacs. Based on code by
 Titus von der Malsburg."
   (interactive)
-  (let ((dom (libxml-parse-html-region (point-min) (point-max))))
+  (let ((dom (libxml-parse-html-region (point-min) (point-max)))
+	(shr-inhibit-images t))
     (erase-buffer)
     (shr-insert-document dom)
     (goto-char (point-min))))


### PR DESCRIPTION
When HTML emails contain references to remote images, retrieving these images
leaks information.  For example, the sender can see when I openend the email
and from which computer (IP address).  For this reason, it is preferrable to
not retrieve images.

See this discussion on mu-discuss: https://groups.google.com/forum/#!topic/mu-discuss/gr1cwNNZnXo
