### PR TITLE
Use getline() to read server commands rather than a read/append loop

### DIFF
--- a/mu/mu-cmd-server.c
+++ b/mu/mu-cmd-server.c
@@ -189,33 +189,21 @@ static GHashTable*
 read_command_line (GError **err)
 {
 	char		*line;
+	size_t           size;
 	GHashTable	*hash;
-	GString		*gstr;
 
 	line = NULL;
-	gstr = g_string_sized_new (512);
+	size = 0;
 
 	fputs (";; mu> ", stdout);
-
-	do {
-		int kar;
-
-		kar = fgetc (stdin);
-		if (kar == '\n' || kar == EOF)
-			break;
-		else
-			gstr = g_string_append_c (gstr, (char)kar);
-
-	} while (1);
-
-	line = g_string_free (gstr, FALSE);
+	getline (&line, &size, stdin);
 
 	if (!mu_str_is_empty (line))
 		hash = mu_str_parse_arglist (line, err);
 	else
 		hash = NULL;
 
-	g_free (line);
+	free (line);
 
 	return hash;
 }


### PR DESCRIPTION
This uses the now-standard `getline()` to read server commands, rather than the old way which used a loop that called `fgetc()` and `g_string_append_c()` one character at a time. The return value of `getline()` is not checked, but that has the same semantics as the current `fgetc()` loop and terminates under the same conditions.

I can add an autoconf check and pre-processor ifdefs to support hypothetical systems that don't have `getline()`, but that seems like unnecessary complexity given that `getline()`:

 * Has been a de facto part of most libc implementations since I started writing C at least.
 * Was added to POSIX ten years ago (as of POSIX.1-2008).
 * Was included in the C dynamic memory TR from 2010, which isn't technically part of the C standard but is implemented by everyone.