### PR TITLE
Use better warning/hardening compiler flags, and fix some one byte strncpy() overflows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,14 @@ AX_CXX_COMPILE_STDCXX_14
 m4_ifdef([AX_COMPILER_FLAGS],[AX_COMPILER_FLAGS(,,[yes])])
 AX_VALGRIND_CHECK
 
+AX_CHECK_COMPILE_FLAG([-Wall], [AX_APPEND_COMPILE_FLAGS([-Wall], [WARN_CFLAGS])])
+AC_SUBST(WARN_CFLAGS)
+
+AX_CHECK_COMPILE_FLAG([-Wformat-security], [AX_APPEND_COMPILE_FLAGS([-Wformat-security], [HARDEN_CFLAGS])])
+AX_CHECK_COMPILE_FLAG([-Wstack-protector],[AX_APPEND_COMPILE_FLAGS([-Wstack-protector], [HARDEN_CFLAGS])])
+AX_CHECK_COMPILE_FLAG([-Wstack-protector-all],[AX_APPEND_COMPILE_FLAGS([-Wstack-protector-all], [HARDEN_CFLAGS])])
+AC_SUBST(HARDEN_CFLAGS)
+
 # for now, use AM_PROG_LIBTOOL, as we don't want to require
 # a too new setup for autotools/libtool
 AM_PROG_LIBTOOL

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -22,6 +22,7 @@ SUBDIRS= parser . tests
 
 AM_CFLAGS=					\
 	$(WARN_CFLAGS)				\
+	$(HARDEN_CFLAGS)			\
 	$(GMIME_CFLAGS)				\
 	$(GLIB_CFLAGS)				\
 	$(GUILE_CFLAGS)				\

--- a/lib/mu-contacts.c
+++ b/lib/mu-contacts.c
@@ -232,7 +232,7 @@ encode_email_address (const char *addr)
 		return FALSE;
 
 	/* make sure chars are with {' ' .. '~'}, and not '[' ']' */
-	for (cur = strncpy(enc, addr, sizeof(enc)); *cur != '\0'; ++cur)
+	for (cur = strncpy(enc, addr, sizeof(enc) - 1); *cur != '\0'; ++cur)
 		if (!isalnum(*cur)) {
 			*cur = 'A' +  (*cur % ('Z' - 'A'));
 		} else

--- a/lib/mu-date.c
+++ b/lib/mu-date.c
@@ -55,7 +55,7 @@ mu_date_str_s (const char* frm, time_t t)
 			g_error_free (err);
 			strcpy (buf, "<error>");
 		} else
-			strncpy (buf, conv, sizeof(buf));
+			strncpy (buf, conv, sizeof(buf) - 1);
 
 		g_free (conv);
 	}

--- a/lib/parser/Makefile.am
+++ b/lib/parser/Makefile.am
@@ -21,6 +21,8 @@ include $(top_srcdir)/gtest.mk
 AM_CXXFLAGS=			\
 	-I$(srcdir)/..		\
 	-I$(top_srcdir)/lib	\
+	$(WARN_CFLAGS)		\
+	$(HARDEN_CFLAGS)	\
 	$(GLIB_CFLAGS)		\
 	$(XAPIAN_CXXFLAGS)	\
 	$(WARN_CXXFLAGS)	\

--- a/m4/ax_append_compile_flags.m4
+++ b/m4/ax_append_compile_flags.m4
@@ -1,0 +1,67 @@
+# ============================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_append_compile_flags.html
+# ============================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_COMPILE_FLAGS([FLAG1 FLAG2 ...], [FLAGS-VARIABLE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   For every FLAG1, FLAG2 it is checked whether the compiler works with the
+#   flag.  If it does, the flag is added FLAGS-VARIABLE
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  During the check the flag is always added to the
+#   current language's flags.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: This macro depends on the AX_APPEND_FLAG and
+#   AX_CHECK_COMPILE_FLAG. Please keep this macro in sync with
+#   AX_APPEND_LINK_FLAGS.
+#
+# LICENSE
+#
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 6
+
+AC_DEFUN([AX_APPEND_COMPILE_FLAGS],
+[AX_REQUIRE_DEFINED([AX_CHECK_COMPILE_FLAG])
+AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
+for flag in $1; do
+  AX_CHECK_COMPILE_FLAG([$flag], [AX_APPEND_FLAG([$flag], [$2])], [], [$3], [$4])
+done
+])dnl AX_APPEND_COMPILE_FLAGS

