### PR TITLE
Fix mu4e-context-determine to match documentation

### DIFF
--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -107,7 +107,7 @@ If there are contexts but none match, return nil, unless
     (or (find-if (lambda (context)
 		   (and (mu4e-context-match-func context)
 		     (funcall (mu4e-context-match-func context) msg))) mu4e-contexts)
-      (car mu4e-contexts))))
+      (when pick-first (car mu4e-contexts)))))
 
 (provide 'mu4e-context)
  


### PR DESCRIPTION
The documentation of `mu4e-context-determine` states that

>If there are contexts but none match, return nil, unless PICK-FIRST is non-nil, in which case return the first context."

but it never actually checks `pick-first`.