### PR TITLE
mu-cmd-server.c: quote msgid in query

### DIFF
--- a/mu/mu-cmd-server.c
+++ b/mu/mu-cmd-server.c
@@ -258,7 +258,7 @@ get_docid_from_msgid (MuQuery *query, const char *str, GError **err)
 	unsigned docid;
 	MuMsgIter *iter;
 
-	querystr = g_strdup_printf ("msgid:%s", str);
+	querystr = g_strdup_printf ("msgid:\"%s\"", str);
 	iter = mu_query_run (query, querystr,
 			     MU_MSG_FIELD_ID_NONE,
 			     1, MU_QUERY_FLAG_NONE, err);
@@ -293,7 +293,7 @@ get_docids_from_msgids (MuQuery *query, const char *str, GError **err)
 	MuMsgIter *iter;
 	GSList *lst;
 
-	querystr = g_strdup_printf ("msgid:%s", str);
+	querystr = g_strdup_printf ("msgid:\"%s\"", str);
 	iter = mu_query_run (query, querystr, MU_MSG_FIELD_ID_NONE,
 			     -1 /*unlimited*/, MU_QUERY_FLAG_NONE,
 			     err);


### PR DESCRIPTION
Hi.  I received some messages with spaces in the message id.  mu4e was having problems handling the messages when attempting the "move" server command to set flags when I viewed the messages.  The query to return all docids for the msgid was returning no results.  Surrounding the msgid with quotes in the mu query fixed the problem.

If this seems like the correct approach, feel free to merge the fix.  If you'd like to see it reworked in some way, I'd be happy to make another attempt.

Thanks for this amazing mailreader!