### PR TITLE
mu: escape the name of the part

### DIFF
--- a/lib/mu-msg-sexp.c
+++ b/lib/mu-msg-sexp.c
@@ -366,7 +366,7 @@ each_part (MuMsg *msg, MuMsgPart *part, PartInfo *pinfo)
 		 ":attachment %s :size %i %s %s)",
 		 pinfo->parts ? pinfo->parts: "",
 		 part->index,
-		 name ? name : "noname",
+		 name ? mu_str_escape_c_literal(name, TRUE) : "noname",
 		 part->type ? part->type : "application",
 		 part->subtype ? part->subtype : "octet-stream",
 		 tmpfile ? " :temp" : "", tmpfile ? tmpfile : "",


### PR DESCRIPTION
I had a bug where mu4e wouldn't display a message, and instead kept "Waiting for message..." in the buffer. It was a bit annoying to debug because of the async nature of mu4e and because of an `ignore-errors` in `mu4e~proc-eat-sexp-from-buf`. The problem was that mu didn't properly quote some backslashes (in the mail, the name of the attachments had backslashes!), causing `read-from-string` to produce an error, which was ignored because of `ignore-errors`. This PR is a potential fix but I'm not sure it's the right place to do the escaping. Of course feel free to ignore and fix by other means.

[makes me wonder if `mu4e~proc-eat-sexp-from-buf` should perhaps be a tiny bit smarter about which error to ignore...]