### PR TITLE
Added new mu4e-split-view mode: single-window

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -105,7 +105,7 @@
    Klaus Holst, Lukas Fürmetz, Magnus Therning, Maximilian Matthe,
    Nicolas Richard, Piotr Trojanek, Prashant Sachdeva, Remco van 't
    Veer, Stephen Eglen, Stig Brautaset, Thierry Volpiatto, Thomas
-   Moulia, Titus von der Malsburg, Yuri D'Elia
+   Moulia, Titus von der Malsburg, Yuri D'Elia, Vladimir Sedach
 
 * Old news
   :PROPERTIES:

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -624,10 +624,10 @@ tempfile)."
 (defun mu4e~switch-back-to-mu4e-buffer ()
   "Try to go back to some previous buffer, in the order view->headers->main."
   (unless (eq mu4e-split-view 'single-window)
-    (if (buffer-live-p mu4e~view-buffer)
-	(switch-to-buffer mu4e~view-buffer)
-      (if (buffer-live-p mu4e~headers-buffer)
-	  (switch-to-buffer mu4e~headers-buffer)
+    (if (buffer-live-p (mu4e-get-view-buffer))
+	(switch-to-buffer (mu4e-get-view-buffer))
+      (if (buffer-live-p (mu4e-get-headers-buffer))
+	  (switch-to-buffer (mu4e-get-headers-buffer))
 	;; if all else fails, back to the main view
 	(when (fboundp 'mu4e) (mu4e))))))
 
@@ -734,7 +734,7 @@ is a symbol, one of `reply', `forward', `edit', `resend'
 	;; window. The 10-or-so line headers buffer is not a good place to write
 	;; it...
 	(unless (eq mu4e-split-view 'single-window)
-	  (let ((viewwin (get-buffer-window mu4e~view-buffer)))
+	  (let ((viewwin (get-buffer-window (mu4e-get-view-buffer))))
 	    (when (window-live-p viewwin)
 	      (select-window viewwin))))
 	;; talk to the backend

--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -115,7 +115,8 @@ non-nil."
 		  (set (car cell) (cdr cell)))
 	  (mu4e-context-vars context)))
       (setq mu4e~context-current context)
-      (mu4e~main-view-real nil nil)
+      (unless (eq mu4e-split-view 'single-window)
+        (mu4e~main-view-real nil nil))
       (mu4e-message "Switched context to %s" (mu4e-context-name context)))
     context))
 

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -351,7 +351,7 @@ headers."
 
 	  ;; first, remove the old one (otherwise, we'd have two headers with
 	  ;; the same docid...
-	  (mu4e~headers-remove-handler docid t)
+          (mu4e~headers-remove-header docid t)
 
 	  ;; if we're actually viewing this message (in mu4e-view mode), we
 	  ;; update it; that way, the flags can be updated, as well as the path
@@ -374,7 +374,7 @@ headers."
 	    (mu4e~headers-highlight docid))
 	  (run-hooks 'mu4e-message-changed-hook))))))
 
-(defun mu4e~headers-remove-handler (docid &optional skip-hook)
+(defun mu4e~headers-remove-handler (docid)
   "Remove handler, will be called when a message with DOCID has
 been removed from the database. This function will hide the removed
 message from the current list of headers. If the message is not
@@ -382,17 +382,15 @@ present, don't do anything.
 
 If SKIP-HOOK is not nil, `mu4e-message-changed-hook' will be invoked."
   (when (buffer-live-p (mu4e-get-headers-buffer))
-    (with-current-buffer (mu4e-get-headers-buffer)
-      (mu4e~headers-remove-header docid t)
-      ;; if we were viewing this message, close it now.
-      (when (and (mu4e~headers-view-this-message-p docid)
-		 (buffer-live-p (mu4e-get-view-buffer)))
-        (unless (eq mu4e-split-view 'single-window)
-          (mapc #'delete-window (get-buffer-window-list
-                                 (mu4e-get-view-buffer))))
-        (kill-buffer (mu4e-get-view-buffer)))
-      (unless skip-hook
-	(run-hooks 'mu4e-message-changed-hook)))))
+    (mu4e~headers-remove-header docid t))
+  ;; if we were viewing this message, close it now.
+  (when (and (mu4e~headers-view-this-message-p docid)
+             (buffer-live-p (mu4e-get-view-buffer)))
+    (unless (eq mu4e-split-view 'single-window)
+      (mapc #'delete-window (get-buffer-window-list
+                             (mu4e-get-view-buffer))))
+    (kill-buffer (mu4e-get-view-buffer)))
+  (run-hooks 'mu4e-message-changed-hook))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -198,8 +198,8 @@ clicked."
 (defun mu4e~main-view ()
   "Create the mu4e main-view, and switch to it."
   (if (eq mu4e-split-view 'single-window)
-      (if (buffer-live-p mu4e~headers-buffer)
-          (switch-to-buffer mu4e~headers-buffer)
+      (if (buffer-live-p (mu4e-get-headers-buffer))
+          (switch-to-buffer (mu4e-get-headers-buffer))
         (mu4e~main-menu))
     (mu4e~main-view-real nil nil)
     (switch-to-buffer mu4e~main-buffer-name)

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -197,9 +197,13 @@ clicked."
 
 (defun mu4e~main-view ()
   "Create the mu4e main-view, and switch to it."
-  (mu4e~main-view-real nil nil)
-  (switch-to-buffer mu4e~main-buffer-name)
-  (goto-char (point-min))
+  (if (eq mu4e-split-view 'single-window)
+      (if (buffer-live-p mu4e~headers-buffer)
+          (switch-to-buffer mu4e~headers-buffer)
+        (mu4e~main-menu))
+    (mu4e~main-view-real nil nil)
+    (switch-to-buffer mu4e~main-buffer-name)
+    (goto-char (point-min)))
   (add-to-list 'global-mode-string '(:eval (mu4e-context-label))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -209,16 +213,37 @@ clicked."
 (defun mu4e~main-toggle-mail-sending-mode ()
   "Toggle sending mail mode, either queued or direct."
   (interactive)
-  (let ((curpos (point)))
-    (unless (file-directory-p smtpmail-queue-dir)
-      (mu4e-error "`smtpmail-queue-dir' does not exist"))
-    (setq smtpmail-queue-mail (not smtpmail-queue-mail))
-    (message
-     (concat "Outgoing mail will now be "
-	     (if smtpmail-queue-mail "queued" "sent directly")))
-    (mu4e~main-view-real nil nil)
-    (goto-char curpos)))
+  (unless (file-directory-p smtpmail-queue-dir)
+    (mu4e-error "`smtpmail-queue-dir' does not exist"))
+  (setq smtpmail-queue-mail (not smtpmail-queue-mail))
+  (message (concat "Outgoing mail will now be "
+                   (if smtpmail-queue-mail "queued" "sent directly")))
+  (unless (eq mu4e-split-view 'single-window)
+    (let ((curpos (point)))
+      (mu4e~main-view-real nil nil)
+      (goto-char curpos))))
 
+(defun mu4e~main-menu ()
+  "mu4e main view in the minibuffer."
+  (interactive)
+  (let ((mu4e-hide-index-messages t))
+    (call-interactively
+     (lookup-key
+      mu4e-main-mode-map
+      (string
+       (read-key
+        (mu4e-format
+         "%s"
+         (concat
+          (mu4e~main-action-str "[j]ump " 'mu4e-jump-to-maildir)
+          (mu4e~main-action-str "[s]earch " 'mu4e-search)
+          (mu4e~main-action-str "[C]ompose " 'mu4e-compose-new)
+          (mu4e~main-action-str "[b]ookmarks " 'mu4e-headers-search-bookmark)
+          (mu4e~main-action-str "[;]Switch context " 'mu4e-context-switch)
+          (mu4e~main-action-str "[U]pdate " 'mu4e-update-mail-and-index)
+          (mu4e~main-action-str "[N]ews " 'mu4e-news)
+          (mu4e~main-action-str "[A]bout " 'mu4e-about)
+          (mu4e~main-action-str "[H]elp " 'mu4e-display-manual)))))))))
 
 ;; (progn
 ;;   (define-key mu4e-compose-mode-map (kbd "C-c m") 'mu4e~main-toggle-mail-sending-mode)

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -108,10 +108,10 @@ is either a headers or view buffer."
   `(cond
      ((eq major-mode 'mu4e-headers-mode) ,@body)
      ((eq major-mode 'mu4e-view-mode)
-       (when (buffer-live-p mu4e~view-headers-buffer)
+       (when (buffer-live-p (mu4e-get-headers-buffer))
 	 (let* ((msg (mu4e-message-at-point))
 		 (docid (mu4e-message-field msg :docid)))
-	   (with-current-buffer mu4e~view-headers-buffer
+	   (with-current-buffer (mu4e-get-headers-buffer)
 	     (if (mu4e~headers-goto-docid docid)
 	       ,@body
 	       (mu4e-error "cannot find message in headers buffer."))))))

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -999,24 +999,21 @@ frame to display buffer BUF."
   (when mu4e~progress-reporter
     (progress-reporter-done mu4e~progress-reporter)
     (setq mu4e~progress-reporter nil))
-  (let* ((status (process-status proc))
-	  (code (process-exit-status proc))
-	  (maybe-error (or (not (eq status 'exit)) (/= code 0)))
-	  (buf (and (buffer-live-p mu4e~update-buffer) mu4e~update-buffer))
-	  (win (and buf (get-buffer-window buf))))
-    (unless mu4e-hide-index-messages
-      (message nil))
-    (if maybe-error
+  (unless mu4e-hide-index-messages
+    (message nil))
+  (if (or (not (eq (process-status proc) 'exit))
+          (/= (process-exit-status proc) 0))
       (progn
 	(when mu4e-index-update-error-warning
 	  (mu4e-message "Update process returned with non-zero exit code")
 	  (sit-for 5))
 	(when mu4e-index-update-error-continue
 	  (mu4e-update-index)))
-      (mu4e-update-index))
-    (if (window-live-p win)
-      (with-selected-window win (kill-buffer-and-window))
-      (when (buffer-live-p buf) (kill-buffer buf)))))
+    (mu4e-update-index))
+  (when (buffer-live-p mu4e~update-buffer)
+    (unless (eq mu4e-split-view 'single-window)
+      (mapc #'delete-window (get-buffer-window-list mu4e~update-buffer)))
+    (kill-buffer mu4e~update-buffer)))
 
 ;; complicated function, as it:
 ;;   - needs to check for errors
@@ -1216,16 +1213,17 @@ and MAXHEIGHT are ignored."
   "Bury mu4e-buffers (main, headers, view) (and delete all windows
 displaying it). Do _not_ bury the current buffer, though."
   (interactive)
-  (let ((curbuf (current-buffer)))
-    ;; note: 'walk-windows' does not seem to work correctly when modifying
-    ;; windows; therefore, the doloops here
-    (dolist (frame (frame-list))
-      (dolist (win (window-list frame nil))
-	(with-current-buffer (window-buffer win)
-	  (unless (eq curbuf (current-buffer))
-	    (when (member major-mode '(mu4e-headers-mode mu4e-view-mode))
-	      (when (eq t (window-deletable-p win))
-		(delete-window win))))))) t))
+  (unless (eq mu4e-split-view 'single-window)
+    (let ((curbuf (current-buffer)))
+      ;; note: 'walk-windows' does not seem to work correctly when modifying
+      ;; windows; therefore, the doloops here
+      (dolist (frame (frame-list))
+        (dolist (win (window-list frame nil))
+          (with-current-buffer (window-buffer win)
+            (unless (eq curbuf (current-buffer))
+              (when (member major-mode '(mu4e-headers-mode mu4e-view-mode))
+                (when (eq t (window-deletable-p win))
+                  (delete-window win))))))) t)))
 
 
 (defun mu4e-get-time-date (prompt)

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -563,9 +563,15 @@ Or go to the top level if there is none."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun mu4e-last-query ()
   "Get the most recent query or nil if there is none."
-  (when (buffer-live-p mu4e~headers-buffer)
-    (with-current-buffer  mu4e~headers-buffer
+  (when (buffer-live-p (mu4e-get-headers-buffer))
+    (with-current-buffer  (mu4e-get-headers-buffer)
       mu4e~headers-last-query)))
+
+(defun mu4e-get-view-buffer ()
+  (get-buffer mu4e~view-buffer-name))
+
+(defun mu4e-get-headers-buffer ()
+  (get-buffer mu4e~headers-buffer-name))
 
 (defun mu4e-select-other-view ()
   "When the headers view is selected, select the message view (if
@@ -574,9 +580,9 @@ that has a live window), and vice versa."
   (let* ((other-buf
 	   (cond
 	     ((eq major-mode 'mu4e-headers-mode)
-	       mu4e~view-buffer)
+	       (mu4e-get-view-buffer))
 	     ((eq major-mode 'mu4e-view-mode)
-	       mu4e~headers-buffer)))
+	       (mu4e-get-headers-buffer))))
 	  (other-win (and other-buf (get-buffer-window other-buf))))
     (if (window-live-p other-win)
       (select-window other-win)
@@ -906,8 +912,8 @@ successful, call FUNC (if non-nil) afterwards."
     (setq mu4e~update-timer nil))
   (mu4e-clear-caches)
   (mu4e~proc-kill)
-  ;; kill all main/view/headers buffer
-  (mapcar
+  ;; kill all mu4e buffers
+  (mapc
     (lambda (buf)
       (with-current-buffer buf
 	(when (member major-mode

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -851,7 +851,7 @@ argument, and returns a string. See the default value of
 ;; headers
 (defconst mu4e~headers-buffer-name "*mu4e-headers*"
   "Name of the buffer for message headers.")
-(defvar mu4e~headers-buffer nil "Buffer for message headers.")
+
 ; view
 (defconst mu4e~view-buffer-name "*mu4e-view*"
   "Name for the message view buffer.")
@@ -859,12 +859,7 @@ argument, and returns a string. See the default value of
 (defconst mu4e~view-embedded-buffer-name " *mu4e-embedded-view*"
   "Name for the embedded message view buffer.")
 
-(defvar mu4e~view-buffer nil "The view buffer.")
-
 (defvar mu4e~view-msg nil "The message being viewed in view mode.")
-
-(defvar mu4e~view-headers-buffer nil
-  "The headers buffer connected to this view.")
 
 (defvar mu4e~contacts nil
   "Hash of that maps contacts (ie. 'name <e-mail>') to an integer

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -229,14 +229,17 @@ KEY) is still recognized as well, for backward-compatibility.")
 (defcustom mu4e-split-view 'horizontal
   "How to show messages / headers.
 A symbol which is either:
- * `horizontal':   split horizontally (headers on top)
- * `vertical':     split vertically (headers on the left).
- * anything else:  don't split (show either headers or messages,
-		  not both)
+ * `horizontal':    split horizontally (headers on top)
+ * `vertical':      split vertically (headers on the left).
+ * `single-window': view and headers in one window (mu4e will try not to
+		    touch your window layout), main view in minibuffer
+ * anything else:   don't split (show either headers or messages,
+		    not both)
 Also see `mu4e-headers-visible-lines'
 and `mu4e-headers-visible-columns'."
   :type '(choice (const :tag "Split horizontally" horizontal)
 		 (const :tag "Split vertically" vertical)
+		 (const :tag "Single window" single-window)
 		 (const :tag "Don't split" nil))
   :group 'mu4e-headers)
 

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -860,6 +860,7 @@ argument, and returns a string. See the default value of
   "Name for the embedded message view buffer.")
 
 (defvar mu4e~view-msg nil "The message being viewed in view mode.")
+(make-variable-buffer-local 'mu4e~view-msg)
 
 (defvar mu4e~contacts nil
   "Hash of that maps contacts (ie. 'name <e-mail>') to an integer

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -938,8 +938,9 @@ this view."
        (unless docid
 	 (mu4e-error "message without docid: action is not possible."))
        (with-current-buffer mu4e~view-headers-buffer
-	 (when (get-buffer-window)
-	   (select-window (get-buffer-window)))
+         (unless (eq mu4e-split-view 'single-window)
+           (when (get-buffer-window)
+             (select-window (get-buffer-window))))
 	 (if (mu4e~headers-goto-docid docid)
 	   ,@body
 	   (mu4e-error "cannot find message in headers buffer."))))))
@@ -969,8 +970,12 @@ message view. If this succeeds, return the new docid. Otherwise,
 return nil."
   (mu4e~view-in-headers-context
     (mu4e~headers-prev-or-next-unread backwards))
-  (mu4e-select-other-view)
-  (mu4e-headers-view-message))
+  (if (eq mu4e-split-view 'single-window)
+      (when (eq (window-buffer) mu4e~view-buffer)
+        (with-current-buffer mu4e~view-headers-buffer
+         (mu4e-headers-view-message)))
+    (mu4e-select-other-view)
+    (mu4e-headers-view-message)))
 
 (defun mu4e-view-headers-prev-unread ()
 "Move point to the previous unread message header in the headers

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -308,7 +308,6 @@ marking if it still had that."
     ;; again by triggering mu4e~view again as it marks the message as read
     (with-current-buffer buf
       (switch-to-buffer buf)
-      (setq mu4e~view-msg msg)
       (when (or embedded (not (mu4e~view-mark-as-read-maybe msg)))
 	(let ((inhibit-read-only t))
 	  (erase-buffer)
@@ -320,7 +319,8 @@ marking if it still had that."
 	  (mu4e~view-make-urls-clickable)
 	  (mu4e~view-show-images-maybe msg)
 	  (when embedded (local-set-key "q" 'kill-buffer-and-window))
-	  (mu4e-view-mode))))))
+	  (mu4e-view-mode)
+          (setq mu4e~view-msg msg))))))
 
 (defun mu4e~view-get-property-from-event (prop)
   "Get the property PROP at point, or the location of the mouse.
@@ -800,7 +800,6 @@ FUNC should be a function taking two arguments:
 \\{mu4e-view-mode-map}."
   (use-local-map mu4e-view-mode-map)
 
-  (make-local-variable 'mu4e~view-msg)
   (make-local-variable 'mu4e~view-link-map)
   (make-local-variable 'mu4e~view-attach-map)
   (make-local-variable 'mu4e~view-cited-hidden)

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -1060,6 +1060,11 @@ shown (default: 8).
 @item @t{vertical}: display the message view on the
 right side of the header view. Use @code{mu4e-headers-visible-columns} to set
 the number of visible columns (default: 30).
+@item @t{single-window}: single window mode. Single-window mode tries to
+minimize mu4e window operations (opening, killing, resizing, etc) and buffer
+changes, while still retaining the view and headers buffers. In addition, it
+replaces mu4e main view with a minibuffer prompt containing the same
+information.
 @item anything else: don't do any splitting
 @end itemize
 


### PR DESCRIPTION
Single-window mode is meant to minimize mu4e window operations (opening,
killing, resizing, etc) and buffer changes, while still retaining the
view and headers buffers. In addition, it replaces mu4e main view with a
minibuffer prompt containing the same information.

Eventually I would like to do a single buffer mode that can toggle between view and header mode. Single-buffer mode will make it convenient to have multiple mu4e search sessions going on at the same time. Doing a single buffer mode will entail changing mu4e to keep track of messages in a data structure instead of implicitly in the headers buffer, which is a major refactor. This will have the additional benefit of making it possible to write integrations for tools like helm and ivy for browsing the message list and selecting messages; essentially letting people use whatever tool they want instead of the headers buffer. My planned approach is to first provide the message list via imenu, as the package imenu-anywhere integrates helm, ivy, and a few others, which would give mu4e-ivy etc headers integrations "for free." It should also then be possible to integrate mu4e search with helm/ivy flex searching.