### PR TITLE
mu4e: show sender mail addresses by default

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -66,7 +66,7 @@ For the complete list of available headers, see `mu4e-header-info'."
   :group 'mu4e-view)
 
 
-(defcustom mu4e-view-show-addresses nil
+(defcustom mu4e-view-show-addresses t
   "Whether to initially show full e-mail addresses for contacts in
 address fields, rather than only their names."
   :type 'boolean


### PR DESCRIPTION
Hiding email addresses poses a big security risk for the receiver, since
anybody can set the display name however they wish and thus impersonate another
person trivially.

Before this change, `Alice <admin@mallory.com>` would be shown as `Alice` to
Bob, who was expecting Mail from `Alice <alice@gmail.com>`.