### PR TITLE
Only ignore the "/mu/mu" executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 www/mu
 mug
-mu
+/mu/mu
 mug2
 .desktop
 *html


### PR DESCRIPTION
Currently the whole directory "/mu" are ignored, thus we have to force git to track the files in that directory.