--- a/m4/ax_append_flag.m4
+++ b/m4/ax_append_flag.m4
@@ -1,0 +1,71 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_append_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_FLAG(FLAG, [FLAGS-VARIABLE])
+#
+# DESCRIPTION
+#
+#   FLAG is appended to the FLAGS-VARIABLE shell variable, with a space
+#   added in between.
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  FLAGS-VARIABLE is not changed if it already contains
+#   FLAG.  If FLAGS-VARIABLE is unset in the shell, it is set to exactly
+#   FLAG.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 6
+
+AC_DEFUN([AX_APPEND_FLAG],
+[dnl
+AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_SET_IF
+AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[FLAGS])])
+AS_VAR_SET_IF(FLAGS,[
+  AS_CASE([" AS_VAR_GET(FLAGS) "],
+    [*" $1 "*], [AC_RUN_LOG([: FLAGS already contains $1])],
+    [
+     AS_VAR_APPEND(FLAGS,[" $1"])
+     AC_RUN_LOG([: FLAGS="$FLAGS"])
+    ])
+  ],
+  [
+  AS_VAR_SET(FLAGS,[$1])
+  AC_RUN_LOG([: FLAGS="$FLAGS"])
+  ])
+AS_VAR_POPDEF([FLAGS])dnl
+])dnl AX_APPEND_FLAG

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,74 @@
+# ===========================================================================
+#   http://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 4
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/m4/ax_require_defined.m4
+++ b/m4/ax_require_defined.m4
@@ -1,0 +1,37 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_require_defined.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_REQUIRE_DEFINED(MACRO)
+#
+# DESCRIPTION
+#
+#   AX_REQUIRE_DEFINED is a simple helper for making sure other macros have
+#   been defined and thus are available for use.  This avoids random issues
+#   where a macro isn't expanded.  Instead the configure script emits a
+#   non-fatal:
+#
+#     ./configure: line 1673: AX_CFLAGS_WARN_ALL: command not found
+#
+#   It's like AC_REQUIRE except it doesn't expand the required macro.
+#
+#   Here's an example:
+#
+#     AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+AC_DEFUN([AX_REQUIRE_DEFINED], [dnl
+  m4_ifndef([$1], [m4_fatal([macro ]$1[ is not defined; is a m4 file missing?])])
+])dnl AX_REQUIRE_DEFINED

--- a/mu/Makefile.am
+++ b/mu/Makefile.am
@@ -27,6 +27,7 @@ AM_CPPFLAGS=-I${top_srcdir}/lib $(GLIB_CFLAGS)
 # really need all the params they get
 AM_CFLAGS=						\
 	$(WARN_CFLAGS)					\
+	$(HARDEN_CFLAGS)			  	\
 	-Wno-switch-enum				\
 	-DMU_SCRIPTS_DIR="\"$(pkgdatadir)/scripts/\""
 

--- a/mu/mu-cmd-find.c
+++ b/mu/mu-cmd-find.c
@@ -344,7 +344,7 @@ field_string_list (MuMsg *msg, MuMsgFieldId mfid)
 
 	str = mu_str_from_list (lst, ',');
 	if (str) {
-		strncpy (buf, str, sizeof(buf));
+		strncpy (buf, str, sizeof(buf) - 1);
 		g_free (str);
 		return buf;
 	}

--- a/mu/mu-cmd-server.c
+++ b/mu/mu-cmd-server.c
@@ -1406,7 +1406,7 @@ get_path_from_docid (MuStore *store, unsigned docid, GError **err)
 		return NULL;
 	}
 
-	strncpy (path, msgpath, sizeof(path));
+	strncpy (path, msgpath, sizeof(path) - 1);
 
 	mu_msg_unref (msg);
 	return path;

--- a/mu/tests/test-mu-contacts.c
+++ b/mu/tests/test-mu-contacts.c
@@ -81,7 +81,7 @@ contact_new (const char *email, const char *name,
 }
 
 static void
-contact_destroy (Contact *contact)
+contact_destroy (Contact *contact, void *unused)
 {
 	if (contact) {
 		g_free (contact->name);

--- a/toys/mug/Makefile.am
+++ b/toys/mug/Makefile.am
@@ -30,6 +30,7 @@ AM_CPPFLAGS=-I${top_srcdir} -I${top_srcdir}/lib $(GTK_CFLAGS) $(WEBKIT_CFLAGS)	\
 # really need all the params they get
 AM_CFLAGS=									\
 	$(WARN_CFLAGS)								\
+	$(HARDEN_CFLAGS)							\
 	-Wno-redundant-decls							\
 	-Wno-deprecated-declarations						\
 	-Wno-switch-enum


### PR DESCRIPTION
This adds better support in the makefile for `-Wall`. There was some existing `WARN_CFLAGS` logic in the project but it didn't seem like it was working correctly, e.g. there was no `AC_SUBST()` for it. This hooks up that logic. I've also added some additional logic for common hardening options supported by GCC and Clang. I'm using some new AX_ macros that are copied from upstream as is usual. The flags will only be enabled on compilers that actually support these flags.

This also fixes some minor issues with how mu is using `strncpy()`, which was caught by GCC:

```
  CC       mu-contacts.lo
In function ‘encode_email_address’,
    inlined from ‘mu_contacts_add’ at mu-contacts.c:293:10:
mu-contacts.c:235:13: warning: ‘strncpy’ specified bound 255 equals destination size [-Wstringop-truncation]
  for (cur = strncpy(enc, addr, sizeof(enc)); *cur != '\0'; ++cur)
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The issue is that in calls like this, if `strlen(addr) == sizeof(enc)` then after this call `enc` will not be null-terminated, which is normally not expected.

There's also a warning I fixed related to a pedantic function signature mismatch.

With this these changes I can build the project cleanly (without warnings) on GCC 8.1.1