### PR TITLE
mu4e: don't loose search history when editing search

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1387,11 +1387,10 @@ searching. If SHOW is non-nil, show the message with MSGID."
   ;; `mu4e~headers-query-next' or `mu4e~headers-query-prev'."
   (interactive)
   (let* ((prompt (mu4e-format (or prompt "Search for: ")))
-	  (expr
-	    (if edit
-	      (read-string prompt expr)
-	      (or expr
-		(read-string prompt nil 'mu4e~headers-search-hist)))))
+         (expr
+          (read-string prompt
+                       (if edit expr nil)
+                       'mu4e~headers-search-hist)))
     (mu4e-mark-handle-when-leaving)
     (mu4e~headers-search-execute expr ignore-history)
     (setq mu4e~headers-msgid-target msgid


### PR DESCRIPTION
Even though the user may be editing this expression there is no reason
to not have the mu4e~headers-search-hist present for the prompt. Emacs
will only replace it with system wide history which would likely
contain irrelevant history for the action.