### PR TITLE
Compare email addresses case insensitively

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -85,9 +85,12 @@ NODEFAULT, hour and minute fields will be nil if not given."
 
 (defun mu4e-user-mail-address-p (addr)
   "If ADDR is one of user's e-mail addresses return t, nil otherwise.
-User's addresses are set in `mu4e-user-mail-address-list')."
+User's addresses are set in `mu4e-user-mail-address-list'.  Case
+insensitive comparison is used."
   (when (and addr mu4e-user-mail-address-list
-	  (find addr mu4e-user-mail-address-list :test 'string=))
+	  (find addr mu4e-user-mail-address-list
+		:test (lambda (s1 s2)
+			(eq t (compare-strings s1 nil nil s2 nil nil t)))))
     t))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -155,8 +155,11 @@ the attachment dir. See Info node `(mu4e) Attachments' for details."
 (defcustom mu4e-user-mail-address-list `(,user-mail-address)
   "List of e-mail addresses to consider 'my email addresses'.
 I.e. addresses whose presence in an email imply that it is a
-personal message. Note that e-mail addresses are case-sensitive,
-as per RFC531."
+personal message. Note that the local part (the part before '@')
+of e-mail addresses is case-sensitive, as per RFC531.  In
+practice however, most of the mail systems do not distinguish
+addresses based on the case, so the emails in this list will be
+matched case-insensitively."
   :type '(repeat (string :tag "Address"))
   :group 'mu4e)
 


### PR DESCRIPTION
The local part of email addresses is supposed to be case sensitive according to the standard but this is typically not respected (for good reasons).  The domain part, on the other hand, should be matched case insensitively.

This PR takes the stand that the whole address should be matched case insensitively because this is the common practice.