### PR TITLE
ensure mu4e-view-mode hooks run

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -348,8 +348,8 @@ article-mode."
 	  (mu4e~fontify-signature)
 	  (mu4e~view-make-urls-clickable)
 	  (mu4e~view-show-images-maybe msg)
-	  (when embedded (local-set-key "q" 'kill-buffer-and-window))
-          (unless mode-enabled (run-mode-hooks 'mu4e-view-mode-hook)))))
+          (when embedded (local-set-key "q" 'kill-buffer-and-window)))
+        (unless mode-enabled (run-mode-hooks 'mu4e-view-mode-hook))))
     (switch-to-buffer buf)))
 
 (defun mu4e~view-gnus (msg)


### PR DESCRIPTION
This is duplicate of #1265. I made this PR because I wasn't aware at the time of the PR #1265 and I'm not sure if the fix in that PR actually addresses the underlying problem. The problem seems to the nesting of `(run-mode-hooks 'mu4e-view-mode-hook)` inside ` (when (or embedded (not (mu4e~view-mark-as-read-maybe msg)))` and doesn't have anything to do with the condition `mode-enabled`