### PR TITLE
mu: remove useless assignment in mu-extract

### DIFF
--- a/mu/mu-cmd-extract.c
+++ b/mu/mu-cmd-extract.c
@@ -202,7 +202,6 @@ save_part_if (MuMsg *msg, MuMsgPart *part, SaveData *sd)
 		return;
 
 	rv	 = FALSE;
-	filepath = NULL;
 	err      = NULL;
 
 	msgopts = mu_config_get_msg_options (sd->opts);

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -2759,7 +2759,7 @@ corresponds to the message at point. Something like:
 @end lisp
 
 @noindent
-Messages that operate on attachments receive a @var{msg} parameter, which
+Functions that operate on attachments receive a @var{msg} parameter, which
 corresponds to the message at point, and an @var{attachment-num}, which is the
 number of the attachment as seen in the message view. An attachment function
 looks like:


### PR DESCRIPTION
The `filepath` variable is assigned with `NULL`, but not read until reassigned few lines below.

Detected with [cppcheck](http://cppcheck.sourceforge.net/).