### PR TITLE
Ensure tests have unique names.

### DIFF
--- a/lib/tests/test-mu-str.c
+++ b/lib/tests/test-mu-str.c
@@ -543,7 +543,7 @@ main (int argc, char *argv[])
 	g_test_add_func ("/mu-str/mu-str-to-list-strip",
 			 test_mu_str_to_list_strip);
 
-	g_test_add_func ("/mu-str/mu-str-esc-to-list",
+	g_test_add_func ("/mu-str/mu-str-parse-arglist",
 			 test_parse_arglist);
 
 	g_test_add_func ("/mu-str/mu-str-replace",


### PR DESCRIPTION
glib 2.46 complains if this isn't the case:
(test-mu-str:28790): GLib-ERROR **: duplicate test case path: /mu-str/mu-str-esc-to-list