### PR TITLE
mu4e: simplify what "e" does in mu4e-view mode

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -1228,14 +1228,7 @@ attachments, but as this is the default, you may not need it."
       (dolist (num attachnums)
 	(mu4e-view-save-attachment-single msg num)))))
 
-(defun mu4e-view-save-attachment (&optional multi)
-  "Offer to save attachment(s).
-If MULTI (prefix-argument) is nil, save a single one, otherwise,
-offer to save a range of attachments."
-  (interactive "P")
-  (if multi
-    (mu4e-view-save-attachment-multi)
-    (mu4e-view-save-attachment-single)))
+(defalias #'mu4e-view-save-attachment #'mu4e-view-save-attachment-multi)
 
 (defun mu4e-view-open-attachment (&optional msg attnum)
   "Open attachment number ATTNUM from MSG.

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -1220,9 +1220,8 @@ C-u f fetches multiple URLs
 k            save the numbered URL in the kill-ring.
 C-u k saves multiple URLs
 
-e            extract (save) attachment (asks for number)
+e            extract (save) one or more attachments (asks for numbers)
 (or: <mouse-2> or S-RET with point on attachment)
-C-u e extracts multiple attachments
 o            open attachment (asks for number)
 (or: <mouse-1> or M-RET with point on attachment)
 


### PR DESCRIPTION
The default was to use e to save one attachment or C-u e to save multiple. This
simplifies it so that e simply offers to save one or many attachments.