### PR TITLE
Query markpair in interactive declaration

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1153,21 +1153,23 @@ descendants."
       (goto-char last-marked-point)
       (mu4e-headers-next))))
 
-(defun mu4e-headers-mark-thread (&optional subthread)
+(defun mu4e-headers-mark-thread (&optional subthread markpair)
   "Like `mu4e-headers-mark-thread-using-markpair' but prompt for the markpair."
-  (interactive "P")
-  (let* (;; FIXME: e.g., for refiling we should evaluate this
-	 ;; for each line separately
-	 (markpair
-	  (mu4e~mark-get-markpair
-	   (if subthread "Mark subthread with: " "Mark whole thread with: ")
-	   t)))
-    (mu4e-headers-mark-thread-using-markpair markpair)))
+  (interactive
+   (let* ((subthread current-prefix-arg))
+     (list current-prefix-arg
+           ;; FIXME: e.g., for refiling we should evaluate this
+           ;; for each line separately
+           (mu4e~mark-get-markpair
+            (if subthread "Mark subthread with: " "Mark whole thread with: ") t))))
+  (mu4e-headers-mark-thread-using-markpair markpair subthread))
 
-(defun mu4e-headers-mark-subthread ()
+(defun mu4e-headers-mark-subthread (&optional markpair)
   "Like `mu4e-mark-thread', but only for a sub-thread."
   (interactive)
-  (mu4e-headers-mark-thread t))
+  (if markpair (mu4e-headers-mark-thread t markpair)
+    (let ((current-prefix-arg t))
+      (call-interactively 'mu4e-headers-mark-thread))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -935,17 +935,25 @@ matching messages with that mark."
   (interactive)
   (mu4e~view-in-headers-context (mu4e-headers-mark-pattern)))
 
-(defun mu4e-view-mark-thread ()
-  "Ask user for a kind of mark (move, delete etc.), and apply it to
-all messages in the thread at point in the headers view."
+(defun mu4e-view-mark-thread (&optional markpair)
+  "Ask user for a kind of mark (move, delete etc.), and apply it
+to all messages in the thread at point in the headers view. The
+optional MARKPAIR can also be used to provide the mark
+selection."
   (interactive)
-  (mu4e~view-in-headers-context (mu4e-headers-mark-thread)))
+  (mu4e~view-in-headers-context
+   (if markpair (mu4e-headers-mark-thread nil markpair)
+       (call-interactively 'mu4e-headers-mark-thread))))
 
-(defun mu4e-view-mark-subthread ()
-  "Ask user for a kind of mark (move, delete etc.), and apply it to
-all messages in the subthread at point in the headers view."
+(defun mu4e-view-mark-subthread (&optional markpair)
+  "Ask user for a kind of mark (move, delete etc.), and apply it
+to all messages in the subthread at point in the headers view.
+The optional MARKPAIR can also be used to provide the mark
+selection."
   (interactive)
-  (mu4e~view-in-headers-context (mu4e-headers-mark-subthread)))
+  (mu4e~view-in-headers-context
+   (if markpair (mu4e-headers-mark-subthread markpair)
+     (mu4e-headers-mark-subthread))))
 
 (defun mu4e-view-search-narrow ()
   "Run `mu4e-headers-search-narrow' in the headers buffer."


### PR DESCRIPTION
My mail processing workflow is to browse through threads with the press of a button and mark the previous thread as read. Now the closest I can get is pressing `T!` to mark thread read. Unfortunately this can't be reduced to one keypress as `mu4e-headers-mark-thread` always queries the mark type separately.

I did some refactoring to the relevant mark-thread functions to make my workflow possible without using the private `mu4e~view-in-headers-context`. So my view-mark-thread-as-read keybinding becomes:

```
(lambda ()
  (interactive)
  (mu4e-view-mark-thread '(read)))
```

Relevant issue: https://github.com/syl20bnr/spacemacs/pull/3922/.

If there's no reason to have  `mu4e~view-in-headers-context` as private, then I think it is cleaner to just make it public API that hopefully won't change in the future.
