### PR TITLE
Fix display of bugs link in mu4e-about.org

### DIFF
--- a/mu4e/mu4e-about.org
+++ b/mu4e/mu4e-about.org
@@ -6,8 +6,8 @@
 
   *mu4e* and *mu* are free software, licensed under the terms of the [[http://www.gnu.org/licenses/gpl-3.0.html][GNU GPLv3]].
 
-  You can get the code from [[https://github.com/djcb/mu][the git repository]]; there, you can also [[https://github.com/djcb/mu/issues][file bugs
-  and feature requests]].
+  You can get the code from [[https://github.com/djcb/mu][the git repository]]; there, you can also
+  [[https://github.com/djcb/mu/issues][file bugs and feature requests]].
 
   *mu4e* has its own [[info:mu4e][manual]], which includes an [[info:mu4e#FAQ%20-%20Frequently%20Anticipated%20Questions][FAQ]]. If that is not enough,
    there's also the [[http://groups.google.com/group/mu-discuss][mu mailing list]].


### PR DESCRIPTION
It appears that these need to be on the same line for Emacs to render the link correctly.