### PR TITLE
mu4e: smarter initialization of mu4e-msg2pdf

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -49,7 +49,11 @@ Works for headers view and message-view."
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defvar mu4e-msg2pdf (concat mu4e-builddir "/toys/msg2pdf/msg2pdf")
+(defvar mu4e-msg2pdf
+  (let ((exec (locate-file "msg2pdf" exec-path exec-suffixes)))
+    (if exec
+        exec
+      (concat mu4e-builddir "/toys/msg2pdf/msg2pdf")))
   "Path to the msg2pdf toy.")
 
 (defun mu4e-action-view-as-pdf (msg)


### PR DESCRIPTION
Before this commit the initialization of the mu4e-msg2pdf variable
assumed that the build directory was available. However, that's not the
case when installing mu from a distro package (in my case from OBS).

With this change, mu4e will look for the `msg2pdf` binary on the
`exec-path` first. If the binary exists, then this will be the initial
value. If the binary doesn't exist, then we fallback to the
`mu4e-builddir` approach.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>