### PR TITLE
Improve behavior of mu4e-action-show-thread

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -299,13 +299,17 @@ store your org-contacts."
 
 (defun mu4e-action-show-thread (msg)
   "Show all messages that are in the same thread as the message
-at point."
+at point.  Point remains on the message with the message-id where
+the action was invoked.  If invoked in view-mode, continue to
+display the message."
   (let ((msgid (mu4e-message-field msg :message-id)))
     (when msgid
       (let ((mu4e-headers-show-threads t)
 	     (mu4e-headers-include-related t))
         (mu4e-headers-search
-         (format "msgid:%s" msgid))))))
+         (format "msgid:%s" msgid)
+         nil nil nil
+         msgid (eq major-mode 'mu4e-view-mode))))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 


### PR DESCRIPTION
This patch improves the behavior of mu4e-action-show-thread.  This
action now leaves the point on the message where the action was invoked,
which helps prevent losing ones' place in a long thread.  When invoked
in view mode, it continues to display the message that was being viewed,
instead of returning to a header-only view.