### PR TITLE
Remove the backup file of a draft message when sending it

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -532,10 +532,10 @@ the appropriate flag at the message forwarded or replied-to."
     (mu4e~proc-remove docid))
   ;; kill any remaining buffers for the draft file, or they will hang around...
   ;; this seems a bit hamfisted...
-  (dolist (buf (buffer-list))
-    (when (and (buffer-file-name buf)
-               (string= (buffer-file-name buf) path))
-      (if message-kill-buffer-on-exit
+  (if message-kill-buffer-on-exit
+      (dolist (buf (buffer-list))
+	(when (and (buffer-file-name buf)
+		   (string= (buffer-file-name buf) path))
 	  (kill-buffer buf))))
   ;; now, try to go back to some previous buffer, in the order
   ;; view->headers->main

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -529,7 +529,9 @@ message. For Forwarded ('Passed') and Replied messages, try to set
 the appropriate flag at the message forwarded or replied-to."
   (mu4e~compose-set-parent-flag path)
   (when (file-exists-p path) ;; maybe the draft was not saved at all
-    (mu4e~proc-remove docid))
+    (mu4e~proc-remove docid)
+    (let ((backup (file-newest-backup path)))
+      (if backup (ignore-errors (delete-file backup)))))
   ;; kill any remaining buffers for the draft file, or they will hang around...
   ;; this seems a bit hamfisted...
   (if message-kill-buffer-on-exit


### PR DESCRIPTION
Fixes https://github.com/djcb/mu/issues/837

The solution is a bit unsatisfactory because it only removes the most recent backup file (while one would like to remove all associated backups to the file) but it works well in practice.