### PR TITLE
fix: image not show the first time we view a mail

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -365,7 +365,7 @@ headers."
 	  ;; update it; that way, the flags can be updated, as well as the path
 	  ;; (which is useful for viewing the raw message)
 	  (when (mu4e~headers-view-this-message-p docid)
-	    (mu4e-view msg))
+	    (mu4e-view-msg msg))
 	  ;; now, if this update was about *moving* a message, we don't show it
 	  ;; anymore (of course, we cannot be sure if the message really no
 	  ;; longer matches the query, but this seem a good heuristic.  if it
@@ -1584,20 +1584,12 @@ window. "
   (unless (eq major-mode 'mu4e-headers-mode)
     (mu4e-error "Must be in mu4e-headers-mode (%S)" major-mode))
   (let* ((msg (mu4e-message-at-point))
-	  (docid (or (mu4e-message-field msg :docid)
-		   (mu4e-warn "No message at point")))
-	  ;; decrypt (or not), based on `mu4e-decryption-policy'.
-	  (decrypt
-	    (and (member 'encrypted (mu4e-message-field msg :flags))
-	      (if (eq mu4e-decryption-policy 'ask)
-		(yes-or-no-p (mu4e-format "Decrypt message?"))
-		mu4e-decryption-policy)))
-	  (viewwin (mu4e~headers-redraw-get-view-window)))
+         (viewwin (mu4e~headers-redraw-get-view-window)))
     (unless (window-live-p viewwin)
       (mu4e-error "Cannot get a message view"))
     (select-window viewwin)
     (switch-to-buffer (mu4e~headers-get-loading-buf))
-    (mu4e~proc-view docid mu4e-view-show-images decrypt)))
+    (mu4e-view-msg msg)))
 
 (defun mu4e-headers-rerun-search ()
   "Rerun the search for the last search expression."

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -297,6 +297,17 @@ found."
     (delete-all-overlays)
     (remove-overlays)))
 
+(defun mu4e-view-msg (msg)
+  "Call mu4e~proc-view to trigger a call to mu4e-view with complete msg"
+  (let ((docid (or (mu4e-message-field msg :docid)
+                   (mu4e-warn "No message at point")))
+        ;; decrypt (or not), based on `mu4e-decryption-policy'.
+        (decrypt
+         (and (member 'encrypted (mu4e-message-field msg :flags))
+              (if (eq mu4e-decryption-policy 'ask)
+                  (yes-or-no-p (mu4e-format "Decrypt message?"))
+                mu4e-decryption-policy))))
+    (mu4e~proc-view docid mu4e-view-show-images decrypt)))
 
 (defun mu4e-view (msg)
   "Display the message MSG in a new buffer, and keep in sync with HDRSBUF.


### PR DESCRIPTION
Prepare settings:

       setq mu4e-view-show-images t
       setq mu4e-view-auto-mark-as-read t

We receive a mail with image attachments, when we view it, mu4e will send a `view` command to mu, mu will response a `view` msg with image attachments(:temp not nil), then mu4e send a `move` command to mu for mark as read, mu responsed with a `update` msg without attachments(:temp is nil), mu4e display it with `mu4e-view`, then image lost.