### PR TITLE
Fix kill ring clobbering by get mail filter

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -897,7 +897,10 @@ Also scrolls to the final line, and update the progress throbber."
         (goto-char (point-max))
         (if (string-match ".*\r\\(.*\\)" msg)
             (progn
-              (kill-line 0)
+              (end-of-line)
+              (let ((end (point)))
+                (beginning-of-line)
+                (delete-region (point) end))
               (insert (match-string 1 msg)))
           (insert msg)))
       ;; Auto-scroll unless user is interacting with the window.


### PR DESCRIPTION
The kill ring fills up with lines like:

  C: 0/1  B: 28/29  M: +0/0 *0/0 #0/0  S: +2/2 *1/1 #0/0

when using mbsync or another tool using carriage return for progress.