### PR TITLE
Use automake support for texi to generate version info in the manual

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -278,7 +278,6 @@ lib/parser/Makefile
 lib/tests/Makefile
 mu4e/Makefile
 mu4e/mu4e-meta.el
-mu4e/texi.texi
 guile/Makefile
 guile/texi.texi
 guile/mu/Makefile

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -1,9 +1,9 @@
 \input texinfo.tex    @c -*-texinfo-*-
 @documentencoding UTF-8
-@include texi.texi
+@include version.texi
 @c %**start of header
 @setfilename mu4e.info
-@settitle Mu4e @value{mu-version} user manual
+@settitle Mu4e @value{VERSION} user manual
 
 @c Use proper quote and backtick for code sections in PDF output
 @c Cf. Texinfo manual 14.2
@@ -26,7 +26,7 @@ Documentation License.''
 
 @titlepage
 @title @t{Mu4e} --- an e-mail client for GNU/Emacs
-@subtitle version  @value{mu-version}
+@subtitle version  @value{VERSION}, @value{UPDATED}
 @author Dirk-Jan C. Binnema
 
 @c The following two commands start the copyright page.
@@ -52,7 +52,7 @@ Documentation License.''
 @unnumbered Welcome to mu4e
 @end iftex
 
-Welcome to @t{mu4e} @value{mu-version}.
+Welcome to @t{mu4e} @value{VERSION}.
 
 @t{mu4e} (@t{mu}-for-emacs) is an e-mail client for GNU-Emacs version
 24.4 or higher, built on top of the

--- a/mu4e/texi.texi.in
+++ b/mu4e/texi.texi.in
@@ -1,3 +1,0 @@
-@c the version for mu for including in texinfo docs
-@set mu-version @VERSION@
-


### PR DESCRIPTION
Automake contains some support for automagically adding version information to a texi manual (see
https://www.gnu.org/software/automake/manual/automake.html#Texinfo).

> If the .texi file @includes version.texi, then that file will be automatically generated

This patch gets rid of the texi.texi.in and instead uses the standard method to inject version information in the manual.

This fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=870634