### PR TITLE
Fix issues reported by the byte-compiler.

### DIFF
--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -304,11 +304,14 @@ If there is just one recipient of ORIGMSG do nothing."
 It looks something like
   <time>-<random>.<hostname>:2,
 You can append flags."
-  (let* ((hostname
-	   (downcase
-	     (save-match-data
-	       (substring system-name
-		 (string-match "^[^.]+" system-name) (match-end 0))))))
+  (let* ((sysname (if (fboundp 'system-name)
+		      (system-name)
+		    (with-no-warnings system-name)))
+	 (hostname (downcase
+		    (save-match-data
+		      (substring sysname
+				 (string-match "^[^.]+" sysname)
+				 (match-end 0))))))
     (format "%s.%04x%04x%04x%04x.%s:2,%s"
       (format-time-string "%s" (current-time))
       (random 65535) (random 65535) (random 65535) (random 65535)

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -999,7 +999,7 @@ of `mu4e-split-view', and return a window for the message view."
              '(split-window-vertically mu4e-headers-visible-lines))
             ((eq mu4e-split-view 'vertical) ;; split vertically
              '(split-window-horizontally mu4e-headers-visible-columns)))))
-     (cond ((with-demoted-errors "Unable to split window"
+     (cond ((with-demoted-errors "Unable to split window: %S"
               (eval new-win-func)))
            (t ;; no splitting; just use the currently selected one
             (selected-window)))))

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -1086,7 +1086,8 @@ attachments, but as this is the default, you may not need it."
             (let* ((att (mu4e~view-get-attach msg num))
                    (fname  (plist-get att :name))
                    (index (plist-get att :index))
-                   (retry t))
+                   (retry t)
+		   fpath)
               (while retry
                 (setq fpath (expand-file-name (concat attachdir fname) path))
                 (setq retry


### PR DESCRIPTION
The byte-compiler also complains about `mu4e-doc-dir` not being defined. I have not fixed that because I don't know if that variable is defined and set in a generated file. If so, you should add `(defvar mu4e-doc-dir)` to silence the compiler.

I have also noticed that you still use `cl` instead of `cl-lib` and that indentation often is very broken. Would you accept patches that fix those things?