### PR TITLE
mu4e: match truename of `mu4e-maildir`

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -153,14 +153,14 @@ see its docstring)."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun mu4e~guess-maildir (path)
   "Guess the maildir for some path, or nil if cannot find it."
-  (let ((idx (or (string-match mu4e-maildir path)
-                 (string-match (file-truename mu4e-maildir) path))))
+  (let* ((maildir mu4e-maildir)
+         (idx (string-match maildir path)))
+    (unless (and idx (zerop idx))
+      (setq maildir (file-truename maildir))
+      (setq idx (string-match maildir path)))
     (when (and idx (zerop idx))
-      (replace-regexp-in-string
-	mu4e-maildir
-	""
-	(expand-file-name
-	  (concat path "/../.."))))))
+      (substring (expand-file-name "../.." path)
+                 (length maildir)))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -153,7 +153,8 @@ see its docstring)."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun mu4e~guess-maildir (path)
   "Guess the maildir for some path, or nil if cannot find it."
-  (let ((idx (string-match mu4e-maildir path)))
+  (let ((idx (or (string-match mu4e-maildir path)
+                 (string-match (file-truename mu4e-maildir) path))))
     (when (and idx (zerop idx))
       (replace-regexp-in-string
 	mu4e-maildir


### PR DESCRIPTION
If `mu4e-maildir` is a symlink, mu4e will
fail to determine drafts folder when you want
to edit drafts.