### PR TITLE
Add support for specifying --muhome via MU_HOME in the environment

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -16,6 +16,9 @@
    - prefer gpg2 for crypto
    - fix a crash when running on OpenBSD
    - fix --clear-links (broken filenames)
+   - You can now set the MU_HOME environment variable as an
+     alternative way of setting the mu homedir via the --muhome
+     commadn-line parameter.
     
 *** mu4e
 

--- a/lib/mu-util.c
+++ b/lib/mu-util.c
@@ -199,9 +199,16 @@ gchar*
 mu_util_guess_mu_homedir (void)
 {
 	const char* home;
+	const gchar *hdir1;
 
-	/* g_get_home_dir use /etc/passwd, not $HOME; this is better,
-	 * as HOME may be wrong when using 'sudo' etc.*/
+	/* first, try MU_HOME */
+	hdir1 = g_getenv ("MU_HOME");
+
+	if (hdir1 && mu_util_check_dir (hdir1, TRUE, FALSE))
+		return g_strdup (hdir1);
+
+	/* then, g_get_home_dir use /etc/passwd, not $HOME; this is
+	 * better, as HOME may be wrong when using 'sudo' etc.*/
 	home = g_get_home_dir ();
 
 	if (!home) {

--- a/lib/mu-util.h
+++ b/lib/mu-util.h
@@ -62,7 +62,8 @@ char* mu_util_guess_maildir (void)
 
 
 /**
- * guess the place of the mu homedir (typically, ~/.mu). Note, this
+ * guess the place of the mu homedir; first try $MU_HOME; if it is
+ * unset or non-existant, try ~/.mu. Note, the fallback ~/.mu
  * directory does not necessarily exist. mu_util_check_dir can be used
  * to check that
  *

--- a/man/mu.1
+++ b/man/mu.1
@@ -152,7 +152,9 @@ including \fBmu\fR without any command.
 .TP
 \fB\-\-muhome\fR
 causes \fBmu\fR to use an alternative directory to
-store and read its database and logs. By default, \fI~/.mu\fR is used.
+store and read its database and logs. By default, \fBmu\fR uses
+whatever the \fBMU_HOME\fR environment variable is set to; if it is
+not set, \fI~/.mu\fR is used.
 
 .TP
 \fB\-d\fR, \fB\-\-debug\fR

--- a/man/mug.1
+++ b/man/mug.1
@@ -23,7 +23,9 @@ toolbar.
 
 .TP
 \fB\-\-muhome\fR causes \fBmug\fR to use an alternative directory to read its
-database and bookmarks and write its logs. By default, \fI~/.mu\fR is used.
+database and bookmarks and write its logs. By default, \fBmug\fR uses
+whatever the \fBMU_HOME\fR environment variable is set to; if it is
+not set, \fI~/.mu\fR is used.
 
 .SH BUGS
 Please report bugs if you find them:


### PR DESCRIPTION
When you have multiple mu home directories, e.g. for the use case
detailed in my "Changing mu4e-{maildir,mu-home} from a context hook"
post to the mailing list it's quite inconvenient to have to hammer out
"mu --muhome=.. find .." every time you want to run some ad-hoc
command.

This allows me to set up a screen session where I do searches in mu
directory A in some screen panes, and searches in directory B in
others.

I initially called this MU_MUHOME but then I noticed that the perl
plugin has MUP_MU_HOME for analogous functionality, so I'm just
following its example.

The code I'm adding in mu-util.c is just a copy/paste & adjustment of
the same sort of already tested functionality in
mu_util_guess_maildir() just a few lines earlier.