### PR TITLE
shorten modeline str if longer than max-width

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -1299,8 +1299,20 @@ the view and compose modes."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun mu4e~quote-for-modeline (str)
-  "Quote a string to be used literally in the modeline."
-  (replace-regexp-in-string "%" "%%" str t t))
+  "Quote a string to be used literally in the modeline. The
+string will be shortened to fit if its length exceeds
+`mu4e-modeline-max-width'."
+  (let* (;; Adjust the max-width to include the length of the " ..." string
+         (width (let ((w (- mu4e-modeline-max-width 4)))
+                  (if (> w 0) w 0)))
+         (str (let* ((l (length str))
+                     ;; If the input str is longer than the max-width, then will shorten
+                     (w (if (> l width) width l))
+                     ;; If the input str is longer than the max-width, then append " ..."
+                     (a (if (> l width) " ..." "")))
+                (concat (substring str 0 w) a))))
+    ;; Escape the % character
+    (replace-regexp-in-string "%" "%%" str t t)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -180,6 +180,13 @@ threads. You can customize the exact fancy characters used with
   :type 'string
   :group 'mu4e)
 
+(defcustom mu4e-modeline-max-width 30
+  "Determines the maximum length of the string to be used in the
+modeline. If the string exeeds this limit, it will be shortened
+to fit."
+  :type 'integer
+  :group 'mu4e)
+
 (defvar mu4e-debug nil
   "When set to non-nil, log debug information to the *mu4e-log* buffer.")
 


### PR DESCRIPTION
This is a fix to limit the length of the query string displayed in the `spaceline` modeline.

The `spaceline` package displays the query in a segment of the modeline. When this is a long (perhaps bookmarked) query, the modeline either (a) becomes crowded or (b) another problem manifests where the whole spaceline modeline goes blank.

The variable `mu4e-modeline-max-width` is introduced to limit the length and `mu4e~quote-for-modeline` is extended a bit to shorten the query string if needed.