### PR TITLE
Fix a regression in pull request #831

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -93,7 +93,7 @@ return the filename."
                 (if (plist-get attachment :temp)
                     (replace-match (format "src=\"%s\"" (plist-get attachment :temp)))
                   (replace-match (format "src=\"%s%s\"" temporary-file-directory (plist-get attachment :name)))
-                  (mu4e~proc-extract 'save (mu4e-message-field :docid) (plist-get attachment :index) mu4e-decryption-policy temporary-file-directory)
+                  (mu4e~proc-extract 'save (mu4e-message-field msg :docid) (plist-get attachment :index) mu4e-decryption-policy temporary-file-directory)
                   (mu4e-remove-file-later (format "%s%s" temporary-file-directory (plist-get attachment :name))))))
             attachments)
       (save-buffer)


### PR DESCRIPTION
The mu4e-message-field function was called in a way that would never
work, fix that by calling it correctly.

There's the additional follow-up TODO here that the mu4e-message-field
function itself should probably die on this sort of invocation, but I
don't know enough about elisp idioms to know how that should look.

This fixes my issue #894.