### PR TITLE
mu4e: add mu4e-msg-changed-hook

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -629,6 +629,12 @@ This can be used as a simple way to invoke some action when new
 messages appear, but note that an update in the index does not
 necessarily mean a new message.")
 
+(defvar mu4e-msg-changed-hook nil
+  "Hook run when there is a message changed in db. For new
+messages, it depends on `mu4e-index-updated-hook'. This can be
+used as a simple way to invoke some action when a message
+changed.")
+
 ;; some handler functions for server messages
 ;;
 (defun mu4e-info-handler (info)


### PR DESCRIPTION
This PR is to add a hook that will be ran when users update and delete a message and `mu4e-index-updated-hook` invoked.

I'm using https://github.com/agpchil/mu4e-maildirs-extension to show maildirs summary and it currently uses `mu4e-index-updated-hook` to detect there is a change in db. It is not reliable for this use case. E.g. if I read/delete couple of messages in headers view and go back to main view, it doesn't know there are some changes that need to recalculate the summary.

