### PR TITLE
When mu4e-context-determine fails, prompt user

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -368,8 +368,9 @@ tempfile)."
   (set (make-local-variable 'mu4e-compose-parent-message) original-msg)
   (put 'mu4e-compose-parent-message 'permanent-local t)
   (let ((context (mu4e-context-determine mu4e-compose-parent-message)))
-    (when context
-      (mu4e-context-switch (mu4e-context-name context))))
+    (if context
+        (mu4e-context-switch (mu4e-context-name context))
+      (when mu4e-contexts (mu4e-context-switch))))
   (run-hooks 'mu4e-compose-pre-hook)
 
   ;; this opens (or re-opens) a messages with all the basic headers set.

--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -107,7 +107,7 @@ If there are contexts but none match, return nil, unless
     (or (find-if (lambda (context)
 		   (and (mu4e-context-match-func context)
 		     (funcall (mu4e-context-match-func context) msg))) mu4e-contexts)
-      (car mu4e-contexts))))
+      (when pick-first (car mu4e-contexts)))))
 
 (provide 'mu4e-context)
  


### PR DESCRIPTION
When `mu4e-context-determine` fails to pick a context (i.e. returns nil) when invoked from `mu4e~compose-handler` and there are available contexts, prompt the user to pick one.

This PR depends on #737, so please review/pull that one first.