### PR TITLE
Fix a core dump under OpenBSD-current (ca. 5.7-beta, 04-MAR-2014) on amd64

### DIFF
--- a/lib/mu-msg-iter.cc
+++ b/lib/mu-msg-iter.cc
@@ -366,7 +366,7 @@ mu_msg_iter_get_msgid (MuMsgIter *iter)
 	g_return_val_if_fail (!mu_msg_iter_is_done(iter), NULL);
 
 	try {
-		return iter->msgid().c_str();
+		return g_strdup(iter->msgid().c_str());
 
 	} MU_XAPIAN_CATCH_BLOCK_RETURN (NULL);
 }
@@ -397,7 +397,7 @@ mu_msg_iter_get_thread_id (MuMsgIter *iter)
 	try {
 		const std::string thread_id (
 			iter->cursor().get_document().get_value(MU_MSG_FIELD_ID_THREAD_ID).c_str());
-		return thread_id.empty() ? NULL : thread_id.c_str();
+		return thread_id.empty() ? NULL : g_strdup(thread_id.c_str());
 
 
 	} MU_XAPIAN_CATCH_BLOCK_RETURN (NULL);

--- a/lib/mu-query.cc
+++ b/lib/mu-query.cc
@@ -424,14 +424,13 @@ get_thread_ids (MuMsgIter *iter, GHashTable **orig_set)
 		unsigned docid;
 		/* record the thread id for the message */
 		if ((thread_id = mu_msg_iter_get_thread_id (iter)))
-			g_hash_table_insert (ids, g_strdup (thread_id),
+			g_hash_table_insert (ids, (void *)thread_id,
 					     GSIZE_TO_POINTER(TRUE));
 		/* record the original set */
 		docid = mu_msg_iter_get_docid(iter);
-		if (docid != 0 && (msgid = mu_msg_iter_get_msgid (iter)))
-			g_hash_table_insert (*orig_set, g_strdup (msgid),
+		if (docid != 0 && (msgid = mu_msg_iter_get_msgid(iter)))
+			g_hash_table_insert (*orig_set, (void *)msgid,
 					     GSIZE_TO_POINTER(docid));
-
 		if (!mu_msg_iter_next (iter))
 			break;
 	}


### PR DESCRIPTION
First, thanks for mu, it's great!

I'm a heavy mu/mu4e user on OpenBSD.  I just switched to running
-current on my amd64 thinkpad and mu was dumping core.  The reason
seems to be that c_str() was being used as the return value from
mu_msg_iter_get_{msgid,thread_id}.  At least in the case of
get_msgid() this resulted in an invalid pointer being passed to
g_strdup() in get_thread_ids() in mu-query.cc.  The same pattern was
used in mu_msg_iter_get_thread_ids().  In both cases the function is
only called once and the caller just calls g_strdup() so I moved the
call to g_strdup() into the functions in mu-msg-iter.cc.
