### PR TITLE
Handle mbsync output in mu4e-update buffer

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -895,7 +895,11 @@ Also scrolls to the final line, and update the progress throbber."
       ;; Insert at end of buffer. Leave point alone.
       (with-current-buffer (process-buffer proc)
         (goto-char (point-max))
-        (insert msg))
+        (if (string-match ".*\r\\(.*\\)" msg)
+            (progn
+              (kill-line 0)
+              (insert (match-string 1 msg)))
+          (insert msg)))
       ;; Auto-scroll unless user is interacting with the window.
       (when (and (window-live-p procwin)
 	      (not (eq (selected-window) procwin)))


### PR DESCRIPTION
The mbsync command uses carriage return characters to go to the beginning of the line.  This change does the same for the mu4e-update buffer.  See also #827.