### PR TITLE
Remove mail-header-separator newline on draft save

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -41,8 +41,8 @@
 ;; before-save-hook and after-save-hook to remove/re-add this special line, so
 ;; it stays in the buffer, but never hits the disk.
 ;; see:
-;;     mu4e~compose-insert-mail-header-separator
-;;     mu4e~compose-remove-mail-header-separator
+;;     mu4e~draft-insert-mail-header-separator
+;;     mu4e~draft-remove-mail-header-separator
 ;;
 ;; (maybe we can get away with remove it only just before sending? what does
 ;; gnus do?)

--- a/mu4e/mu4e-tests.el
+++ b/mu4e/mu4e-tests.el
@@ -1,0 +1,31 @@
+(require 'ert)
+
+(ert-deftest mu4e-test-remove-mail-header-separator ()
+  "`mail-header-separator` is removed correctly"
+  (let* ((header "To: mail@example.com")
+         (sep "--example-separator--")
+         (testeq
+          (lambda (orig removed)
+            (with-temp-buffer
+              (insert orig)
+              ;; shadow the separator the mu4e function sees
+              (make-local-variable 'mail-header-separator)
+              (setq mail-header-separator sep)
+              (mu4e~draft-remove-mail-header-separator)
+              (should (equal (buffer-string) removed))))))
+    ;; empty mail equal to header
+    (funcall testeq
+             (concat header "\n" sep)
+             (concat header "\n"))
+    ;; message starts directly
+    (funcall testeq
+             (concat header "\n" sep "\n" "message1")
+             ;; needs one empty line
+             (concat header "\n\n" "message1"))
+    ;; empty line is kept
+    (funcall testeq
+             (concat header "\n" sep "\n\n" "message2")
+             (concat header "\n\n" "message2"))))
+
+
+(provide 'mu4e-tests)


### PR DESCRIPTION
This is my take on #1244.

Somewhere in the middle I noticed that the problem most likely lies within `message-mode` instead, which introduces the separator and removes it as well on `message-send`.

This does solve the problem of #1244, but removes one line of whitespace on each draft save. :roll_eyes: 
So it’s just a temporary fix at best and should probably go into `message-mode`.