### PR TITLE
Add info on update status in modeline

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1107,7 +1107,13 @@ the query history stack."
 		       (mu4e~quote-for-modeline mu4e~headers-last-query)
 		       'face 'mu4e-modeline-face)
 		      " "
-		       (mu4e-context-label)))))
+                      (mu4e-context-label)
+                      (if (and mu4e-display-update-status-in-modeline
+                               (buffer-live-p mu4e~update-buffer)
+                               (process-live-p (get-buffer-process mu4e~update-buffer)))
+                          (propertize " (updating)" 'face 'mu4e-modeline-face)
+                        "")))))
+
     ;; when the buffer is already visible, select it; otherwise,
     ;; switch to it.
     (unless (get-buffer-window buf 0)

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -501,6 +501,11 @@ be quoted, since mu4e does this automatically for you."
   :type '(repeat (cons (string :tag "Maildir") character))
   :group 'mu4e-folders)
 
+(defcustom mu4e-display-update-status-in-modeline nil
+  "Non-nil value will display the update status in the modeline."
+  :group 'mu4e
+  :type 'boolean)
+
 ;; Faces
 (defgroup mu4e-faces nil
   "Type faces (fonts) used in mu4e."


### PR DESCRIPTION
## Pull purpose
Just add an indicator "(updating)" in the modeline when an update is running. 
It is disabled by default and can be enabled through the custom variable `mu4e-display-update-status-in-modeline`.
![mu4e](https://user-images.githubusercontent.com/6860164/28363800-2e275e7e-6c82-11e7-86fd-94fceb834dcb.png)

## Motivation
I use auto update in the background when displaying the mails of my inbox (to be sure to see the last messages).
It can be annoying to be unable to know when it's done.