### PR TITLE
mu4e: quote user-full-name according to rfc822 when construct from field

### DIFF
--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -231,7 +231,7 @@ based on `user-full-name' and `user-mail-address'; if the latter is
 nil, function returns nil."
   (when user-mail-address
     (if user-full-name
-      (format "%s <%s>" user-full-name user-mail-address)
+      (format "%s <%s>" (mu4e~rfc822-quoteit user-full-name) user-mail-address)
       (format "%s" user-mail-address))))
 
 


### PR DESCRIPTION
If user-full-name is set to this format: ```Last Name, First Name```, without proper quotation, SMTP will use ```Last Name``` for from field which is wrong.