### PR TITLE
mu4e: use builtin function "shr-render-region" for simplicity

### DIFF
--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -36,7 +36,7 @@
 
 (defcustom mu4e-html2text-command
   (if (fboundp 'shr-insert-document) 'mu4e-shr2text 'html2text)
-  
+
   "Either a shell command or a function that converts from html to plain text.
 
 If it is a shell-command, the command reads html from standard
@@ -268,7 +268,7 @@ point in eiter the headers buffer or the view buffer."
 `mu4e-html2text-command' in a new enough emacs. Based on code by
 Titus von der Malsburg."
   (interactive)
-  (let ((dom (libxml-parse-html-region (point-min) (point-max)))
+  (let (
 	 ;; When HTML emails contain references to remote images,
 	 ;; retrieving these images leaks information. For example,
 	 ;; the sender can see when I openend the email and from which
@@ -277,8 +277,7 @@ Titus von der Malsburg."
 	 ;; See this discussion on mu-discuss:
 	 ;; https://groups.google.com/forum/#!topic/mu-discuss/gr1cwNNZnXo
 	 (shr-inhibit-images t))
-    (erase-buffer)
-    (shr-insert-document dom)
+    (shr-render-region (point-min) (point-max))
     (goto-char (point-min))))
 
 (provide 'mu4e-message)


### PR DESCRIPTION
Hi,

Emacs already has the function ``shr-render-region`` which requires Emacs been built with ``libxml2`` option.  This built-in function also reports better error message if the ``libxml2`` option was disabled.

Also some minor space fixes.

Please note, for unknown reason, Github does **NOT** show my changes correctly.   Please ``diff`` by yourself.  Thanks!

Cheers,
Aly