### PR TITLE
Fix org-mu4e bug with HTML in text/plain part

### DIFF
--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -196,7 +196,6 @@ and images in a multipart/related part."
 	    (raw-body (buffer-substring begin end))
 	    (tmp-file (make-temp-name (expand-file-name "mail"
 					temporary-file-directory)))
-            (body (org-export-string-as raw-body 'html t))
 	    ;; because we probably don't want to skip part of our mail
 	    (org-export-skip-text-before-1st-heading nil)
 	    ;; because we probably don't want to export a huge style file
@@ -217,7 +216,7 @@ and images in a multipart/related part."
 	(goto-char begin)
 	(newline)
 	(insert (org~mu4e-mime-multipart
-		  body html (mapconcat 'identity html-images "\n")))))) 
+		  raw-body html (mapconcat 'identity html-images "\n"))))))
 
 ;; next some functions to make the org/mu4e-compose-mode switch as smooth as
 ;; possible.


### PR DESCRIPTION
When sending org mode mail, both the text/html and text/plain parts
contained the HTML version of the mail, instead of just the text/html
part. This patch puts the raw-body (org format) in the text part, and
the html with replaced images in the html part.