### PR TITLE
Allow to do retagging using marks instead of message actions

### DIFF
--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -156,7 +156,7 @@ properties are:
    :char "+"
    :prompt "+flag"
    :show-target (lambda (target) "flag")
-   :action (lambda (docid msg target) (mu4e~proc-move dociddocid nil    "+F-u-N")))
+   :action (lambda (docid msg target) (mu4e~proc-move docid nil    "+F-u-N")))
   (move
    :char "m"
    :prompt "move"


### PR DESCRIPTION
This makes using gmail labels as convenient as using folders.

(See the commit message for examples)
