### PR TITLE
Fix region bounds checking when marking headers in mu4e

### DIFF
--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -324,7 +324,7 @@ headers in the region. Optionally, provide TARGET (for moves)."
     (save-excursion
       (let ((cant-go-further) (eor (region-end)))
 	(goto-char (region-beginning))
-	(while (and (<= (point) eor) (not cant-go-further))
+	(while (and (< (point) eor) (not cant-go-further))
 	  (mu4e-mark-at-point mark target)
 	  (setq cant-go-further (not (mu4e-headers-next))))))))
 


### PR DESCRIPTION
This a pull request to improve the region bounds checking when marking headers so that too many headers are not marked when a region is active.

For example, using evil I visually select the lines for two emails:

![example image](http://drop.bryan.sh/RHDv4MjPY9.png)

At this point, if I were press 'd' to mark these two emails for delete, then the third email from 'NETGEAR' would be marked for deletion as well.

I've tracked this down to the fact that `(region-end)` is not actually included in the region, so while the region only extends to the end of the second line, mu4e actually thinks it extends to the first position on the third line.

You can verify that `(region-end)` is outside the actual region by putting the cursor on the last character in a word, running `(point)`, then selecting that word, running `(region-end)`, and you'll notice that the result will be 1 greater than the point value was.

I've corrected this issue by verifying that the point is `<` (exclusive) the `(region-end)` instead of `<=` (inclusive).

Thanks!