### PR TITLE
Fix typo from higl.* to highl.*

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -813,7 +813,7 @@ user-interaction ongoing."
   (hl-line-mode 1))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; higlighting
+;;; highlighting
 (defvar mu4e~highlighted-docid nil
   "The highlighted docid")
 

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -480,7 +480,7 @@ I.e. a message with the draft flag set."
   :group 'mu4e-faces)
 
 (defface mu4e-highlight-face
-  '((t :inherit higlight))
+  '((t :inherit highlight))
   "Face for highlighting things."
   :group 'mu4e-faces)
 


### PR DESCRIPTION
A simple typo fix