### PR TITLE
mu4e: fix action to show thread for single-window mode

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -362,7 +362,8 @@ display the message."
 	(mu4e-headers-search
 	  (format "msgid:%s" msgid)
 	  nil nil nil
-	  msgid (eq major-mode 'mu4e-view-mode))))))
+	  msgid (and (eq major-mode 'mu4e-view-mode)
+		     (not (eq mu4e-split-view 'single-window))))))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 


### PR DESCRIPTION
When in single-window mode and invoking `mu4e-action-show-thread` from
the view buffer, stay in the headers buffer rather than going back to
the view buffer.