### PR TITLE
mu4e: ensure sent dir is created with proper maildir structure

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -287,6 +287,12 @@ If needed, set the Fcc header, and register the handler function."
 	(lexical-let ((maildir mdir) (old-handler message-fcc-handler-function))
 	  (lambda (file)
 	    (setq message-fcc-handler-function old-handler) ;; reset the fcc handler
+	    (let ((mdir-path (concat mu4e-maildir maildir)))
+	      ;; Create the full maildir structure for the sent folder if it doesn't exist. `mu4e~proc-mkdir`
+              ;; runs asynchronously but no matter whether it runs before or after `write-file`, the sent
+              ;; maildir ends up in the correct state.
+	      (unless (file-exists-p mdir-path)
+		(mu4e~proc-mkdir mdir-path)))
 	    (write-file file)		       ;; writing maildirs files is easy
 	    (mu4e~proc-add file (or maildir "/")))))))) ;; update the database
 


### PR DESCRIPTION
offlineimap will only sync directories that have 'cur', 'tmp', and
'new' sub-directories. Currently, mu4e can end up in a state where the
sent folder only has the 'cur' directory and is therefore not synced.

Upon saving a sent email, emacs' write-file will prompt to create
parent directories if the sent maildir does not already exist. This
results in the following directory structure:

`<mu4e-maildir>/<sent>/cur/<email>`

Note that the 'tmp' and 'new' directories are missing. This commit
ensures that they are always created.