### PR TITLE
mu4e: don’t use msgid as format template

### DIFF
--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -312,11 +312,9 @@ Start the process if needed."
 
 (defsubst mu4e~docid-msgid-param (docid-or-msgid)
   "Construct a backend parameter based on DOCID-OR-MSGID."
-  (format
-    (if (stringp docid-or-msgid)
-      (concat "msgid:"(mu4e~escape (format "%s" docid-or-msgid)))
-      "docid:%d")
-    docid-or-msgid))
+  (if (stringp docid-or-msgid)
+    (concat "msgid:" (mu4e~escape docid-or-msgid))
+    (format "docid:%d" docid-or-msgid)))
 
 (defun mu4e~proc-find (query threads sortfield sortdir maxnum skip-dups
 			include-related)


### PR DESCRIPTION
The Message-Id header may contain percent characters, which we don’t want to
pass on as format specifiers. Instead of escaping these characters too, we can
instead get rid of the call to format when a string has already been supplied.