### PR TITLE
Only require html2text if it will be used

### DIFF
--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -31,12 +31,13 @@
 (require 'mu4e-utils)
 
 (require 'cl)
-(require 'html2text)
 (require 'flow-fill)
 
 
 (defcustom mu4e-html2text-command
-  (if (fboundp 'shr-insert-document) 'mu4e-shr2text 'html2text)
+  (if (fboundp 'shr-insert-document)
+    'mu4e-shr2text
+    (progn (require 'html2text) 'html2text))
 
   "Either a shell command or a function that converts from html to plain text.
 


### PR DESCRIPTION
html2text is deprecated in the emacs pretest, by unconditionally
importing it mu4e causes a mildly irritating yes/no prompt to appear
during startup.

This change ensures that html2text is not loaded unless the emacs
running is a version that does not have 'shr-insert-document