### PR TITLE
Follow-up to commit #630: Clarify bbdb setup comes after mu4e setup

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -2779,7 +2779,9 @@ is also possible to manage your addresses with the current (2015-06-23)
 development release of @t{BBDB}, or releases of @t{BBDB} after
 3.1.2.@footnote{@url{http://savannah.nongnu.org/projects/bbdb/}}.
 
-To enable BBDB, add to your configuration something like:
+To enable BBDB, add to your @file{~/.emacs} (or its moral equivalent,
+such as @file{~/.emacs.d/init.el}) the following @emph{after} the
+@code{(require 'mu4e)} line:
 
 @lisp
 ;; Load BBDB (Method 1)


### PR DESCRIPTION
I've hopefully made it clear that the BBDB setup should come after `(require 'mu4e)`.