### PR TITLE
Add support for mu4e-use-fancy-chars to the marking in the headers view

### DIFF
--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -124,7 +124,13 @@ is either a headers or view buffer."
   "The list of all the possible marks.
 This is an alist mapping mark symbols to their properties.  The
 properties are:
-  :char (string)  The character to display in the headers view
+  :char (string) or (basic . fancy) The character to display in
+    the headers view. Either a single-character string, or a
+    dotted-pair cons cell where the second item will be used if
+    `mu4e-use-fancy-chars' is `t' or `marks', otherwise we'll use
+    the first one. It can also be a plain string for backwards
+    compatibility since we didn't always support
+    `mu4e-use-fancy-chars' here.
   :prompt (string) The prompt to use when asking for marks (used for
      example when marking a whole thread)
   :ask-target (function returning a string) Get the target.  This
@@ -235,7 +241,14 @@ The following marks are available, and the corresponding props:
 	  ;; target (the target folder) the other ones get a pseudo "target", as
 	  ;; info for the user.
 	  (markdesc (cdr (or (assq mark mu4e-marks) (mu4e-error "Invalid mark %S" mark))))
-	  (markkar (plist-get markdesc :char))
+	  (get-markkar
+	   (lambda (char)
+	     (if (listp char)
+	         (if (or (eq mu4e-use-fancy-chars t)
+	                 (eq mu4e-use-fancy-chars 'marks))
+	             (cdr char) (car char))
+	       char)))
+	  (markkar (funcall get-markkar (plist-get markdesc :char)))
 	  (target (mu4e~mark-get-dyn-target mark target))
 	  (show-fct (plist-get markdesc :show-target))
 	  (shown-target (if show-fct

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -153,7 +153,7 @@ properties are:
 	:dyn-target  (lambda (target msg) (mu4e-get-refile-folder msg))
 	:action      (lambda (docid msg target) (mu4e~proc-move docid (mu4e~mark-check-target target) "-N")))
        (delete
-	 :char "D"
+	 :char      ("D" . "🗙")
 	 :prompt "Delete"
 	 :show-target (lambda (target) "delete")
 	 :action (lambda (docid msg target) (mu4e~proc-remove docid)))
@@ -173,7 +173,7 @@ properties are:
 	 :show-target (lambda (target) "read")
 	 :action (lambda (docid msg target) (mu4e~proc-move docid nil    "+S-u-N")))
        (trash
-	 :char      "d"
+	 :char      ("d" . "🗑")
 	 :prompt "dtrash"
 	 :dyn-target (lambda (target msg) (mu4e-get-trash-folder msg))
 	 :action (lambda (docid msg target) (mu4e~proc-move docid (mu4e~mark-check-target target) "+T-N")))

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -236,8 +236,8 @@ The following marks are available, and the corresponding props:
 	  ;; info for the user.
 	  (markdesc (cdr (or (assq mark mu4e-marks) (mu4e-error "Invalid mark %S" mark))))
 	  (markkar (plist-get markdesc :char))
-          (target (mu4e~mark-get-dyn-target mark target))
-          (show-fct (plist-get markdesc :show-target))
+	  (target (mu4e~mark-get-dyn-target mark target))
+	  (show-fct (plist-get markdesc :show-target))
 	  (shown-target (if show-fct
 			  (funcall show-fct target)
                           (if target (format "%S" target)))))


### PR DESCRIPTION
The mu4e-use-fancy-chars customization wasn't supported for the headers view's main marking of messages. Now it is, I've bent over backwards here to not make this break anyone's existing customization at the expense of some slight complexity.

I just added non-ASCII fancy characters for two of the actions, I couldn't find topical ones for the rest.