### PR TITLE
force use of strings for other-header in mu4e~compose-mail

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -762,7 +762,10 @@ draft message."
 
   ;; add any other headers specified
   (when other-headers
-    (message-add-header other-headers))
+    (dolist (h other-headers other-headers)
+      (if (symbolp (car h)) (setcar h (symbol-name (car h))))
+      (message-add-header (concat (capitalize (car h)) ": " (cdr h) "\n"  ))
+      ))
 
   ;; yank message
   (if (bufferp yank-action)


### PR DESCRIPTION
org-mime and potentially other users of `compose-mail' pass a parameter
`other-headers', an alist of the form ((symbol . string)).
`mu4e~compose-mail' sends this parameter to message-add-header, which
appears to expect a string instead.  We therefore loop through
other-headers and instead pass a string to message-add-header for each
element of other-headers.