### PR TITLE
Add custom variable mu4e-hide-main-view-buffer

### DIFF
--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -198,7 +198,7 @@ clicked."
 
 (defun mu4e~main-view ()
   "Create the mu4e main-view, and switch to it."
-  (if (eq mu4e-split-view 'single-window)
+  (if mu4e-hide-main-view-buffer
       (if (buffer-live-p (mu4e-get-headers-buffer))
 	  (switch-to-buffer (mu4e-get-headers-buffer))
 	(mu4e~main-menu))

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -232,6 +232,10 @@ string or an s-expression that evaluates to query string) and a
 An older form of bookmark, a 3-item list with (QUERY DESCRIPTION
 KEY) is still recognized as well, for backward-compatibility.")
 
+(defcustom mu4e-hide-main-view-buffer nil
+  "If non-nil, mu4e's main view buffer will be replaced with a minibuffer prompt."
+  :type 'boolean
+  :group 'mu4e)
 
 (defcustom mu4e-split-view 'horizontal
   "How to show messages / headers.


### PR DESCRIPTION
If non-nil, mu4e's main view buffer will be replaced with a minibuffer
prompt.

The function `mu4e-main-view` is modified to rely on this variable
rather than `mu4e-split-view` (currently, the minibuffer is used if
and only if `mu4e-split-view` is set to `'single-window`. Thus one can
now use single-window mode together with the main view buffer (useful
e.g. with the mu4e-maildirs-extension package) or another view mode
together with the minibuffer menu.