### PR TITLE
POC: Respect format=flowed and delsp=yes for viewing plain-text messages

### DIFF
--- a/lib/mu-msg.h
+++ b/lib/mu-msg.h
@@ -167,6 +167,19 @@ const char*     mu_msg_get_body_text       (MuMsg *msg, MuMsgOptions opts);
 
 
 /**
+ * get the content type parameters for the text body part
+ *
+ * @param msg a valid MuMsg* instance
+ * @param opts options for getting the body
+ *
+ * @return the value of the requested body part content type parameter, or
+ * NULL in case of error or if there is no such body. the returned string
+ * should *not* be modified or freed. The returned data is in UTF8 or NULL.
+ */
+const GSList*	mu_msg_get_body_text_content_type_parameters	(MuMsg *self, MuMsgOptions opts);
+
+
+/**
  * get the html body of this message
  *
  * @param msg a valid MuMsg* instance

--- a/lib/tests/test-mu-msg.c
+++ b/lib/tests/test-mu-msg.c
@@ -184,6 +184,7 @@ static void
 test_mu_msg_03 (void)
 {
 	MuMsg *msg;
+	GSList *params;
 
 	msg = get_msg (MU_TESTMAILDIR4 "/1283599333.1840_11.cthulhu!2,");
 	g_assert_cmpstr (mu_msg_get_to(msg),
@@ -199,6 +200,14 @@ test_mu_msg_03 (void)
 	g_assert_cmpstr (mu_msg_get_body_text(msg, MU_MSG_OPTION_NONE),
 			 ==,
 			 "\nLet's write some fünkÿ text\nusing umlauts.\n\nFoo.\n");
+
+	params = mu_msg_get_body_text_content_type_parameters(msg, MU_MSG_OPTION_NONE);
+	g_assert_cmpuint (g_slist_length ((GSList*)params), ==, 2);
+
+	g_assert_cmpstr ((char*)params->data,==, "charset");
+	params = g_slist_next(params);
+	g_assert_cmpstr ((char*)params->data,==,"UTF-8");
+
 	g_assert_cmpuint (mu_msg_get_flags(msg),
 			  ==, MU_FLAG_UNREAD); /* not seen => unread */
 


### PR DESCRIPTION
This is my initial attempt at addressing #808, supporting `format=flowed` (and `delsp=yes`) when viewing mail.

While this does rewrap some test messages I've tried nicely, I wouldn't recommend merging it in its current form:

- ~There are almost certainly may be memory leaks here.~ Update: may not be true any more, after the last few commits on this branch.
- ~I also encountered a situation where some mails didn't load.~ Update: I was able to track down why, and plugged that particular hole. It's running fine for me now.
- I suspect we would also want a toggle to say whether to honour reflow, much as we do for sending.

I fear this approach is too simplistic because of the way mu accumulates plain-text bodies. This approach could produce very nasty results if some plain-text bodies are marked `format=flowed` and others are not, but then everything is format-flowed. This body accumulation happens in C, but I don't relish the idea of re-implementing `flow-fill.el` in C so we can choose to reflow individual body chunks while accumulating. I feel a better solution would be to delay the accumulation and, instead of providing separate html and text strings in mu-msg-sexp.c, just provide an array of bodies, each with their own content type, and handle the accumulation in emacs-lisp.

