### PR TITLE
Allow specifying list shortnames with regexes

### DIFF
--- a/mu4e/mu4e-lists.el
+++ b/mu4e/mu4e-lists.el
@@ -85,4 +85,9 @@
   "A list of (MAILING-LIST-ID . SHORTNAME); these are used in
 addition to the 'built-in' list `mu4e~user-lists'.")
 
+(defvar mu4e-mailing-list-patterns nil
+  "A list of regex patterns to capture a shortname out of a list ID. For
+the first regex that matches, its first matchgroup will be used as the
+shortname.")
+
 (provide 'mu4e-lists)

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -517,7 +517,8 @@ that has a live window), and vice versa."
 
 (defun mu4e-get-mailing-list-shortname (list-id)
   "Get the shortname for a mailing-list with list-id LIST-ID. based
-  on `mu4e~mailing-lists' and `mu4e-user-mailing-lists'."
+on `mu4e~mailing-lists', `mu4e-user-mailing-lists', and
+`mu4e-mailing-list-patterns'."
   (unless mu4e~lists-hash
     (setq mu4e~lists-hash (make-hash-table :test 'equal))
     (dolist (cell mu4e~mailing-lists)
@@ -526,6 +527,12 @@ that has a live window), and vice versa."
       (puthash (car cell) (cdr cell) mu4e~lists-hash)))
   (or
     (gethash list-id mu4e~lists-hash)
+    (and (boundp 'mu4e-mailing-list-patterns)
+         (cl-member-if
+          (lambda (pattern)
+            (string-match pattern list-id))
+          mu4e-mailing-list-patterns)
+         (match-string 1 list-id))
     ;; if it's not in the db, take the part until the first dot if there is one;
     ;; otherwise just return the whole thing
     (if (string-match "\\([^.]*\\)\\." list-id)

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -799,8 +799,8 @@ in the example above). To determine whether a message was sent by you,
 your e-mail addresses.
 @item The 'List' field shows the mailing-list a message is sent to;
 @code{mu4e} tries to create a convenient shortcut for the mailing-list name;
-the variable @code{mu4e-user-mailing-lists} can be used to add your own
-shortcuts.
+the variables @code{mu4e-user-mailing-lists} and
+@code{mu4e-mailing-list-patterns} can be used to add your own shortcuts.
 @item The letters in the 'Flags' field correspond to the following: D=@emph{draft},
 F=@emph{flagged} (i.e., 'starred'), N=@emph{new}, P=@emph{passed} (i.e.,
 forwarded), R=@emph{replied}, S=@emph{seen}, T=@emph{trashed},


### PR DESCRIPTION
This way mu4e will intelligently shorten mailing list names which
contain dots:

    (setq mu4e-mailing-list-patterns
          '("\\([a-z0-9.]+\\)\.lists\.company\.com"))