### PR TITLE
For the upcoming org-mode version 9 org-add-link-type is obsolete, so…

### DIFF
--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -120,6 +120,14 @@ Example usage:
 (org-add-link-type "mu4e" 'org-mu4e-open)
 (add-hook 'org-store-link-functions 'org-mu4e-store-link)
 
+;; org-add-link-type is obsolete as of org-mode 9.
+;; Instead we will use the org-link-set-parameters method
+(if (fboundp 'org-link-set-parameters)
+    (org-link-set-parameters "mu4e"
+			     :follow #'org-mu4e-open
+			     :store #'org-mu4e-store-link))
+
+
 (defun org-mu4e-open (path)
   "Open the mu4e message (for paths starting with 'msgid:') or run
 the query (for paths starting with 'query:')."


### PR DESCRIPTION
… if org-link-set-parameters is bound we will use that instead.