### PR TITLE
Allow mu4e-bookmarks to contain lisp expressions

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -381,7 +381,7 @@ KAR, or raise an error if none is found."
 	     (= kar (nth 2 bm)))
 	   mu4e-bookmarks)))
    (if chosen-bm
-     (nth 0 chosen-bm)
+     (eval (nth 0 chosen-bm))
      (mu4e-warn "Unknown shortcut '%c'" kar))))
 
 


### PR DESCRIPTION
This allows expressions such as:

```
((concat "maildir:/inbox date:"
     (format-time-string "%Y%m01"
                 (subtract-time (current-time) (days-to-time 28)))
     "..")
 "Last calendar month"
 "m")
```

which allow me to look at the last calendar month (i.e. starting from the 1st of the month).
