### PR TITLE
Make usage of fancy chars configurable.

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -353,7 +353,8 @@ into a string."
   "Calculate the thread prefix based on thread info THREAD."
   (when thread
     (let ((get-prefix
-	    (lambda (cell)  (if mu4e-use-fancy-chars (cdr cell) (car cell)))))
+           (lambda (cell)  (if (or (eq mu4e-use-fancy-chars t)
+                                   (eq mu4e-use-fancy-chars 'threads)) (cdr cell) (car cell)))))
       (concat
 	(make-string (* (if (plist-get thread :empty-parent) 0 1)
 		 (plist-get thread :level)) ?\s)
@@ -378,7 +379,9 @@ internally, the Maildir spec determines what the flags look like,
 while our display may be different)."
   (let ((str "")
         (get-prefix
-         (lambda (cell) (if mu4e-use-fancy-chars (cdr cell) (car cell)))))
+         (lambda (cell)  (if (or (eq mu4e-use-fancy-chars t)
+                                 (eq mu4e-use-fancy-chars 'marks)) (cdr cell) (car cell)))))
+
     (dolist (flag mu4e-headers-visible-flags)
       (when (member flag flags)
         (setq str

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -140,8 +140,11 @@ personal message. This is used when indexing messages."
   'mu4e-user-mail-address-list "0.9.9.x")
 
 (defcustom mu4e-use-fancy-chars nil
-  "Whether to use fancy (non-ascii) characters."
-  :type 'boolean
+  "Whether to use fancy (non-ascii) characters for marks and/or threads."
+  :type '(choice (const :tag "Do not use fancy chars" nil)
+                 (const :tag "Use fancy chars everywhere" t)
+                 (const :tag "Use fancy chars only for threads" threads)
+                 (const :tag "Use fancy chars only for marks" marks))
   :group 'mu4e)
 
 (defcustom mu4e-date-format-long "%c"


### PR DESCRIPTION
mu4e-use-fancy-chars to can have the setting t (use fancy chars for marks and threads), marks, threads or nil. The change won't brake any config.