### PR TITLE
Compose mails with format=flowed by default

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -340,15 +340,6 @@ simply executes `fill-paragraph'."
 	(fill-paragraph nil region))
     (fill-paragraph nil region)))
 
-(define-key-after
-  (lookup-key text-mode-map [menu-bar text])
-  [mu4e-hard-newlines]
-  '(menu-item "Format=flowed" mu4e-toggle-use-hard-newlines
-	      :button (:toggle . use-hard-newlines)
-	      :help "Toggle format=flowed"
-	      :visible (eq major-mode 'mu4e-compose-mode))
-  'sep)
-
 (defun mu4e-toggle-use-hard-newlines ()
   (interactive)
   (setq use-hard-newlines (not use-hard-newlines))
@@ -395,6 +386,15 @@ simply executes `fill-paragraph'."
       (set (make-local-variable 'visual-line-fringe-indicators)
 	   '(left-curly-arrow right-curly-arrow))
       (visual-line-mode t))
+
+    (define-key-after
+      (lookup-key message-mode-map [menu-bar text])
+      [mu4e-hard-newlines]
+      '(menu-item "Format=flowed" mu4e-toggle-use-hard-newlines
+		  :button (:toggle . use-hard-newlines)
+		  :help "Toggle format=flowed"
+		  :visible (eq major-mode 'mu4e-compose-mode))
+      'sep)
 
     ;; setup the fcc-stuff, if needed
     (add-hook 'message-send-hook

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -326,6 +326,23 @@ message-thread by removing the In-Reply-To header."
       (define-key map (kbd "C-c C-k") 'mu4e-message-kill-buffer)
       map)))
 
+(define-key-after
+  (lookup-key text-mode-map [menu-bar text])
+  [mu4e-hard-newlines]
+  '(menu-item "Format=flowed" mu4e-toggle-use-hard-newlines
+	      :button (:toggle . use-hard-newlines)
+	      :help "Toggle format=flowed"
+	      :visible (eq major-mode 'mu4e-compose-mode))
+  'sep)
+
+(defun mu4e-toggle-use-hard-newlines ()
+  (interactive)
+  (setq use-hard-newlines (not use-hard-newlines))
+  (if use-hard-newlines
+      (turn-off-auto-fill)
+    (turn-on-auto-fill)))
+
+
 (defvar mu4e-compose-mode-abbrev-table nil)
 (define-derived-mode mu4e-compose-mode message-mode "mu4e:compose"
   "Major mode for the mu4e message composition, derived from `message-mode'.

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -143,7 +143,7 @@ Also see `mu4e-context-policy'."
   :safe 'symbolp
   :group 'mu4e-compose))
 
-(defcustom mu4e-compose-format-flowed t
+(defcustom mu4e-compose-format-flowed nil
   "Whether to compose messages to be sent as format=flowed (or
    with long lines if `use-hard-newlines' is set to nil).  The
    variable `fill-flowed-encode-column' lets you customize the
@@ -334,7 +334,7 @@ by blank lines.  If `use-hard-newlines' is not enabled, this
 simply executes `fill-paragraph'."
   ;; Inspired by https://www.emacswiki.org/emacs/UnfillParagraph
   (interactive (progn (barf-if-buffer-read-only) '(t)))
-  (if use-hard-newlines
+  (if mu4e-compose-format-flowed
       (let ((fill-column (point-max))
 	    (use-hard-newlines nil)); rfill "across" hard newlines
 	(fill-paragraph nil region))
@@ -393,7 +393,8 @@ simply executes `fill-paragraph'."
       '(menu-item "Format=flowed" mu4e-toggle-use-hard-newlines
 		  :button (:toggle . use-hard-newlines)
 		  :help "Toggle format=flowed"
-		  :visible (eq major-mode 'mu4e-compose-mode))
+		  :visible (eq major-mode 'mu4e-compose-mode)
+		  :enable mu4e-compose-format-flowed)
       'sep)
 
     ;; setup the fcc-stuff, if needed

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -324,7 +324,21 @@ message-thread by removing the In-Reply-To header."
       (define-key map (kbd "C-S-u")   'mu4e-update-mail-and-index)
       (define-key map (kbd "C-c C-u") 'mu4e-update-mail-and-index)
       (define-key map (kbd "C-c C-k") 'mu4e-message-kill-buffer)
+      (define-key map (kbd "M-q")     'mu4e-fill-paragraph)
       map)))
+
+(defun mu4e-fill-paragraph (&optional region)
+  "If `use-hard-newlines', takes a multi-line paragraph and makes
+it into a single line of text.  Assume paragraphs are separated
+by blank lines.  If `use-hard-newlines' is not enabled, this
+simply executes `fill-paragraph'."
+  ;; Inspired by https://www.emacswiki.org/emacs/UnfillParagraph
+  (interactive (progn (barf-if-buffer-read-only) '(t)))
+  (if use-hard-newlines
+      (let ((fill-column (point-max))
+	    (use-hard-newlines nil)); rfill "across" hard newlines
+	(fill-paragraph nil region))
+    (fill-paragraph nil region)))
 
 (define-key-after
   (lookup-key text-mode-map [menu-bar text])

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -3841,15 +3841,23 @@ devices) and here's the RFC with all the details:
 @url{http://www.ietf.org/rfc/rfc2646.txt}.
 
 Since version 0.9.17, @t{mu4e} send emails with @t{format=flowed} by
-default.  The transformation of your message into the proper format is
+setting
+
+@lisp
+(setq mu4e-compose-format-flowed t)
+@end lisp
+
+in your Emacs init file (@file{~/.emacs} or @file{~/.emacs.d/init.el}).
+The transformation of your message into the proper format is
 done at the time of sending.  In order to happen properly, you should
 write each paragraph of your message of as a long line (i.e. without
 carriage return).  If you introduce unwanted newlines in your paragraph,
 use @kbd{M-q} to reformat it as a single line.
 
-If you want to send the message with long lines but without
-@t{format=flowed} (because, say, the receiver does not understand it as
-it is the case for Google or Github), use @kbd{M-x use-hard-newlines} or
+If you want to send the message with paragraphs on single lines but
+without @t{format=flowed} (because, say, the receiver does not
+understand the latter as it is the case for Google or Github), use
+@kbd{M-x use-hard-newlines} (to turn @code{use-hard-newlines} off) or
 uncheck the box @t{format=flowed} in the @t{Text} menu when composing a
 message.
 

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -3840,21 +3840,19 @@ don't have it, your mails mostly look quite bad especially on mobile
 devices) and here's the RFC with all the details:
 @url{http://www.ietf.org/rfc/rfc2646.txt}.
 
-To add this to outgoing mu4e emails, activate @t{use-hard-newlines} and
-use only @t{M-q} or @t{fill-paragraph} for your paragraphs, Emacs
-indicates intra-paragraph breaks with soft newlines and inter-paragraph
-breaks with hard newlines. When the Gnus code sees these on outgoing
-emails, it automatically sets @t{format=flowed}.
+Since version 0.9.17, @t{mu4e} send emails with @t{format=flowed} by
+default.  The transformation of your message into the proper format is
+done at the time of sending.  In order to happen properly, you should
+write each paragraph of your message of as a long line (i.e. without
+carriage return).  If you introduce unwanted newlines in your paragraph,
+use @kbd{M-q} to reformat it as a single line.
 
-To enable this, you can use something like this in your init.el:
+If you want to send the message with long lines but without
+@t{format=flowed} (because, say, the receiver does not understand it as
+it is the case for Google or Github), use @kbd{M-x use-hard-newlines} or
+uncheck the box @t{format=flowed} in the @t{Text} menu when composing a
+message.
 
-@lisp
-;; tip submitted by mu4e user cpbotha
-(add-hook 'mu4e-compose-mode-hook
-          (defun cpb-compose-setup ()
-            "Outgoing mails get format=flowed."
-            (use-hard-newlines t 'guess)))
-@end lisp
 @end enumerate
 
 @node Known issues


### PR DESCRIPTION
The default is expressed by the variable `mu4e-compose-format-flowed`, so it is easy to change.  However, given the variety of devices people use to read mails, I've considered that a format that respect that is better (however some important services — gmail, github — do not understand format=flowed so maybe we want the "long lines" mode to be the default).