### PR TITLE
Mu4e orphan thread prefix

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -233,38 +233,26 @@ one of: `:date', `:subject', `:size', `:prio', `:from', `:to.',
 
 ;; thread prefix marks
 (defvar mu4e-headers-thread-child-prefix '("├>" . "┣▶ ")
-  "Prefix for messages in sub threads that do have a following sibling.
-
-This variable is only used when mu4e-headers-new-thread-style is non-nil.")
+  "Prefix for messages in sub threads that do have a following sibling.")
 
 (defvar mu4e-headers-thread-last-child-prefix '("└>" . "┗▶ ")
-  "Prefix for messages in sub threads that do not have a following sibling.
-
-This variable is only used when mu4e-headers-new-thread-style is non-nil.")
+  "Prefix for messages in sub threads that do not have a following sibling.")
 
 (defvar mu4e-headers-thread-connection-prefix '("│" . "┃ ")
   "Prefix to connect sibling messages that do not follow each other.
 
-This prefix should have the same length as `mu4e-headers-thread-blank-prefix'.
-
-This variable is only used when mu4e-headers-new-thread-style is non-nil.")
+This prefix should have the same length as `mu4e-headers-thread-blank-prefix'.")
 
 (defvar mu4e-headers-thread-blank-prefix '(" " . "  ")
   "Prefix to separate non connected messages.
 
-This prefix should have the same length as `mu4e-headers-thread-connection-prefix'.
-
-This variable is only used when mu4e-headers-new-thread-style is non-nil.")
+This prefix should have the same length as `mu4e-headers-thread-connection-prefix'.")
 
 (defvar mu4e-headers-thread-orphan-prefix '("" . "")
-  "Prefix for orphan messages.
-
-This variable is only used when mu4e-headers-new-thread-style is non-nil.")
+  "Prefix for orphan messages.")
 
 (defvar mu4e-headers-thread-duplicate-prefix '("=" . "≡ ")
-  "Prefix for duplicate messages.
-
-This variable is only used when mu4e-headers-new-thread-style is non-nil.")
+  "Prefix for duplicate messages.")
 
 (defvar mu4e-headers-actions
   '( ("capture message"  . mu4e-action-capture-message)

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -462,7 +462,7 @@ into a string."
 	  (last-child   (plist-get thread :last-child))
 	  (duplicate    (plist-get thread :duplicate)))
       ;; Do not prefix root messages.
-      (if (or (= level 0) empty-parent)
+      (if (= level 0)
 	  (setq mu4e~headers-thread-state '()))
       (if (> level 0)
 	  (let* ((length (length mu4e~headers-thread-state))


### PR DESCRIPTION
Use special prefixes for orphan threads as suggested by @wavexx. It should look like:

```
Unrelated message
─>Single orphan message
┬>Orphan messsage
├>Second message on orphan thread
└>Last message on orphan thread
```
