### PR TITLE
mu: swap begin and end if begin is _numerically_ bigger than end

### DIFF
--- a/lib/mu-query.cc
+++ b/lib/mu-query.cc
@@ -115,12 +115,12 @@ public:
 		if (!substitute_size (begin) || !substitute_size (end))
 			return Xapian::BAD_VALUENO;
 
+		begin = Xapian::sortable_serialise (atol(begin.c_str()));
+		end = Xapian::sortable_serialise (atol(end.c_str()));
+                
 		/* swap if b > e */
 		if (begin > end)
 			std::swap (begin, end);
-
-		begin = Xapian::sortable_serialise (atol(begin.c_str()));
-		end = Xapian::sortable_serialise (atol(end.c_str()));
 
 		return (Xapian::valueno)MU_MSG_FIELD_ID_SIZE;
 	}

--- a/mu/tests/test-mu-query.c
+++ b/mu/tests/test-mu-query.c
@@ -507,6 +507,7 @@ test_mu_query_sizes (void)
 	int i;
 	QResults queries[] = {
 		{ "size:0b..2m", 19},
+		{ "size:3b..2m", 19},
 		{ "size:2k..4k", 4},
 		{ "size:2m..0b", 19}
 	};


### PR DESCRIPTION
The old behaviour would compare the strings, so would swap the start and end ranges if start was 3K and end was 2M.

Fixes: #964