### PR TITLE
mu4e: remove `realdelete' option of OfflineIMAP

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -3525,7 +3525,6 @@ remoteuser = USERNAME@gmail.com
 remotepass = PASSWORD
 ssl = yes
 maxconnections = 1
-realdelete = no
 @end verbatim
 
 Obviously, you need to replace @t{USERNAME} and @t{PASSWORD} with your actual


### PR DESCRIPTION
Quotation from the commit log:

> offlineimap/Changelog.md says Gmail `realdelete' option is considered
> harmful and was removed on OfflineIMAP v6.5.2.1 (2012-04-04).

so we should remove it.

See: https://github.com/OfflineIMAP/offlineimap/blob/master/Changelog.md#offlineimap-v6521-2012-04-04