### PR TITLE
Do not duplicate headers views in iconified/hidden frames

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1101,7 +1101,7 @@ the query history stack."
 		       (mu4e-context-label)))))
     ;; when the buffer is already visible, select it; otherwise,
     ;; switch to it.
-    (unless (get-buffer-window buf 'visible)
+    (unless (get-buffer-window buf 0)
       (switch-to-buffer buf))
     (run-hook-with-args 'mu4e-headers-search-hook expr)
     (mu4e~proc-find


### PR DESCRIPTION
When the frame running mu4e is in another virtual desktop or iconified, but
still contains a visible headers buffer, do not attempt to create a new view.