### PR TITLE
Bump version string to 1.0-alpha3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@
 ## Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 AC_PREREQ([2.68])
-AC_INIT([mu],[1.0-alpha2],[https://github.com/djcb/mu/issues],[mu])
+AC_INIT([mu],[1.0-alpha3],[https://github.com/djcb/mu/issues],[mu])
 AC_COPYRIGHT([Copyright (C) 2008-2017 Dirk-Jan C. Binnema])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_SRCDIR([mu/mu.cc])


### PR DESCRIPTION
The value in configure.ac is out of sync with the git tags.