### PR TITLE
mu4e-view: select next unread message in view buffer

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -866,9 +866,9 @@ message view. If this succeeds, return the new docid. Otherwise,
 return nil."
   (interactive "P")
   (mu4e~view-in-headers-context 
-    (mu4e-headers-next-unread backwards)))
-;; NOTE perhaps nice to have it also _select_ the found message;
-;; but it seems emacs gets a bit confused when we try that.
+    (mu4e-headers-next-unread backwards))
+  (mu4e-select-other-view)
+  (mu4e-headers-view-message))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Previously, the behavior of mu4e-view-headers-next-unread was that the cursor moved in the headers view but did not change the highlight nor the message in the view buffer. This patch updates the function to also select the message in the view buffer which appears to also highlight the message correctly in the header view.
