### PR TITLE
s/defsubst/defun/ for all but the most trivial cases

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -393,7 +393,7 @@ If SKIP-HOOK is not nil, `mu4e-message-changed-hook' will be invoked."
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defsubst mu4e~headers-contact-str (contacts)
+(defun mu4e~headers-contact-str (contacts)
   "Turn the list of contacts CONTACTS (with elements (NAME . EMAIL)
 into a string."
   (mapconcat
@@ -402,7 +402,7 @@ into a string."
 	(or name email "?"))) contacts ", "))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defsubst mu4e~headers-thread-prefix (thread)
+(defun mu4e~headers-thread-prefix (thread)
   "Calculate the thread prefix based on thread info THREAD."
   (when thread
     (let ((get-prefix
@@ -423,7 +423,7 @@ into a string."
 	    (funcall get-prefix mu4e-headers-default-prefix)))
 	" "))))
 
-(defsubst mu4e~headers-flags-str (flags)
+(defun mu4e~headers-flags-str (flags)
   "Get a display string for the flags.
 Note that `mu4e-flags-to-string' is for internal use only; this
 function is for display. (This difference is significant, since
@@ -457,7 +457,7 @@ while our display may be different)."
 It's a cons cell with the car element being the From: prefix, the
 cdr element the To: prefix.")
 
