### PR TITLE
Fix racing condition with context in mu4e~compose-handler

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -403,6 +403,9 @@ tempfile)."
   (set (make-local-variable 'mu4e-compose-parent-message) original-msg)
   (put 'mu4e-compose-parent-message 'permanent-local t)
   (run-hooks 'mu4e-compose-pre-hook)
+  ;; maybe switch the context.
+  (mu4e~context-autoswitch mu4e-compose-parent-message
+			   mu4e-compose-context-policy)
   ;; this opens (or re-opens) a messages with all the basic headers set.
   (condition-case nil
       (mu4e-draft-open compose-type original-msg)
@@ -431,12 +434,7 @@ tempfile)."
    ;; hide some headers
   (mu4e~compose-hide-headers)
   ;; switch on the mode
-  (mu4e-compose-mode)
-  ;; maybe switch the context, this should happen
-  ;; after `mu4e-compose-mode', otherwise mu4e in the meaning time
-  ;; switch back to view-mode buffer and calculate context there.
-  (mu4e~context-autoswitch mu4e-compose-parent-message
-			   mu4e-compose-context-policy))
+  (mu4e-compose-mode))
 
 (defun mu4e-sent-handler (docid path)
   "Handler function, called with DOCID and PATH for the just-sent

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -402,11 +402,7 @@ tempfile)."
   ;; message being forwarded or replied to, otherwise it is nil.
   (set (make-local-variable 'mu4e-compose-parent-message) original-msg)
   (put 'mu4e-compose-parent-message 'permanent-local t)
-  ;; maybe switch the context
-  (mu4e~context-autoswitch mu4e-compose-parent-message
-			   mu4e-compose-context-policy)
   (run-hooks 'mu4e-compose-pre-hook)
-
   ;; this opens (or re-opens) a messages with all the basic headers set.
   (condition-case nil
       (mu4e-draft-open compose-type original-msg)
@@ -435,7 +431,12 @@ tempfile)."
    ;; hide some headers
   (mu4e~compose-hide-headers)
   ;; switch on the mode
-  (mu4e-compose-mode))
+  (mu4e-compose-mode)
+  ;; maybe switch the context, this should happen
+  ;; after `mu4e-compose-mode', otherwise mu4e in the meaning time
+  ;; switch back to view-mode buffer and calculate context there.
+  (mu4e~context-autoswitch mu4e-compose-parent-message
+			   mu4e-compose-context-policy))
 
 (defun mu4e-sent-handler (docid path)
   "Handler function, called with DOCID and PATH for the just-sent

--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -144,8 +144,6 @@ to do:
 		     (and (mu4e-context-match-func context)
 		       (funcall (mu4e-context-match-func context) msg)))
 	  mu4e-contexts)
-	;; no matching one; but is there a current one?
-	(mu4e-context-current) 	
 	;; no context found yet; consult policy
 	(case policy
 	  (pick-first (car mu4e-contexts))


### PR DESCRIPTION
* mu4e/mu4e-compose.el (mu4e~compose-handler):
Switch the context after `mu4e-compose-mode', otherwise mu4e in the meaning time
switch back to view-mode buffer and calculate context there.