### PR TITLE
mu4e: Don't descend in maildirs when recursively getting maildirs

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -323,15 +323,14 @@ Function will return the cdr of the list element."
 	     (directory-files-and-attributes
 	       (concat path mdir) nil
 	       "^[^.]\\|\\.[^.][^.]" t))))
-    (dolist (dentry dentries)
-      (when (and (booleanp (cadr dentry)) (cadr dentry))
+    (dolist (dentry dentries dirs)
+      (when (eq (cadr dentry) t)
 	(if (file-accessible-directory-p
-	      (concat mu4e-maildir "/" mdir "/" (car dentry) "/cur"))
-	  (setq dirs (cons (concat mdir (car dentry)) dirs)))
-	(unless (member (car dentry) '("cur" "new" "tmp"))
-	  (setq dirs (append dirs (mu4e~get-maildirs-1 path
-				    (concat mdir (car dentry) "/")))))))
-    dirs))
+	     (concat mu4e-maildir "/" mdir "/" (car dentry) "/cur"))
+	    (push (concat mdir (car dentry)) dirs)
+	  (unless (member (car dentry) '("cur" "new" "tmp"))
+	    (setq dirs (append dirs (mu4e~get-maildirs-1 path
+							 (concat mdir (car dentry) "/"))))))))))
 
 (defvar mu4e-cache-maildir-list nil
   "Whether to cache the list of maildirs; set it to t if you find


### PR DESCRIPTION
maildirs are already the leaf nodes in the folder structure.
Also reduce number of intermediate (garbage collected) values.

I wondered why `[j]ump to some maildir` was a bit laggy on my system (I have a fairly large maildir structure).  This commit improves performance from:

```
ELISP> (benchmark 100 '(mu4e~get-maildirs-1 "~/.mail/gmail/" "/"))
"Elapsed time: 52.475803s (12.332123s in 100 GCs)"
```
to

```
ELISP> (benchmark 100 '(mu4e~get-maildirs-1 "~/.mail/gmail/" "/"))
"Elapsed time: 0.237148s (0.107507s in 1 GCs)"
```