### PR TITLE
updated fontify-signature for RFC 1153 compliant digest messages

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -1289,14 +1289,17 @@ used in the view and compose modes."
 
 (defun mu4e~fontify-signature ()
   "Give the message signatures a distinctive color. This is used in
-the view and compose modes."
+the view and compose modes and will color each signature in digest messages adhearing to RFC 1153."
   (let ((inhibit-read-only t))
     (save-excursion
       ;; give the footer a different color...
       (goto-char (point-min))
-      (let ((p (re-search-forward "^-- *$" nil t)))
-	(when p
-	  (add-text-properties p (point-max) '(face mu4e-footer-face)))))))
+      (while (re-search-forward "^-- *$" nil t)
+        (let ((p (point))
+              (end (or
+                    (re-search-forward "\\(^-\\{30\\}.*$\\)" nil t) ;; 30 by RFC1153
+                    (point-max))))
+              (add-text-properties p end '(face mu4e-footer-face)))))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun mu4e~quote-for-modeline (str)


### PR DESCRIPTION
mu4e~fontify-signature had been coloring the first signature of a digest message and all the subsequent messages after the first signature.  I altered the code so it colors each signature and stops at the RFC 1153 border of 30 (or more) hyphens.

I experimented with another version that stopped coloring if it detected a quoted message, new headers, or another signature, but I think in all these cases the composer of the message has put their signature in front of the old content in error.  Since I can't predict what sorts of things people would want to put in their signature and RFC 3676 doesn't specify any way to signal the end of a signature, I stuck with the RFC 1153 definition.

Respectfully submitted,
-James