### PR TITLE
Add reply-to argument to mu4e-compose-reply

### DIFF
--- a/man/mu-server.1
+++ b/man/mu-server.1
@@ -74,7 +74,7 @@ Messages of type 'new' don't use the docid: parameter, the other ones do.
 
 .nf
 -> cmd:compose type:<reply|forward|edit|new> [docid:<docid>]
-<- (:compose <reply|forward|edit|new> :original <s-exp> :include (<list-of-attachments))
+<- (:compose <reply|forward|edit|new> :original <s-exp> :include (<list-of-attachments)) :reply-to <all|sender>
 .fi
 
 The <list-of-attachments> is an s-expression describing the attachments to

--- a/mu/mu-cmd-server.c
+++ b/mu/mu-cmd-server.c
@@ -530,7 +530,9 @@ cmd_compose (ServerContext *ctx, GHashTable *args, GError **err)
 	char *sexp, *atts;
 	unsigned ctype;
 	MuMsgOptions opts;
+	const char *replytostr;
 
+	replytostr = NULL;
 	opts = get_encrypted_msg_opts (args);
 
 	GET_STRING_OR_ERROR_RETURN (args, "type", &typestr, err);
@@ -550,14 +552,19 @@ cmd_compose (ServerContext *ctx, GHashTable *args, GError **err)
 			print_and_clear_g_error (err);
 			return MU_OK;
 		}
+		if (ctype == REPLY) {
+			replytostr = get_string_from_args (args, "reply-to",
+			                                   TRUE, err);
+		}
 		sexp = mu_msg_to_sexp (msg, atoi(docidstr), NULL, opts);
 		atts = (ctype == FORWARD) ? include_attachments (msg, opts) : NULL;
 		mu_msg_unref (msg);
 	} else
 		atts = sexp = NULL;
 
-	print_expr ("(:compose %s :original %s :include %s)",
-		    typestr, sexp ? sexp : "nil", atts ? atts : "nil");
+	print_expr ("(:compose %s :original %s :include %s :reply-to %s)",
+	            typestr, sexp ? sexp : "nil", atts ? atts : "nil",
+	            replytostr ? replytostr : "nil");
 
 	g_free (sexp);
 	g_free (atts);

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -252,8 +252,8 @@ Ie. either 'name <email>' or 'email')."
 		    (re-search-backward "\\(\\`\\|[\n:,]\\)[ \t]*")
 		    (goto-char (match-end 0))
 		    (point)))))
-	(list start end mu4e~contacts-for-completion))))) 
- 
+	(list start end mu4e~contacts-for-completion)))))
+
 (defun mu4e~compose-setup-completion ()
   "Set up auto-completion of addresses."
   (set (make-local-variable 'completion-ignore-case) t)
@@ -332,7 +332,7 @@ Ie. either 'name <email>' or 'email')."
 		       mu4e~compose-buffer-max-name-length
 		       nil nil t)))))
 
-(defun* mu4e~compose-handler (compose-type &optional original-msg includes)
+(defun* mu4e~compose-handler (compose-type &optional original-msg includes reply-to)
   "Create a new draft message, or open an existing one.
 
 COMPOSE-TYPE determines the kind of message to compose and is a
@@ -359,7 +359,7 @@ tempfile)."
 
   ;; this opens (or re-opens) a messages with all the basic headers set.
   (condition-case nil
-      (mu4e-draft-open compose-type original-msg)
+      (mu4e-draft-open compose-type original-msg reply-to)
     (quit (kill-buffer) (message "[mu4e] Operation aborted")
           (return-from mu4e~compose-handler)))
   ;; insert mail-header-separator, which is needed by message mode to separate
@@ -451,7 +451,7 @@ buffer."
 	  (when (and forwarded-from (string-match "<\\(.*\\)>" forwarded-from))
 	    (mu4e~proc-move (match-string 1 forwarded-from) nil "+P-N")))))))
 
