### PR TITLE
mu4e-headers: Add hook executed when we're opening bookmarks (again)

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -20,9 +20,14 @@
    - Let `mu4e~read-char-choice' become case-insensitive if there is
      no exact match; small convenience that affects most the
      single-char option reading in mu4e.
-   - Now, just before executing a search, a hook-function
+   - Now, just before executing any search, a hook-function
      `mu4e-headers-search-pre-hook` is invoked, which receives the
      search expression as its parameter.
+   - In addition there's a `mu4e-headers-search-bookmark-hook` which
+     gets called when searches get invoked as a bookmark (note that
+     `mu4e-headers-search-pre-hook` will also be called just
+     afterwards). This hook also receives the search expression as its
+     parameter.
              
 ** 0.9.16
 

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -160,9 +160,27 @@ query have been received and are displayed."
   :type 'hook
   :group 'mu4e-headers)
 
+(defcustom mu4e-headers-search-bookmark-hook nil
+  "Hook run just after we invoke a bookmarked search. This
+function receives the query as its parameter.
+
+The reason to use this instead of `mu4e-headers-search-pre-hook'
+is if you only want to execute a hook when a search is entered
+via a bookmark, e.g. if you'd like to treat the bookmarks as a
+custom folder and change the options for the search,
+e.g. `mu4e-headers-show-threads', `mu4e-headers-include-related',
+`mu4e-headers-skip-duplicates` or `mu4e-headers-results-limit'."
+  :type 'hook
+  :group 'mu4e-headers)
+
 (defcustom mu4e-headers-search-pre-hook nil
   "Hook run just before executing a new search operation. This
-function receives the query as its parameter."
+function receives the query as its parameter.
+
+This is a more general hook facility than the
+`mu4e-headers-search-bookmark-hook'. It gets called on every
+executed search, not just those that are invoked via bookmarks,
+but also manually invoked searches."
   :type 'hook
   :group 'mu4e-headers)
 
@@ -1300,6 +1318,7 @@ the search."
   (let ((expr
 	  (or expr
 	    (mu4e-ask-bookmark (if edit "Select bookmark: " "Bookmark: ")))))
+    (run-hook-with-args 'mu4e-headers-search-bookmark-hook expr)
     (mu4e-headers-search expr (when edit "Edit bookmark: ") edit)))
 
 (defun mu4e-headers-search-bookmark-edit ()


### PR DESCRIPTION
This was merged in as part of pull request #718 but changed to a more
general facility in 7716e00.

It's fantastic that we have the more general hook facility for any
search, but the primary use-case I had for the bookmark hook can't be
satisfied by the more general mu4e-headers-search-pre-hook.

The reason I added this hook was to emulate the folders I used in
Icedove as mu4e bookmarks. E.g. some folders are threaded, others are
not. By default mu4e only allows you to set this globally via options
like mu4e-headers-show-threads.

So I have a mu4e-headers-search-bookmark-hook which is basically a long
line of cond statements like:

    ((string-equal expr "NOT flag:trashed AND date:365d..now AND (flag:flagged)")
        (setq mu4e-headers-show-threads nil)
        (setq mu4e-headers-include-related nil)
        (setq mu4e-headers-skip-duplicates t)
        (setq mu4e-headers-results-limit 500))

For this to work properly it's critical that the hook doesn't execute on
any search, but *only* those where we enter it via the bookmark.

As an example, I have a "b+" search which finds messages I've flagged,
most of my searches have related & threading turned on, but for that
search I only want to show the specific messages I've flagged, so the
hook turns both of those settings off before executing the search.

But I might still want to change my mind and look at the related
messages as threads by pressing P and then W. This works with the
mu4e-headers-search-bookmark-hook because it only executes when we get
the search via a bookmark.

But it doesn't work with the mu4e-headers-search-pre-hook because when I
toggle the setting my settings hook (which matches the search executed
by the bookmark) will just turn it back off again.

Perhaps there's some clever way to know if we're getting to the
mu4e-headers-search-pre-hook via the bookmark that I've missed. But if
there isn't I need a hook that works like this.