### PR TITLE
mu4e: Add possibility to forward messages as attachments

### DIFF
--- a/mu4e/TODO
+++ b/mu4e/TODO
@@ -11,7 +11,6 @@
 *** message statistics
 *** include exchange handling / org integration
 *** integrate bbdb
-*** forward-as-attachment
 *** identity support
 
 

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -190,20 +190,25 @@ place to do that."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
+(defun mu4e-compose-attach-message (msg)
+  "Insert message MSG as an attachment."
+  (let ((path (plist-get msg :path)))
+    (unless (file-exists-p path)
+      (mu4e-warn "Message file not found"))
+    (mml-attach-file
+      path
+      "message/rfc822"
+      (or (plist-get msg :subject) "No subject")
+      "attachment")))
+
 (defun mu4e-compose-attach-captured-message ()
   "Insert the last captured message file as an attachment.
 Messages are captured with `mu4e-action-capture-message'."
   (interactive)
   (unless mu4e-captured-message
     (mu4e-warn "No message has been captured"))
-  (let ((path (plist-get mu4e-captured-message :path)))
-    (unless (file-exists-p path)
-      (mu4e-warn "Captured message file not found"))
-    (mml-attach-file
-      path
-      "message/rfc822"
-      (or (plist-get mu4e-captured-message :subject) "No subject")
-      "attachment")))
+  (mu4e-compose-attach-message mu4e-captured-message))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
@@ -526,7 +531,7 @@ COMPOSE-TYPE is `new', ORIGINAL-MSG should be nil.
 Optionally (when forwarding, replying) ORIGINAL-MSG is the original
 message we will forward / reply to.
 
-Optionally (when forwarding) INCLUDES contains a list of
+Optionally (when inline forwarding) INCLUDES contains a list of
    (:file-name <filename> :mime-type <mime-type> :disposition <disposition>)
 for the attachements to include; file-name refers to
 a file which our backend has conveniently saved for us (as a
@@ -557,13 +562,16 @@ tempfile)."
   (mu4e~draft-insert-mail-header-separator)
   ;; maybe encrypt/sign replies
   (mu4e~compose-crypto-reply original-msg compose-type)
-  ;; include files -- e.g. when forwarding a message with attachments,
-  ;; we take those from the original.
+  ;; include files -- e.g. when inline forwarding a message with
+  ;; attachments, we take those from the original.
   (save-excursion
     (goto-char (point-max)) ;; put attachments at the end
-    (dolist (att includes)
-      (mml-attach-file
-	(plist-get att :file-name) (plist-get att :mime-type))))
+
+    (if (and (eq compose-type 'forward) mu4e-compose-forward-as-attachment)
+	(mu4e-compose-attach-message original-msg)
+      (dolist (att includes)
+	(mml-attach-file
+	 (plist-get att :file-name) (plist-get att :mime-type)))))
   ;; buffer is not user-modified yet
   (mu4e~compose-set-friendly-buffer-name compose-type)
   (set-buffer-modified-p nil)

--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -402,8 +402,10 @@ fields will be the same as in the original."
 	    ""
 	    mu4e~draft-forward-prefix)
 	  subject))
-      "\n\n"
-      (mu4e~draft-cite-original origmsg))))
+      (unless mu4e-compose-forward-as-attachment
+        (concat
+         "\n\n"
+          (mu4e~draft-cite-original origmsg))))))
 
 (defun mu4e~draft-newmsg-construct ()
   "Create a new message."

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -393,6 +393,10 @@ the From: address.)"
   :type 'string
   :group 'mu4e-compose)
 
+(defcustom mu4e-compose-forward-as-attachment nil
+  "Whether to forward messages as attachments instead of inline."
+  :type 'boolean
+  :group 'mu4e-compose)
 
 ;; backward compatibility
 (make-obsolete-variable 'mu4e-reply-to-address 'mu4e-compose-reply-to-address

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -3824,7 +3824,7 @@ see @ref{(emacs) Mail Aliases}.
 @item @emph{How can I automatically add some header to an outgoing message?}
 Once more, see @ref{Compose hooks}.
 @item @emph{How can I influence the way the original message looks when
-replying or forwarding?} Since @code{mu4e-compose-mode} derives from
+replying or inline forwarding?} Since @code{mu4e-compose-mode} derives from
 @code{message-mode}, you can re-use many of its facilities.
 @inforef{Insertion Variables,,message}.
 @item @emph{How can I easily include attachments in the messages I write?}


### PR DESCRIPTION
This commit adds a global variable `mu4e-compose-forward-as-attachment`. To enable choosing forwarding method on a per-message basis would probably require either:

* changing the mu server backend so that it distinguishes between inline forwarding and forwarding as attachment;
* changing the mu server backend so that it doesn’t return attachments at all and making both inline and as attachment forwarding via MIME (and also making mu4e actually display MIME-enclosed inline emails).