### PR TITLE
Fix build error in msgs-count.scm

### DIFF
--- a/guile/scripts/msgs-count.scm
+++ b/guile/scripts/msgs-count.scm
@@ -26,8 +26,9 @@ exec guile -e main -s $0 $@
 
 (use-modules (mu) (mu script) (mu stats))
 
-(define (count expr)
-  "Print the total number of messages matching QUERY."
+(define (count expr output)
+  "Print the total number of messages matching the query EXPR.
+OUTPUT is ignored."
   (display (mu:count expr))
   (newline))
 


### PR DESCRIPTION
mu:run-stats expects the passed-in function to take 2 arguments. The
second argument applies to gnuplot only, which is not applicable to the
count function in msgs-count.scm.

Ref: #533 
