### PR TITLE
Add new face for subject in mu4e-view

### DIFF
--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -623,6 +623,11 @@ mu4e-compose-mode."
   "Face for highlighting marked region in mu4e-view buffer."
   :group 'mu4e-faces)
 
+(defface mu4e-header-subject-face
+  '((t :inherit mu4e-header-value-face))
+  "Face for subject header."
+  :group 'mu4e-faces)
+
 ;; headers info
 (defconst mu4e-header-info
   '( (:attachments .

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -330,7 +330,9 @@ add text-properties to VAL."
 		'help-echo help) " "
 	(if dont-propertize-val
 	  val
-	  (propertize val 'face 'mu4e-header-value-face)) "\n")
+	  (if (string= "Subject" key)
+	      (propertize val 'face 'mu4e-header-subject-face)
+	    (propertize val 'face 'mu4e-header-value-face))) "\n")
       (when mu4e-view-fill-headers
 	;; temporarily set the fill column <margin> positions to the right, so
 	;; we can indent the following lines correctly


### PR DESCRIPTION
I would like to have a different face for the subject line in the mu4e-view.

This adds a new face for the subject in the mu4e-view. The default configuration inherits from mu4e-header-value-face, that means that there is no visual difference to the old configuration. 
