### PR TITLE
mu4e-proc: Add a hook before we call start-command in mu4e~proc-start

### DIFF
--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -50,6 +50,9 @@ a length cookie:
   (concat mu4e~cookie-pre "\\([[:xdigit:]]+\\)" mu4e~cookie-post)
   "Regular expression matching the length cookie.
 Match 1 will be the length (in hex).")
+(defvar mu4e~proc-start-hook nil
+  "Hook run just before `mu4e~proc-start' calls `start-process'
+our 'mu server' process.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defsubst mu4e~proc-send-command (frm &rest args)
@@ -70,6 +73,7 @@ Start the process if needed."
 	  (args (append args (when mu4e-mu-home
 			       (list (concat "--muhome=" mu4e-mu-home))))))
     (setq mu4e~proc-buf "")
+    (run-hooks 'mu4e~proc-start-hook)
     (setq mu4e~proc-process (apply 'start-process
 			      mu4e~proc-name mu4e~proc-name
 			      mu4e-mu-binary args))


### PR DESCRIPTION
I'm using this to "killall mu" before I start mu again, see
<CACBZZX6ntW2uF5MPr-LaPM5HMiQzTgbUHyu6njJ1iX0pT+mGfA@mail.gmail.com> (The
dreaded "Waiting for message..." message and what to do about it")
message on the mu mailing list for more details.

The hook I'm using is:

  (add-hook
   'mu4e~proc-start-hook ; (setq mu4e~proc-start-hook nil)
   '(lambda ()
      (message "Now running the 'killall mu' hook!")
      (shell-command "killall mu")
      (sleep-for 0 250)))

Coupled with:

  (setq mu4e-update-interval nil)

And this monitoring script:

  https://github.com/avar/dotemacs/blob/master/scripts/mu-monitor.pl

While running these two concurrently in a screen session:

    while sleep 1; do time sudo perl ~/g/dotemacs/scripts/mu-monitor.pl; done
    while sleep 30; do time mu index --maildir=~/Maildir/work --max-msg-size=500000000; done