### PR TITLE
mu-server man page: Correct documentation about status reporting

### DIFF
--- a/man/mu-server.1
+++ b/man/mu-server.1
@@ -181,7 +181,7 @@ registers 'my' email addresses; see the documentation for
 .nf
 -> cmd:index path:<path> [my-addresses:<comma-separated-list-of-email-addresses>]
 .fi
-As a response, it will send (for each 500 messages):
+As a response, it will send (for each 1000 messages):
 .nf
 (:info index :status running :processed <processed> :updated <updated>)
 .fi


### PR DESCRIPTION
This 500 number was correct in v0.9.7-pre-302-g858552a, but since
v0.9.8.2-41-gc2e3eac it's been hardcoded to 1000 in the server code.

See also issue #715 and issue #716.