### PR TITLE
comform emacs libs convention

### DIFF
--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -1,4 +1,4 @@
-;;; mu4e.el -- part of mu4e, the mu mail user agent
+;;; mu4e.el --- part of mu4e, the mu mail user agent
 ;;
 ;; Copyright (C) 2011-2012 Dirk-Jan C. Binnema
 
@@ -89,3 +89,5 @@ window, unless BACKGROUND (prefix-argument) is non-nil."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (provide 'mu4e)
+
+;;; mu4e.el ends here


### PR DESCRIPTION
I was try `package-install-file` with the path mu4e in my site-lisp in `/usr/local`. I got the following error:
<pre>Debugger entered--Lisp error: (error "Package lacks a file header")
  signal(error ("Package lacks a file header"))
  error("Package lacks a file header")
  package-buffer-info()
  package-install-from-buffer()
  package-install-file("/usr/local/Cellar/mu/HEAD/share/emacs/site-lisp/mu/mu4e/mu4e.el")
  funcall-interactively(package-install-file "/usr/local/Cellar/mu/HEAD/share/emacs/site-lisp/mu/mu4e/mu4e.el")
  call-interactively(package-install-file record nil)</pre>

Then I dug a little bit. I found [Conventional Headers for Emacs Libraries](http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html)
I found some slight differences. Here it is.

It really doesn't make too much difference, but make the `package-install-file` working.

