### PR TITLE
Add a face for displaying the context in the mode-line

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -149,7 +149,7 @@ Also see `mu4e-context-policy'."
 We have the following choices:
 
 - `sign': sign the reply
-- `sign-and-encrypt': sign and encrypt the repy
+- `sign-and-encrypt': sign and encrypt the reply
 - `encrypt': encrypt the reply, but don't sign it.
 -  anything else: do nothing."
   :type '(choice

--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -47,7 +47,7 @@ describing mu4e's contexts.")
   (if (mu4e-context-current)
     (concat "[" (propertize (mu4e~quote-for-modeline
 			      (mu4e-context-name (mu4e-context-current)))
-		  'face 'mu4e-title-face) "]") ""))
+		  'face 'mu4e-context-face) "]") ""))
 
 (defstruct mu4e-context
   "A mu4e context object with the following members:

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -583,6 +583,11 @@ I.e. a message with the draft flag set."
   "Face for a header title in the headers view."
   :group 'mu4e-faces)
 
+(defface mu4e-context-face
+  '((t :inherit mu4e-title-face :bold t))
+  "Face for displaying the context in the modeline."
+  :group 'mu4e-faces)
+
 (defface mu4e-modeline-face
   '((t :inherit font-lock-string-face :bold t))
   "Face for the query in the mode-line."


### PR DESCRIPTION
When the background is dark, the mode-line background may not be.  That means that the default color chosen to display the context (`mu4e-title-face`) may not be the best one (and may not be easily customizable because it is tied to the way titles are displayed on dark background).  This PR adds a new color for the context (initialized with the old face so nothing changes by default).

![emacs1](https://cloud.githubusercontent.com/assets/1255665/17606769/90f46ef2-6021-11e6-8a16-5748a68f83cf.png)