### PR TITLE
Preliminary support for Content-Base

### DIFF
--- a/lib/mu-msg-sexp.c
+++ b/lib/mu-msg-sexp.c
@@ -532,6 +532,9 @@ mu_msg_to_sexp (MuMsg *msg, unsigned docid, const MuMsgIterThreadInfo *ti,
 	append_sexp_attr (gstr, "in-reply-to",
 			  mu_msg_get_header (msg, "In-Reply-To"));
 
+    append_sexp_attr (gstr, "content-base",
+              mu_msg_get_header (msg, "Content-Base"));
+
 	/* headers are retrieved from the database, views from the
 	 * message file file attr things can only be gotten from the
 	 * file (ie., mu view), not from the database (mu find).  */

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -73,7 +73,7 @@ messages requires html' text bodies."
   "Retrieve FIELD from message plist MSG.
 FIELD is one of :from, :to, :cc, :bcc, :subject, :data,
 :message-id, :path, :maildir, :priority, :attachments,
-:references, :in-reply-to, :body-txt, :body-html
+:references, :in-reply-to, :content-base, :body-txt, :body-html
 
 Returns `nil' if the field does not exist.
 
@@ -123,7 +123,8 @@ Thus, function will return nil for empty lists, non-existing body-txt or body-ht
     (cond
       (val
 	val)   ;; non-nil -> just return it
-      ((member field '(:subject :message-id :path :maildir :in-reply-to))
+      ((member field (list :subject :message-id :path :maildir
+                           :in-reply-to :content-base))
 	"")    ;; string fields except body-txt, body-html: nil -> ""
       ((member field '(:body-html :body-txt))
 	val)

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -674,6 +674,11 @@ mu4e-compose-mode."
 	 :shortname "Subject"
 	 :help "Subject of the thread"
 	 :sortable :subject))
+     (:content-base .
+       ( :name "Website"
+         :shortname "Website"
+         :help "Origin of the email"
+         :sortable t))
      (:to .
        ( :name "To"
 	 :shortname "T"

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -52,8 +52,8 @@
   :group 'mu4e)
 
 (defcustom mu4e-view-fields
-  '(:from :to  :cc :subject :flags :date :maildir :mailing-list :tags
-          :attachments :signature :decryption)
+  '(:from :to  :cc :subject :flags :date :maildir :mailing-list :content-base
+          :tags :attachments :signature :decryption)
   "Header fields to display in the message view buffer.
 For the complete list of available headers, see `mu4e-header-info'."
   :type (list 'symbol)
@@ -200,9 +200,10 @@ found."
       (lambda (field)
 	(let ((fieldval (mu4e-message-field msg field)))
 	  (case field
-	    (:subject  (mu4e~view-construct-header field fieldval))
-	    (:path     (mu4e~view-construct-header field fieldval))
-	    (:maildir  (mu4e~view-construct-header field fieldval))
+            (:subject       (mu4e~view-construct-header field fieldval))
+            (:path          (mu4e~view-construct-header field fieldval))
+            (:maildir       (mu4e~view-construct-header field fieldval))
+            (:content-base  (mu4e~view-construct-header field fieldval))
 	    ((:flags :tags) (mu4e~view-construct-flags-tags-header field fieldval))
 
 	    ;; contact fields


### PR DESCRIPTION
Some of my emails have a `Content-Base` header, with a URL to the webpage that was sent by email (this is the case in email subscriptions to blog posts). When this header is present, Thunderbird shows a `website` header, with a clickable link. Could this be added to mu4e?

This PR is not ready as-is, but I wanted to see how much would be needed. It does not yet make links clickable, and it doesn't decode encoded headers.