### PR TITLE
mu-find(1): Document that you can search throug body:*

### DIFF
--- a/man/mu-find.1
+++ b/man/mu-find.1
@@ -104,6 +104,7 @@ search fields and their abbreviations:
 	from,f          Message sender
 	to,t            To: recipient(s)
 	subject,s       Message subject
+	body,b          Message body
 	maildir,m       Maildir
 	msgid,i         Message-ID
 	prio,p          Message priority ('low', 'normal' or 'high')


### PR DESCRIPTION
This is a long-standing feature, it works, but there was no mention of
it in the docs.

There's also bodyhtml:* but that doesn't seem to do anything for me,
maybe I just don't have enough HTML mail.

These also exist:

    path,l          ???
    refs,r          ???

But I don't know what they're for. They should probably be documented
too.