### PR TITLE
docs: mu-easy: summary to summary-len

### DIFF
--- a/man/mu-easy.1
+++ b/man/mu-easy.1
@@ -108,11 +108,11 @@ In other words, display messages that are either sent to Julius Caesar
 .fi
 
 What if we want to see some of the body of the message?  You can get
-a 'summary' of the first lines of the message using the \fI--summary\fR
+a 'summary' of the first lines of the message using the \fI--summary-len\fR
 option, which will 'summarize' the first \fIn\fR lines of the message:
 
 .nf
-  \fB$ mu find --summary napoleon m:/archive\fR
+  \fB$ mu find --summary-len=3 napoleon m:/archive\fR
 .fi
 
 .nf


### PR DESCRIPTION
This option has apparently changed somewhere down the line.