### PR TITLE
minor NEWS missing bug correction

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_CONFIG_SRCDIR([mu/mu.cc])
 # libtoolize wants to put some stuff in here; if you have an old
 # autotools/libtool setup. you can try to comment this out
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 
 # silent build if we have a new enough automake
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])


### PR DESCRIPTION
Hello,

I am currently on ubuntu 15.04 with autoreconf 2.67, automake .1.14.1 and when I try to compile mu, I have this message
```
> $ autoreconf -i                                                                   [±master]
Makefile.am: error: required file './NEWS' not found
autoreconf: automake failed with exit status: 1
```

Adding foreign to AM_INIT_AUTOMAKE solve this issue