### PR TITLE
logical error of choose text or html part of mail fixed

### DIFF
--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -180,10 +180,11 @@ unless PREFER-HTML is non-nil."
 	      ;; html part, it should't be used
 	      ;; This is an heuristic to guard against 'This messages requires
 	     ;; html' text bodies.
-	      ((or (and (> txtlen 0)
-			(> (length html) txtlimit))
-		   (not prefer-html))
-		txt)
+	     ((or (= (length html) 0)
+		  (and (> txtlen 0)
+		       (> (length html) txtlimit))
+		  (not prefer-html))
+	      txt)
 	      ;; otherwise, it there some html?
 	      (html
 		(with-temp-buffer

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -179,9 +179,10 @@ unless PREFER-HTML is non-nil."
 	      ;; mu4e-view-html-plaintext-ratio-heuristic times shorter than the
 	      ;; html part, it should't be used
 	      ;; This is an heuristic to guard against 'This messages requires
-	      ;; html' text bodies.
-	      ((and (> txtlen 0)
-		 (or (> txtlimit (length html)) (not prefer-html)))
+	     ;; html' text bodies.
+	      ((or (and (> txtlen 0)
+			(> (length html) txtlimit))
+		   (not prefer-html))
 		txt)
 	      ;; otherwise, it there some html?
 	      (html


### PR DESCRIPTION
The logic to decide whether text or html part of email will be used is wrong so that text part will always be choosed, even if html is forced to be used(using `h` in message view).