### PR TITLE
mu4e: fix sending emails with no body

### DIFF
--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -302,10 +302,15 @@ separator is never written to the message file. Also see
       ;; search for the first empty line
       (goto-char (point-min))
       (if (search-forward-regexp "^$" nil t)
-	  (replace-match sepa)
-	  (progn ;; no empty line? then prepend one
-	    (goto-char (point-max))
-	    (insert "\n" sepa))))))
+          (progn
+            (replace-match sepa)
+            ;; `message-narrow-to-headers` searches for a `mail-header-separator` followed by a new
+            ;; line. Therefore, we must insert a newline if on the last line of the buffer.
+            (when (= (point) (point-max))
+              (insert "\n")))
+          (progn ;; no empty line? then prepend one
+            (goto-char (point-max))
+            (insert "\n" sepa))))))
 
 (defun mu4e~draft-remove-mail-header-separator ()
   "Remove `mail-header-separator; we do this before saving a


### PR DESCRIPTION
When trying to send an email with no body, `message-narrow-to-headers` can't find the `mail-header-separator` because it isn't followed by a newline. In that case, the narrowed region falls back to everything until `(point-max)`, which includes the `"--text follows this line--"` string. In turn, when the `message-send-mail` function populates the required headers, these are added *after* the  `"--text follows this line--"` string. 

Example output:

```
User-agent: mu4e 0.9.16; emacs 24.5.1
From: foo@foo.net
To: bar@bar.net
Subject: baz EOM
--text follows this line--Fcc: /path/to/foo
Date: Sat, 11 Mar 2017 22:27:11 -0800
Message-ID: <878tobau2o.fsf@foo.net>
```