### PR TITLE
[FIX] references header dropped bug

### DIFF
--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -141,8 +141,8 @@ References. If both are empty, return nil."
     ;; remove some refs when there are too many
     (when (> refnum mu4e~max-reference-num)
       (let ((surplus (- refnum mu4e~max-reference-num)))
-	(mu4e~shorten-1 refs cut surplus))
-    (mapconcat (lambda (id) (format "<%s>" id)) refs " "))))
+	(mu4e~shorten-1 refs cut surplus)))
+    (mapconcat (lambda (id) (format "<%s>" id)) refs " ")))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Hi Dirk,

I was wondering why threading in `mu` suddenly stopped working sporadically since about 2 weeks ago… so after some bisecting, here it the fix. Basically, the “References” header have been erroneously dropped for all messages composed with less than `mu4e~max-reference-num` number of reference.

I guess there are really [too many parenthesis](https://xkcd.com/297/) in lisp :p

Arthur
