### PR TITLE
Org mu4e compose stabilization

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,7 +130,7 @@ AC_SUBST(GLIB_LIBS)
 glib_version="`$PKG_CONFIG --modversion glib-2.0`"
 
 # gmime, some late-2012 version
-PKG_CHECK_MODULES(GMIME,gmime-2.6 >= 2.6.12)
+PKG_CHECK_MODULES(GMIME,gmime-2.6 >= 2.6.7)
 AC_SUBST(GMIME_CFLAGS)
 AC_SUBST(GMIME_LIBS)
 gmime_version="`$PKG_CONFIG --modversion gmime-2.6`"

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -780,7 +780,10 @@ draft message."
 
   ;; add any other headers specified
   (when other-headers
-    (message-add-header other-headers))
+    (dolist (h other-headers other-headers)
+      (if (symbolp (car h)) (setcar h (symbol-name (car h))))
+      (message-add-header (concat (capitalize (car h)) ": " (cdr h) "\n"  ))
+      ))
 
   ;; yank message
   (if (bufferp yank-action)

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -184,6 +184,20 @@ place to do that."
   :type 'hook
   :group 'mu4e-compose)
 
+
+(defcustom mu4e-compose-post-hook nil
+  "Hook run *after* message composition buffer is set up.
+If the compose-type is either 'reply' or 'forward', the variable
+`mu4e-compose-parent-message' points to the message replied to /
+being forwarded / edited, and `mu4e-compose-type' contains the
+type of message to be composed.
+
+Use this as a replacement for `mu4e-compose-mode-hook' when you need
+ to avoid recursive loops e.g. with `org-mu4e-compose-org-mode'."
+  :type 'hook
+  :group 'mu4e-compose)
+
+
 (defvar mu4e-compose-type nil
   "The compose-type for this buffer, which is a symbol, `new',
   `forward', `reply' or `edit'.")
@@ -581,7 +595,11 @@ tempfile)."
   (mu4e~compose-hide-headers)
   ;; switch on the mode
   (mu4e-compose-mode)
-
+  ;; run mu4e-compose-post-hook -- having this here
+  ;; allows org-mu4e-compose-org-mode and any
+  ;; eventual replacement to run once on buffer creation
+  ;; but not every time mode gets switched
+  (run-hooks 'mu4e-compose-post-hook)
   ;; set mu4e-compose-type once more for this buffer,
   ;; we loose it after the mode-change, it seems
   (set (make-local-variable 'mu4e-compose-type) compose-type)

--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -318,9 +318,9 @@ body using org-mode."
 	  "org-mu4e-compose-org-mode enabled; "
 	  "press M-m before issuing message-mode commands")))
     (progn ;; otherwise, remove crap
+      (mu4e-compose-mode)
       (remove-hook 'post-command-hook 'org~mu4e-mime-switch-headers-or-body t)
       (org~mu4e-mime-undecorate-headers) ;; shut off org-mode stuff
-      (mu4e-compose-mode)
       (message "org-mu4e-compose-org-mode disabled"))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Hi Dirk-Jan,

Two small patches which I think fix some of the stability issuesi n org-mu4e-compose-org-mode.  With these patches, I can now add a hook to compose in html by default. I know this is not best practice, but I think there are many use cases for it, and while it would be better to fix org-mu4e-compose-org-mode entirely, this may help a fair number of people.  