### PR TITLE
Do not convert dash to underscore when indexing

### DIFF
--- a/lib/mu-flags.h
+++ b/lib/mu-flags.h
@@ -137,7 +137,7 @@ MuFlags mu_flags_from_str (const char *str, MuFlagType types,
  * @return concatenation of all non-standard flags, as a string; free
  * with g_free when done. If there are no such flags, return NULL.
  */
-char*  mu_flags_custom_from_str (const char *str) G_GNUC_WARN_UNUSED_RESULT;
+char* mu_flags_custom_from_str (const char *str) G_GNUC_WARN_UNUSED_RESULT;
 
 
 /**

--- a/lib/mu-index.c
+++ b/lib/mu-index.c
@@ -300,7 +300,7 @@ mu_index_set_max_msg_size (MuIndex *index, guint max_size)
 	g_return_if_fail (index);
 
 	if (max_size == 0)
-		index->_max_filesize = 	MU_INDEX_MAX_FILE_SIZE;
+		index->_max_filesize = MU_INDEX_MAX_FILE_SIZE;
 	else
 		index->_max_filesize = max_size;
 }
@@ -388,8 +388,8 @@ mu_index_stats (MuIndex *index, const char *path,
 	if (stats)
 		memset (stats, 0, sizeof(MuIndexStats));
 
-	cb_data._idx_msg_cb        = cb_msg;
-	cb_data._idx_dir_cb        = cb_dir;
+	cb_data._idx_msg_cb = cb_msg;
+	cb_data._idx_dir_cb = cb_dir;
 
 	cb_data._stats     = stats;
 	cb_data._user_data = user_data;

--- a/lib/mu-msg-fields.c
+++ b/lib/mu-msg-fields.c
@@ -115,7 +115,7 @@ static const MuMsgField FIELD_DATA[] = {
 		MU_MSG_FIELD_TYPE_TIME_T,
 		"date", 'd', 'D',
 		FLAG_GMIME | FLAG_XAPIAN_TERM | FLAG_XAPIAN_VALUE |
-		FLAG_XAPIAN_BOOLEAN  | FLAG_RANGE_FIELD
+		FLAG_XAPIAN_BOOLEAN | FLAG_RANGE_FIELD
 	},
 
 	{
@@ -224,7 +224,7 @@ static const MuMsgField FIELD_DATA[] = {
 		MU_MSG_FIELD_TYPE_STRING,
 		"subject", 's', 'S',
 		FLAG_GMIME | FLAG_XAPIAN_INDEX | FLAG_XAPIAN_VALUE |
-		FLAG_XAPIAN_TERM  | FLAG_PREPROCESS
+		FLAG_XAPIAN_TERM | FLAG_PREPROCESS
 	},
 
 	{
@@ -337,21 +337,21 @@ gboolean
 mu_msg_field_xapian_index  (MuMsgFieldId id)
 {
 	g_return_val_if_fail (mu_msg_field_id_is_valid(id),FALSE);
-	return mu_msg_field(id)->_flags & FLAG_XAPIAN_INDEX  ? TRUE: FALSE;
+	return mu_msg_field(id)->_flags & FLAG_XAPIAN_INDEX ? TRUE: FALSE;
 }
 
 gboolean
 mu_msg_field_xapian_value (MuMsgFieldId id)
 {
 	g_return_val_if_fail (mu_msg_field_id_is_valid(id),FALSE);
-	return mu_msg_field(id)->_flags & FLAG_XAPIAN_VALUE  ? TRUE: FALSE;
+	return mu_msg_field(id)->_flags & FLAG_XAPIAN_VALUE ? TRUE: FALSE;
 }
 
 gboolean
 mu_msg_field_xapian_term (MuMsgFieldId id)
 {
 	g_return_val_if_fail (mu_msg_field_id_is_valid(id),FALSE);
-	return mu_msg_field(id)->_flags & FLAG_XAPIAN_TERM  ? TRUE: FALSE;
+	return mu_msg_field(id)->_flags & FLAG_XAPIAN_TERM ? TRUE: FALSE;
 }
 
 
@@ -359,7 +359,7 @@ gboolean
 mu_msg_field_is_range_field (MuMsgFieldId id)
 {
 	g_return_val_if_fail (mu_msg_field_id_is_valid(id),FALSE);
-	return mu_msg_field(id)->_flags & FLAG_RANGE_FIELD  ? TRUE: FALSE;
+	return mu_msg_field(id)->_flags & FLAG_RANGE_FIELD ? TRUE: FALSE;
 }
 
 
@@ -368,7 +368,7 @@ gboolean
 mu_msg_field_uses_boolean_prefix (MuMsgFieldId id)
 {
 	g_return_val_if_fail (mu_msg_field_id_is_valid(id),FALSE);
-	return mu_msg_field(id)->_flags & FLAG_XAPIAN_BOOLEAN?TRUE:FALSE;
+	return mu_msg_field(id)->_flags & FLAG_XAPIAN_BOOLEAN ? TRUE:FALSE;
 }
 
 
@@ -393,7 +393,7 @@ gboolean
 mu_msg_field_preprocess (MuMsgFieldId id)
 {
 	g_return_val_if_fail (mu_msg_field_id_is_valid(id),FALSE);
-	return mu_msg_field(id)->_flags & FLAG_PREPROCESS  ? TRUE: FALSE;
+	return mu_msg_field(id)->_flags & FLAG_PREPROCESS ? TRUE: FALSE;
 }
 
 

--- a/lib/mu-msg-fields.h
+++ b/lib/mu-msg-fields.h
@@ -114,7 +114,7 @@ void mu_msg_field_foreach (MuMsgFieldForeachFunc func, gconstpointer data);
  * @return the name of the field as a constant string, or
  * NULL if the field is unknown
  */
-const char*  mu_msg_field_name (MuMsgFieldId id) G_GNUC_PURE;
+const char* mu_msg_field_name (MuMsgFieldId id) G_GNUC_PURE;
 
 /**
  * get the shortcut of the field -- this a shortcut that can be use in
@@ -134,7 +134,7 @@ char mu_msg_field_shortcut (MuMsgFieldId id) G_GNUC_PURE;
  *
  * @return the xapian prefix char or 0 if the field is unknown
  */
-char  mu_msg_field_xapian_prefix (MuMsgFieldId id) G_GNUC_PURE;
+char mu_msg_field_xapian_prefix (MuMsgFieldId id) G_GNUC_PURE;
 
 
 /**

--- a/lib/mu-store-write.cc
+++ b/lib/mu-store-write.cc
@@ -302,7 +302,6 @@ add_terms_values_number (Xapian::Document& doc, MuMsg *msg, MuMsgFieldId mfid)
 		doc.add_term (prio_val((MuMsgPrio)num));
 }
 
-/* for string and string-list */
 static void
 add_terms_values_msgid (Xapian::Document& doc, MuMsg *msg)
 {

--- a/lib/mu-store-write.cc
+++ b/lib/mu-store-write.cc
@@ -44,7 +44,7 @@ _MuStore::begin_transaction ()
 {
 	try {
 		db_writable()->begin_transaction();
-			in_transaction (true);
+		in_transaction (true);
 	} MU_XAPIAN_CATCH_BLOCK;
 }
 
@@ -371,8 +371,8 @@ add_terms_values_string (Xapian::Document& doc, MuMsg *msg, MuMsgFieldId mfid)
 
 
 static void
-add_terms_values_string_list  (Xapian::Document& doc, MuMsg *msg,
-			       MuMsgFieldId mfid)
+add_terms_values_string_list (Xapian::Document& doc, MuMsg *msg,
+			      MuMsgFieldId mfid)
 {
 	const GSList *lst;
 
@@ -389,7 +389,7 @@ add_terms_values_string_list  (Xapian::Document& doc, MuMsg *msg,
 	}
 
 	if (mu_msg_field_xapian_term (mfid)) {
-		for  (; lst; lst = g_slist_next ((GSList*)lst))
+		for (; lst; lst = g_slist_next ((GSList*)lst))
 			add_terms_values_str (doc, (const gchar*)lst->data,
 					      mfid);
 	}
@@ -516,7 +516,7 @@ typedef struct _MsgDoc		 MsgDoc;
 
 
 static void
-add_terms_values_default  (MuMsgFieldId mfid, MsgDoc *msgdoc)
+add_terms_values_default (MuMsgFieldId mfid, MsgDoc *msgdoc)
 {
 	if (mu_msg_field_is_numeric (mfid))
 		add_terms_values_number
@@ -647,7 +647,7 @@ each_contact_info (MuMsgContact *contact, MsgDoc *msgdoc)
 		char *flat;
 		flat = mu_str_process_term (contact->address);
 		msgdoc->_doc->add_term
-			(std::string  (pfx + flat, 0, MuStore::MAX_TERM_LENGTH));
+			(std::string (pfx + flat, 0, MuStore::MAX_TERM_LENGTH));
 		g_free (flat);
 		add_address_subfields (*msgdoc->_doc, contact->address, pfx);
 

--- a/lib/mu-str.c
+++ b/lib/mu-str.c
@@ -492,7 +492,7 @@ check_for_field (const char *str, gboolean *is_field,
 	while (pfx.str && *pfx.str && !isalnum(*pfx.str))
 		++pfx.str;
 
-	pfx.match =  pfx.range_field = FALSE;
+	pfx.match = pfx.range_field = FALSE;
 
 	mu_msg_field_foreach ((MuMsgFieldForeachFunc)each_check_prefix,
 			      &pfx);

--- a/lib/mu-str.c
+++ b/lib/mu-str.c
@@ -525,6 +525,7 @@ handle_esc_maybe (GString *gstr, char **cur, gunichar uc,
 		case '*':
 		case '&':
 		case '"':
+		case '-':
 			g_string_append_c (gstr, kar);
 			return TRUE;
 		case '.':


### PR DESCRIPTION
Mu converts dash (-) to underscore (_) when indexing. This makes it impossible to search for strings like "non-terminating" (instead one had to search for "non terminating" which is only an approximation).
    
This conversion also prevents me from searching for my company's internal ticket numbers, which contain dashes. Other mail indexers, like Thunderbird and notmuch, do not have a problem with searching for strings with dashes.

(Minor whitespace and comment fixes also included in this pull request).