### PR TITLE
mu4e: add mu4e-index-update-in-background

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -828,7 +828,7 @@ successful, call FUNC (if non-nil) afterwards."
 		(setq mu4e~update-timer
 		  (run-at-time
 		    0 mu4e-update-interval
-		    (lambda () (mu4e-update-mail-and-index t)))))
+		    (lambda () (mu4e-update-mail-and-index mu4e-index-update-in-background)))))
 	      (mu4e-message "Started mu4e with %d message%s in store"
 		doccount (if (= doccount 1) "" "s"))))))
       ;; wake up server

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -83,6 +83,11 @@ already retrieved in another way."
   :group 'mu4e
   :safe 'booleanp)
 
+(defcustom mu4e-index-update-in-background t
+  "Whether run in background for automatic mail retrieval"
+  :type 'boolean
+  :group 'mu4e
+  :safe 'booleanp)
 
 (defcustom mu4e-update-interval nil
   "Number of seconds between automatic calls to retrieve mail and

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -479,10 +479,13 @@ if you use emacs in a terminal.
 You can interrupt the (foreground) update process with @kbd{q}.
 
 It is possible to update your mail and index periodically in the
-background, by setting the variable @code{mu4e-update-interval} to the
-number of seconds between these updates. If set to @code{nil}, it won't
-update at all. After you make changes to @code{mu4e-update-interval},
-@t{mu4e} must be restarted before the changes take effect.
+background or foreground, by setting the variable
+@code{mu4e-update-interval} to the number of seconds between these
+updates. If set to @code{nil}, it won't update at all. After you make
+changes to @code{mu4e-update-interval}, @t{mu4e} must be restarted
+before the changes take effect. By default, this will run in
+background and to change it to run in foreground, set
+@code{mu4e-index-update-in-background} to @code{nil}
 
 @subsection Handling errors during mail retrieval
 


### PR DESCRIPTION
Give users choice to decide if they want to run automatic mu4e-index-update in background or not