### PR TITLE
mu4e-headers: Add hook executed when we're opening bookmarks

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -160,6 +160,12 @@ query have been received and are displayed."
   :type 'hook
   :group 'mu4e-headers)
 
+(defcustom mu4e-headers-search-bookmark-hook nil
+  "Hook run just we're about to do a bookmarked search. The only
+argument is `expr' which is the bookmarked search we're about to
+execute."
+  :type 'hook
+  :group 'mu4e-headers)
 
 (defvar mu4e-headers-sort-field :date
   "Field to sort the headers by.
@@ -1257,6 +1263,7 @@ the search."
   (let ((expr
 	  (or expr
 	    (mu4e-ask-bookmark (if edit "Select bookmark: " "Bookmark: ")))))
+    (run-hook-with-args 'mu4e-headers-search-bookmark-hook expr)
     (mu4e-headers-search expr (when edit "Edit bookmark: ") edit)))
 
 (defun mu4e-headers-search-bookmark-edit ()


### PR DESCRIPTION
I'm using this for a rather nasty hack. When I open different bookmarks
in the mu4e-main view I want to set options for them, currently just
tweaking:

    * mu4e-headers-show-threads
    * mu4e-headers-include-related
    * mu4e-headers-skip-duplicates
    * mu4e-headers-results-limit

This is because some of my searches are *really* expensive when I
include related threads (huge batches of cron-generated E-Mails), but
some aren't. I couldn't find another way to do this. Using
mu4e-headers-mode-hook doesn't work, because we don't have access to the
search (just a variable showing the last search).

Also maybe we should be passing the actual key chord for the bookmark
here. I don't care since I look up the search string that'll be executed
and go from there, but maybe that interface would make more sense.

But whatever, this works for me, and solves a real use-case.