### PR TITLE
perl: Add a .gitignore file with the MYMETA build assets

### DIFF
--- a/perl/.gitignore
+++ b/perl/.gitignore
@@ -1,0 +1,2 @@
+/MYMETA.json
+/MYMETA.yml


### PR DESCRIPTION
These get created by ExtUtils::MakeMaker, so they won't be found by
grepping our own code, but they're created by the build process.