### PR TITLE
Allow to ignore addresses when doing wide replies

### DIFF
--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -387,6 +387,18 @@ are needed for sorting the contacts."
   :type 'string
   :group 'mu4e-compose)
 
+(defcustom mu4e-compose-reply-ignore-address message-dont-reply-to-names
+  "Addresses to prune when doing wide replies.
+
+This can be a regexp matching the address, a list of regexps
+or a predicate function. A value of nil keeps all the addresses."
+  :type '(choice
+	   (const nil)
+	   function
+	   string
+	   (repeat string))
+  :group 'mu4e-compose)
+
 (defcustom mu4e-compose-reply-to-address nil
   "The Reply-To address (if this, for some reason, is not equal to
 the From: address.)"


### PR DESCRIPTION
Introduce a new variable, mu4e-compose-reply-ignore-address, which matches addresses to be skipped when doing wide replies.

This is identical in behavior to messages-dont-reply-to-names from message.el (which we default on). See RFE #915.

In fact, since it supports the same values, I would be tempted to ``defalias`` instead of ``defcustom``, or use ``message-dont-reply-to-names`` directly. But I'm flexible here. An alternative would be to default to mu4e-compose-complete-ignore-address-regexp.

This finally fixes the ability to perform wide replies with noreply addresses. For instance, when replying to github issues with a "\\bnoreply\\n" regexp, mu4e will not even prompt for a wide reply anymore, since all Cc: addresses get removed (as they should).

Feedback appreciated.