### PR TITLE
mu4e: Moving in headers should only change view if mu4e-split-view is non-nil.

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1451,7 +1451,7 @@ docid. Otherwise, return nil."
       ;; attempt to highlight the new line, display the message
       (mu4e~headers-highlight docid)
       ;; update message view if it was already showing
-      (when (window-live-p mu4e~headers-view-win)
+      (when mu4e-split-view
 	(mu4e-headers-view-message))
       docid)))
 


### PR DESCRIPTION
Fixes #690.