### PR TITLE
Only require html2text if emacs version supports it.

### DIFF
--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -31,7 +31,7 @@
 (require 'mu4e-utils)
 
 (require 'cl)
-(require 'html2text)
+(and (version< emacs-version "26.0") (require 'html2text))
 (require 'flow-fill)
 
 


### PR DESCRIPTION
html2text has been obsoleted in emacs 26.  Only require the file if `emacs-version' < "26.0"