### PR TITLE
Make the speedbar feature also work for sr-speedbar

### DIFF
--- a/mu4e/mu4e-speedbar.el
+++ b/mu4e/mu4e-speedbar.el
@@ -32,6 +32,7 @@
 ;;; Code:
 
 (require 'speedbar)
+(require 'sr-speedbar nil t)
 (require 'mu4e-vars)
 (require 'mu4e-headers)
 


### PR DESCRIPTION
sr-speedbar uses speedbar as backend, but displays it in the same frame.

I'm also curious that how speedbar knows to load `mu4e-*-speedbar-buttons`? I didn't find anywhere in the code `mu4e-*-speedbar-buttons` is called. Sorry I'm very new to elisp.