### PR TITLE
Prevent mu4e messages from overwriting information in the echo area

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -190,7 +190,8 @@ an absolute path."
   "Like `message', but prefixed with mu4e.
 If we're waiting for user-input or if there's some message in the
 echo area, don't show anything."
-  (unless (or (active-minibuffer-window))
+  (unless (or (active-minibuffer-window)
+              (current-message))
     (message "%s" (apply 'mu4e-format frm args))))
 
 (defun mu4e-index-message (frm &rest args)


### PR DESCRIPTION
`active-minibuffer-window` returns nil when there is a message in the echo area. In order to prevent overwriting the echo area, need to also check `current-message`.

I think this is what many people were referring to in issue #206.