### PR TITLE
Partially solve issue #75 & add a :report-processed-every argument

### DIFF
--- a/lib/mu-index.h
+++ b/lib/mu-index.h
@@ -96,7 +96,7 @@ void mu_index_set_xbatch_size (MuIndex *index, guint xbatchsize);
  * @return  MU_OK to continue, MU_STOP to stop, or MU_ERROR in
  * case of some error.
  */
-typedef MuError (*MuIndexMsgCallback) (MuIndexStats* stats, void *user_data);
+typedef MuError (*MuIndexMsgCallback) (MuIndexStats* stats, void *user_data, unsigned reporteveryn);
 
 
 /**
@@ -133,7 +133,8 @@ typedef MuError (*MuIndexDirCallback) (const char* path, gboolean enter,
  */
 MuError mu_index_run (MuIndex *index, const char *path, gboolean force,
 		      MuIndexStats *stats, MuIndexMsgCallback msg_cb,
-		      MuIndexDirCallback dir_cb, void *user_data);
+		      unsigned reporteveryn, MuIndexDirCallback dir_cb,
+		      void *user_data);
 
 /**
  * gather some statistics about the Maildir; this is usually much faster

--- a/mu/mu-cmd-index.c
+++ b/mu/mu-cmd-index.c
@@ -175,9 +175,9 @@ typedef struct _IndexData IndexData;
 
 
 static MuError
-index_msg_cb  (MuIndexStats* stats, IndexData *idata)
+index_msg_cb  (MuIndexStats* stats, IndexData *idata, unsigned reporteveryn)
 {
-	if (stats->_processed % 75)
+	if (stats->_processed % reporteveryn)
 	 	return MU_OK;
 
 	print_stats (stats, TRUE, idata->color);
@@ -323,6 +323,7 @@ cmd_index (MuIndex *midx, MuConfig *opts, MuIndexStats *stats, GError **err)
 			   show_progress ?
 			   (MuIndexMsgCallback)index_msg_cb :
 			   (MuIndexMsgCallback)index_msg_silent_cb,
+			   75,
 			   NULL, &idata);
 	newline_before_off();
 

--- a/mu/mu-cmd-server.c
+++ b/mu/mu-cmd-server.c
@@ -999,12 +999,12 @@ cmd_guile (ServerContext *ctx, GHashTable *args, GError **err)
 
 
 static MuError
-index_msg_cb (MuIndexStats *stats, void *user_data)
+index_msg_cb (MuIndexStats *stats, void *user_data, unsigned reporteveryn)
 {
 	if (MU_TERMINATE)
 		return MU_STOP;
 
-	if (stats->_processed % 1000)
+	if (!reporteveryn || stats->_processed % reporteveryn)
 		return MU_OK;
 
 	print_expr ("(:info index :status running "
@@ -1051,14 +1051,14 @@ get_checked_path (const char *path)
 
 
 static MuError
-index_and_cleanup (MuIndex *index, const char *path, GError **err)
+index_and_cleanup (MuIndex *index, const char *path, const unsigned reporteveryn, GError **err)
 {
 	MuError rv;
 	MuIndexStats stats, stats2;
 
 	mu_index_stats_clear (&stats);
 	rv = mu_index_run (index, path, FALSE, &stats,
-			   index_msg_cb, NULL, NULL);
+			   index_msg_cb, reporteveryn, NULL, NULL);
 
 	if (rv != MU_OK && rv != MU_STOP) {
 		mu_util_g_set_error (err, MU_ERROR_INTERNAL, "indexing failed");
@@ -1089,6 +1089,8 @@ cmd_index (ServerContext *ctx, GHashTable *args, GError **err)
 	MuIndex *index;
 	const char *argpath;
 	char *path;
+	const char* reporteverynstr;
+	unsigned reporteveryn = 1000;
 
 	index = NULL;
 
@@ -1102,7 +1104,12 @@ cmd_index (ServerContext *ctx, GHashTable *args, GError **err)
 	if (!(index = mu_index_new (ctx->store, err)))
 		goto leave;
 
-	index_and_cleanup (index, path, err);
+
+	reporteverynstr = get_string_from_args (args, "report-processed-every", TRUE, err);
+	if (reporteverynstr)
+		reporteveryn = atoi (reporteverynstr);
+
+	index_and_cleanup (index, path, reporteveryn, err);
 
 leave:
 	g_free (path);

--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -407,9 +407,14 @@ point to some maildir directory structure. MY-ADDRESSES is a list
 of 'my' email addresses (see `mu4e-user-mail-address-list')."
   (let ((path (mu4e~proc-escape path))
 	 (addrs (when my-addresses (mapconcat 'identity my-addresses ","))))
-    (if addrs
-      (mu4e~proc-send-command "cmd:index path:%s my-addresses:%s" path addrs)
-      (mu4e~proc-send-command "cmd:index path:%s" path))))
+    (if mu4e-hide-index-messages
+        (if addrs
+            (mu4e~proc-send-command "cmd:index path:%s my-addresses:%s report-processed-every:%d" path addrs 0)
+          (mu4e~proc-send-command "cmd:index path:%s report-processed-every:%d" path 0))
+      (if addrs
+          (mu4e~proc-send-command "cmd:index path:%s my-addresses:%s" path addrs)
+        (mu4e~proc-send-command "cmd:index path:%s" path)))))
+
 
 (defun mu4e~proc-add (path maildir)
   "Add the message at PATH to the database.


### PR DESCRIPTION
This argument can be report-processed-every for report no progress, or N
where N >1 for report every N. In mu4e we just use this to pass 0 if
`mu4e-hide-index-messages' is t. This makes the protocol a lot less
chatty during indexing.

We could add something to make the "send us an update every N" to mu4e,
that's supported by mu-server now, but I'm not doing that, this solves
my use-case of having a less chatty *mu4e-log*.

I was trying to do something with (apply) and (mapconcat) in
mu4e~proc-index that would make the if/else branches less copy/pasted,
but couldn't come up with something that wasn't even more verbose and
unwieldy.

This resolves issue #715 and issue #716.