### PR TITLE
mu-store: Silence confusing code that's throwing a clang warning

### DIFF
--- a/lib/mu-store.cc
+++ b/lib/mu-store.cc
@@ -74,7 +74,7 @@ xapian_get_metadata (const gchar *xpath, const gchar *key)
 	g_return_val_if_fail (xpath, NULL);
 	g_return_val_if_fail (key, NULL);
 
-	if (!access(xpath, F_OK) == 0) {
+	if (access(xpath, F_OK) != 0) {
 		g_warning ("cannot access %s: %s", xpath, strerror(errno));
 		return NULL;
 	}


### PR DESCRIPTION
Doing:

    !access(...) == 0

Is equivalent to:

    (!access(...)) == 0

Not:

    !(access(...) == 0)

And throws this warning under clang:

    mu-store.cc:77:6: warning: logical not is only applied to the left hand
    side of this comparison [-Wlogical-not-parentheses]
            if (!access(xpath, F_OK) == 0) {
                ^                    ~~
    mu-store.cc:77:6: note: add parentheses after the '!' to evaluate the
    comparison first
            if (!access(xpath, F_OK) == 0) {
                ^
                 (                       )
    mu-store.cc:77:6: note: add parentheses around left hand side expression
    to silence this warning
            if (!access(xpath, F_OK) == 0) {
                ^
                (                   )

It ends up doing what the author intended anyway since access() returns
-1 on error, and !-1 == 0, but just do the more obvious check and check
that we don't get 0 here with !=.