### PR TITLE
Ensure mu4e-view-mode-hook run after text insertion

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -306,13 +306,13 @@ the the message view affects HDRSBUF, as does marking etc.
 As a side-effect, a message that is being viewed loses its 'unread'
 marking if it still had that."
   (let* ((embedded ;; is it as an embedded msg (ie. message/rfc822 att)?
-          (when (gethash (mu4e-message-field msg :path)
-                         mu4e~path-parent-docid-map) t))
-         (buf
-          (if embedded
+	   (when (gethash (mu4e-message-field msg :path)
+		   mu4e~path-parent-docid-map) t))
+	  (buf
+	    (if embedded
 	      (mu4e~view-embedded-winbuf)
-            (get-buffer-create mu4e~view-buffer-name)))
-         (insert-it (or embedded (not (mu4e~view-mark-as-read-maybe msg)))))
+	      (get-buffer-create mu4e~view-buffer-name)))
+          (insert-it (or embedded (not (mu4e~view-mark-as-read-maybe msg)))))
     (with-current-buffer buf
       (switch-to-buffer buf)
       ;; When MSG is unread, mu4e~view-mark-as-read-maybe will trigger

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -313,15 +313,12 @@ marking if it still had that."
 	      (mu4e~view-embedded-winbuf)
 	      (get-buffer-create mu4e~view-buffer-name))))
     (with-current-buffer buf
-      (unless (eq major-mode 'mu4e-view-mode)
-	(mu4e-view-mode))
-      (setq mu4e~view-msg msg)
       (switch-to-buffer buf)
       ;; When MSG is unread, mu4e~view-mark-as-read-maybe will trigger
       ;; another call to mu4e-view (via mu4e~headers-update-handler as
       ;; the reply handler to mu4e~proc-move)
-      (when (or embedded (not (mu4e~view-mark-as-read-maybe msg)))
-	(let ((inhibit-read-only t))
+      (let ((inhibit-read-only t))
+        (when (or embedded (not (mu4e~view-mark-as-read-maybe msg)))
 	  (erase-buffer)
 	  (mu4e~delete-all-overlays)
 	  (insert (mu4e-view-message-text msg))
@@ -330,7 +327,10 @@ marking if it still had that."
 	  (mu4e~fontify-signature)
 	  (mu4e~view-make-urls-clickable)
 	  (mu4e~view-show-images-maybe msg)
-	  (when embedded (local-set-key "q" 'kill-buffer-and-window)))))))
+	  (when embedded (local-set-key "q" 'kill-buffer-and-window)))
+        (unless (eq major-mode 'mu4e-view-mode)
+          (mu4e-view-mode))
+        (setq mu4e~view-msg msg)))))
 
 (defun mu4e~view-get-property-from-event (prop)
   "Get the property PROP at point, or the location of the mouse.

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -306,31 +306,32 @@ the the message view affects HDRSBUF, as does marking etc.
 As a side-effect, a message that is being viewed loses its 'unread'
 marking if it still had that."
   (let* ((embedded ;; is it as an embedded msg (ie. message/rfc822 att)?
-	   (when (gethash (mu4e-message-field msg :path)
-		   mu4e~path-parent-docid-map) t))
-	  (buf
-	    (if embedded
+          (when (gethash (mu4e-message-field msg :path)
+                         mu4e~path-parent-docid-map) t))
+         (buf
+          (if embedded
 	      (mu4e~view-embedded-winbuf)
-	      (get-buffer-create mu4e~view-buffer-name))))
+            (get-buffer-create mu4e~view-buffer-name)))
+         (insert-it (or embedded (not (mu4e~view-mark-as-read-maybe msg)))))
     (with-current-buffer buf
       (switch-to-buffer buf)
       ;; When MSG is unread, mu4e~view-mark-as-read-maybe will trigger
       ;; another call to mu4e-view (via mu4e~headers-update-handler as
       ;; the reply handler to mu4e~proc-move)
       (let ((inhibit-read-only t))
-        (when (or embedded (not (mu4e~view-mark-as-read-maybe msg)))
+        (when insert-it
 	  (erase-buffer)
 	  (mu4e~delete-all-overlays)
 	  (insert (mu4e-view-message-text msg))
 	  (goto-char (point-min))
 	  (mu4e~fontify-cited)
 	  (mu4e~fontify-signature)
-	  (mu4e~view-make-urls-clickable)
 	  (mu4e~view-show-images-maybe msg)
 	  (when embedded (local-set-key "q" 'kill-buffer-and-window)))
         (unless (eq major-mode 'mu4e-view-mode)
           (mu4e-view-mode))
-        (setq mu4e~view-msg msg)))))
+        (setq mu4e~view-msg msg)
+        (and insert-it (mu4e~view-make-urls-clickable))))))
 
 (defun mu4e~view-get-property-from-event (prop)
   "Get the property PROP at point, or the location of the mouse.


### PR DESCRIPTION
* mu4e/mu4e-view.el (mu4e-view): Do it.

In `mu4e-view` `mu4e-view-mode` run before any text is inserted, as a result all functions from 
`mu4e-view-mode-hook` modifying text in message have no effect. 

