### PR TITLE
Fix core dump in mu-server (at least) for cmd:extract index:0 ...

### DIFF
--- a/lib/mu-msg-part.c
+++ b/lib/mu-msg-part.c
@@ -780,6 +780,11 @@ mu_msg_part_save (MuMsg *msg, MuMsgOptions opts,
 		part = (GMimeObject*)g_mime_message_part_get_message
 			(GMIME_MESSAGE_PART (part));
 
+	if (!part) {
+		g_set_error (err, MU_ERROR_DOMAIN, MU_ERROR_GMIME,
+			     "part %u does not exist", partidx);
+		return FALSE;
+	}
 	if (!GMIME_IS_PART(part) && !GMIME_IS_MESSAGE(part)) {
 		g_set_error (err, MU_ERROR_DOMAIN, MU_ERROR_GMIME,
 			     "unexpected type %s for part %u",


### PR DESCRIPTION
Under OpenBSD (i386-current) I just experienced a core dump from mu-server.
The issue was sending cmd:extract index:0 ...
This patch seems to fix it cleanly, now I just get an error (part 0 does not exist).

Thanks for writing mu! Great stuff.
