### PR TITLE
mu4e: add mu4e-msg-changed-hook to mu4e-index-updated-hook globally

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -912,7 +912,7 @@ user-interaction ongoing."
 
   ;; maybe update the current headers upon indexing changes
   (add-hook 'mu4e-index-updated-hook 'mu4e~headers-do-auto-update nil t)
-  (add-hook 'mu4e-index-updated-hook (lambda () (run-hooks 'mu4e-msg-changed-hook)) t t)
+  (add-hook 'mu4e-index-updated-hook (lambda () (run-hooks 'mu4e-msg-changed-hook)) t)
   (setq
     truncate-lines t
     buffer-undo-list t ;; don't record undo information


### PR DESCRIPTION
`mu4e-msg-changed-hook` should add to `mu4e-index-updated-hook` globally instead of header mode only. Otherwise, it causes issue like https://github.com/agpchil/mu4e-maildirs-extension/issues/34