-(defsubst mu4e~headers-from-or-to (msg)
+(defun mu4e~headers-from-or-to (msg)
   "When the from address for message MSG is one of the the user's addresses,
 \(as per `mu4e-user-mail-address-list'), show the To address;
 otherwise ; show the from address; prefixed with the appropriate
@@ -469,7 +469,7 @@ otherwise ; show the from address; prefixed with the appropriate
       (concat (car mu4e-headers-from-or-to-prefix)
 	(mu4e~headers-contact-str (mu4e-message-field msg :from))))))
 
-(defsubst mu4e~headers-human-date (msg)
+(defun mu4e~headers-human-date (msg)
   "Show a 'human' date.
 If the date is today, show the time, otherwise, show the
 date. The formats used for date and time are
@@ -486,7 +486,7 @@ date. The formats used for date and time are
 	  (format-time-string mu4e-headers-time-format date)
 	  (format-time-string mu4e-headers-date-format date))))))
 
-(defsubst mu4e~headers-thread-subject (msg)
+(defun mu4e~headers-thread-subject (msg)
   "Get the subject if it is the first one in a thread; otherwise,
 return the thread-prefix without the subject-text. In other words,
 show the subject of a thread only once, similar to e.g. 'mutt'."
@@ -499,7 +499,7 @@ show the subject of a thread only once, similar to e.g. 'mutt'."
 	(truncate-string-to-width subj 600) ""))))
 
 
-(defsubst mu4e~headers-mailing-list (list)
+(defun mu4e~headers-mailing-list (list)
   "Get some identifier for the mailing list."
   (if list
     (propertize (mu4e-get-mailing-list-shortname list) 'help-echo list)
@@ -581,7 +581,7 @@ found."
       (add-face-text-property 0 (length line) face t line))
     line))
 
-(defsubst mu4e~headers-line-handler (msg line)
+(defun mu4e~headers-line-handler (msg line)
   (dolist (func mu4e~headers-line-handler-functions)
     (setq line (funcall func msg line)))
   line)
@@ -962,14 +962,14 @@ adding a lot of new headers looks really choppy."
 ;;;; is used for quickly finding a certain header, the latter for retrieving the
 ;;;; docid at point without string matching etc.
 
-(defsubst mu4e~headers-docid-cookie (docid)
+(defun mu4e~headers-docid-cookie (docid)
   "Create an invisible string containing DOCID; this is to be used
 at the beginning of lines to identify headers."
   (propertize (format "%s%d%s"
 		mu4e~headers-docid-pre docid mu4e~headers-docid-post)
     'docid docid 'invisible t));;
 
-(defsubst mu4e~headers-docid-at-point (&optional point)
+(defun mu4e~headers-docid-at-point (&optional point)
   "Get the docid for the header at POINT, or at current (point) if
 nil. Returns the docid, or nil if there is none."
     (save-excursion
@@ -995,7 +995,7 @@ of the beginning of the line."
     newpoint)) ;; return the point, or nil if not found
 
 
-(defsubst mu4e~headers-docid-pos (docid)
+(defun mu4e~headers-docid-pos (docid)
   "Return the pos of the beginning of the line with the header with
 docid DOCID, or nil if it cannot be found."
   (let ((pos))
@@ -1003,7 +1003,7 @@ docid DOCID, or nil if it cannot be found."
       (setq pos (mu4e~headers-goto-docid docid)))
     pos))
 
-(defsubst mu4e~headers-field-for-docid (docid field)
+(defun mu4e~headers-field-for-docid (docid field)
   "Get FIELD (a symbol, see `mu4e-headers-names') for the message
 with DOCID which must be present in the headers buffer."
   (save-excursion
@@ -1043,7 +1043,7 @@ message plist, or nil if not found."
       (goto-char oldpoint))))
 
 
-(defsubst mu4e~headers-add-header (str docid point &optional msg)
+(defun mu4e~headers-add-header (str docid point &optional msg)
   "Add header STR with DOCID to the buffer at POINT if non-nil, or
 at (point-max) otherwise. If MSG is not nil, add it as the
 text-property `msg'."

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -128,7 +128,7 @@ Some notes on the format:
     (plist-get msg field)
     (mu4e-error "message must be non-nil")))
 
-(defsubst mu4e-message-field (msg field)
+(defun mu4e-message-field (msg field)
   "Retrieve FIELD from message plist MSG.
 Like `mu4e-message-field-nil', but will sanitize `nil' values:
 - all string field except body-txt/body-html: nil -> \"\"
@@ -152,7 +152,7 @@ Thus, function will return nil for empty lists, non-existing body-txt or body-ht
   "Return t if MSG contains FIELD, nil otherwise."
   (plist-member msg field))
 
-(defsubst mu4e-message-at-point (&optional noerror)
+(defun mu4e-message-at-point (&optional noerror)
   "Get the message s-expression for the message at point in either
 the headers buffer or the view buffer, or nil if there is no such
 message. If optional NOERROR is non-nil, do not raise an error when

--- a/mu4e/mu4e-proc-mu.el
+++ b/mu4e/mu4e-proc-mu.el
@@ -109,7 +109,7 @@ Start the process if needed."
       (t
 	(error "Something bad happened to the mu server process")))))
 
-(defsubst mu4e~docid-msgid-param (docid-or-msgid)
+(defun mu4e~docid-msgid-param (docid-or-msgid)
   "Construct a backend parameter based on DOCID-OR-MSGID."
   (format
     (if (stringp docid-or-msgid)

--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -59,7 +59,7 @@ Match 1 will be the length (in hex).")
 	    '(run open listen connect stop)))
     t))
 
-(defsubst mu4e~proc-eat-sexp-from-buf ()
+(defun mu4e~proc-eat-sexp-from-buf ()
   "'Eat' the next s-expression from `mu4e~proc-buf'.
 Note: this is a string, not an emacs-buffer. `mu4e~proc-buf gets
 its contents from the mu-servers in the following form:

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -712,7 +712,7 @@ process."
       (t (format "\"%s\"" ph)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defsubst mu4e~process-contact (contact)
+(defun mu4e~process-contact (contact)
   "Process CONTACT, and either return nil when it should not be included,
 or (rfc822-string . CONTACT) otherwise."
   (when mu4e-contact-rewrite-function


### PR DESCRIPTION
Change various 'defsubst' to 'defun' for all cases except things where
the entire body of the function is something trivial like `(plist-get
msgpart field)`.

I want this because I'd like to override mu4e\~headers-contact-str in
my .emacs to e.g. format E-Mail addresses without names like
foo.bar@example.com as "Foo Bar" in the headers view, but
mu4e\~headers-contact-str itself is defsubst, so overriding it doesn't
help, and then it's used in /another/ defsubst'd function,
mu4e\~headers-from-or-to, which in turn is used by the defun'd
mu4e\~headers-field-apply-basic-properties.

So both need to be s/defsubst/defun/'d so you can override them.

More generally, when I asked about this on #emacs on Freenode one
advice was "I have my doubts inlining pays off there" [...] "the
biggest wins are for OO-like access which you'd like to hide behind a
function" [...] "as calling the function takes more time than
accessing a slot, you use defsubst to avoid that".

So I'm leaving the OO-like access as defsubst'd, but I very much doubt
that we're getting anything performance-wise out of having 10-20 line
functions be defsubst'd.