### PR TITLE
* mu4e/mu4e-actions.el: modify org-capture-templates

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -148,9 +148,9 @@ store your org-contacts."
 	  (blurb
 	    (format
 	      (concat
-		"* %s%%?\n"
+		"* %%?%s\n"
 		":PROPERTIES:\n"
-		":EMAIL:%s\n"
+		":EMAIL: %s\n"
 		":NICK:\n"
 		":BIRTHDAY:\n"
 		":END:\n\n")


### PR DESCRIPTION
add " " between :EMAIL: and 'mail' because org-contacts needs the separator.
move the cursor to the left of 'name'