### PR TITLE
Fix propertizing body with mu4e-view-body-face.

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -240,7 +240,10 @@ found."
 		 (mu4e~view-custom-field msg field))))))
       mu4e-view-fields "")
     "\n"
-    (propertize (mu4e-message-body-text msg) 'face 'mu4e-view-body-face)))
+    (let ((body (mu4e-message-body-text msg)))
+      (when (fboundp 'add-face-text-property)
+        (add-face-text-property 0 (string-width body) 'mu4e-view-body-face t body))
+      body)))
 
 (defun mu4e~view-embedded-winbuf ()
   "Get a buffer (shown in a window) for the embedded message."


### PR DESCRIPTION
* mu4e/mu4e-view.el (mu4e-view-message-text):
When using `propertize' all properties added by `mu4e-html2text-command'
in html message are overwrited by `mu4e-view-body-face', so use here
`add-face-text-property' if available, otherwise behave as before and return
body unchanged.