### PR TITLE
mu4e-{view,headers}: Refactor a (lamba) kbd-bound function into a named function

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -616,9 +616,8 @@ after the end of the search results."
       (define-key map (kbd "<M-up>") 'mu4e-headers-prev)
       (define-key map (kbd "<M-down>") 'mu4e-headers-next)
 
+      (define-key map (kbd "[") 'mu4e-headers-prev-unread)
       (define-key map (kbd "]") 'mu4e-headers-next-unread)
-      (define-key map (kbd "[")
-	(lambda() (interactive) (mu4e-headers-next-unread t)))
       
       ;; change the number of headers
       (define-key map (kbd "C-+") 'mu4e-headers-split-view-grow)
@@ -1472,10 +1471,10 @@ previous header."
   (interactive "P")
   (mu4e~headers-move (- (or n 1))))
 
-(defun mu4e-headers-next-unread (&optional backwards)
+(defun mu4e~headers-prev-or-next-unread (backwards)
   "Move point to the next message that is unread (and
 untrashed). If BACKWARDS is non-`nil', move backwards."
-  (interactive "P")
+  (interactive)
   (or (mu4e-headers-find-if-next
 	(lambda (msg)
 	  (let ((flags (mu4e-message-field msg :flags))) 
@@ -1484,6 +1483,17 @@ untrashed). If BACKWARDS is non-`nil', move backwards."
     (mu4e-message (format "No %s unread message found"
 		    (if backwards "previous" "next")))))
 
+(defun mu4e-headers-prev-unread ()
+  "Move point to the previous message that is unread (and
+untrashed)."
+  (interactive)
+  (mu4e~headers-prev-or-next-unread t))
+
+(defun mu4e-headers-next-unread ()
+  "Move point to the next message that is unread (and
+untrashed)."
+  (interactive)
+  (mu4e~headers-prev-or-next-unread nil))
 
 (defun mu4e~headers-jump-to-maildir (maildir)
   "Show the messages in maildir (user is prompted to ask what

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -601,9 +601,8 @@ FUNC should be a function taking two arguments:
       (define-key map (kbd "<M-down>") 'mu4e-view-headers-next)
       (define-key map (kbd "<M-up>") 'mu4e-view-headers-prev)
 
+      (define-key map (kbd "[") 'mu4e-view-headers-prev-unread)
       (define-key map (kbd "]") 'mu4e-view-headers-next-unread)
-      (define-key map (kbd "[")
-	(lambda() (interactive) (mu4e-view-headers-next-unread t)))
       
       ;; switching to view mode (if it's visible)
       (define-key map "y" 'mu4e-select-other-view)
@@ -878,17 +877,29 @@ N (prefix argument), to the Nth previous header."
   (mu4e~view-in-headers-context
     (mu4e~headers-move (- (or n 1)))))
 
-(defun mu4e-view-headers-next-unread (&optional backwards)
+(defun mu4e~view-prev-or-next-unread (backwards)
   "Move point to the next or previous (when BACKWARDS is non-`nil')
 unread message header in the headers buffer connected with this
 message view. If this succeeds, return the new docid. Otherwise,
 return nil."
-  (interactive "P")
   (mu4e~view-in-headers-context 
-    (mu4e-headers-next-unread backwards))
+    (mu4e~headers-prev-or-next-unread backwards))
   (mu4e-select-other-view)
   (mu4e-headers-view-message))
 
+(defun mu4e-view-headers-prev-unread ()
+"Move point to the previous unread message header in the headers
+buffer connected with this message view. If this succeeds, return
+the new docid. Otherwise, return nil."
+  (interactive)
+  (mu4e~view-prev-or-next-unread t))
+
+(defun mu4e-view-headers-next-unread ()
+  "Move point to the next unread message header in the headers
+buffer connected with this message view. If this succeeds, return
+the new docid. Otherwise, return nil."
+  (interactive)
+  (mu4e~view-prev-or-next-unread nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
Because this was a lambda C-h m would just show "??" instead of the
function name, and the documentation would be really confusing since it
showed the deparsed lambda function instead of the function name being
called.

Fix this by refactoring both the view & headers [ and ] functions into
named functions, and make their shared logic new internal
mu4u~{headers,view}-* functions.