-(defun mu4e-compose (compose-type)
+(defun mu4e-compose (compose-type &optional reply-to)
   "Start composing a message of COMPOSE-TYPE, where COMPOSE-TYPE is
 a symbol, one of `reply', `forward', `edit', `new'. All but `new'
 take the message at point as input. Symbol `edit' is only allowed
@@ -485,12 +485,12 @@ for draft messages."
 	  (when (window-live-p viewwin)
 	    (select-window viewwin)))
 	;; talk to the backend
-	(mu4e~proc-compose compose-type decrypt docid)))))
+	(mu4e~proc-compose compose-type decrypt docid reply-to)))))
 
-(defun mu4e-compose-reply ()
+(defun mu4e-compose-reply (&optional reply-to)
   "Compose a reply for the message at point in the headers buffer."
   (interactive)
-  (mu4e-compose 'reply))
+  (mu4e-compose 'reply reply-to))
 
 (defun mu4e-compose-forward ()
   "Forward the message at point in the headers buffer."
@@ -517,12 +517,13 @@ draft message."
 
 ;;;###autoload
 (defun mu4e~compose-mail (&optional to subject other-headers continue
-			   switch-function yank-action send-actions return-action)
+			   switch-function yank-action send-actions return-action
+			   reply-to)
   "This is mu4e's implementation of `compose-mail'."
 
   ;; create a new draft message 'resetting' (as below) is not actually needed in
   ;; this case, but let's prepare for the re-edit case as well
-  (mu4e~compose-handler 'new)
+  (mu4e~compose-handler 'new nil reply-to)
 
   (when (message-goto-to) ;; reset to-address, if needed
     (message-delete-line))

--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -189,7 +189,7 @@ The server output is as follows:
   => the docid will be passed to `mu4e-remove-func'
 
   6. a compose looks like:
-  (:compose <reply|forward|edit|new> [:original<msg-sexp>] [:include <attach>])
+  (:compose <reply|forward|edit|new> [:original<msg-sexp>] [:include <attach>] [:reply-to <all|sender>])
   `mu4e-compose-func'."
   (mu4e-log 'misc "* Received %d byte(s)" (length str))
   (setq mu4e~proc-buf (concat mu4e~proc-buf str)) ;; update our buffer
@@ -245,7 +245,8 @@ The server output is as follows:
 	    (funcall mu4e-compose-func
 	      (plist-get sexp :compose)
 	      (plist-get sexp :original)
-	      (plist-get sexp :include)))
+	      (plist-get sexp :include)
+	      (plist-get sexp :reply-to)))
 
 	  ;; do something with a temporary file
 	  ((plist-get sexp :temp)
@@ -433,7 +434,7 @@ e.g. '/drafts'.
       (mu4e~proc-escape path) (mu4e~proc-escape maildir)))
 
 
-(defun mu4e~proc-compose (type decrypt &optional docid)
+(defun mu4e~proc-compose (type decrypt &optional docid reply-to)
   "Start composing a message of certain TYPE (a symbol, either
 `forward', `reply', `edit' or `new', based on an original
 message (ie, replying to, forwarding, editing) with DOCID or nil
@@ -446,8 +447,11 @@ The result will be delivered to the function registered as
   (unless (eq (null docid) (eq type 'new))
     (mu4e-error "`new' implies docid not-nil, and vice-versa"))
   (mu4e~proc-send-command
-    "cmd:compose type:%s docid:%d extract-encrypted:%s use-agent:true"
-    (symbol-name type) docid (if decrypt "true" "false")))
+    "cmd:compose type:%s docid:%d extract-encrypted:%s use-agent:true%s"
+    (symbol-name type) docid (if decrypt "true" "false")
+    (if (eq reply-to nil)
+        ""
+      (concat " reply-to:" (symbol-name reply-to)))))
 
 (defun mu4e~proc-mkdir (path)
   "Create a new maildir-directory at filesystem PATH."


### PR DESCRIPTION
Make mu4e-compose-reply take an optional argument that shows whether
the reply should be to all recipients or only to the sender.
#373 and #542 related
