### PR TITLE
Fix call to make-obsolete-variable

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -182,7 +182,7 @@ We have the following choices:
  'mu4e-compose-crypto-reply-policy' variable is deprecated.
  'mu4e-compose-crypto-reply-plain-policy' and
  'mu4e-compose-crypto-reply-encrypted-policy' should be used instead")
-(make-obsolete-variable mu4e-compose-crypto-reply-policy "The use of the
+(make-obsolete-variable 'mu4e-compose-crypto-reply-policy "The use of the
  'mu4e-compose-crypto-reply-policy' variable is deprecated.
  'mu4e-compose-crypto-reply-plain-policy' and
  'mu4e-compose-crypto-reply-encrypted-policy' should be used instead"


### PR DESCRIPTION
Missing the quote makes `nil` obsolete instead of `mu4e-compose-crypto-reply-policy`. 