### PR TITLE
org-mu4e: fix org-mu4e-store-and-capture for Org 9.0

### DIFF
--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -138,7 +138,7 @@ the query (for paths starting with 'query:')."
 `org-mu4e-link-query-in-headers-mode', and capture it with
 org-mode)."
   (interactive)
-  (org-mu4e-store-link)
+  (call-interactively 'org-store-link)
   (org-capture))
 
 


### PR DESCRIPTION
#920 fix links in Org 9 (Related discussion: #947). At the same time, `org-mu4e-store-and-capture` is still using `org-mu4e-store-link` only, so it doesn't work in Org 9. Fix by interactively calling `org-store-link` instead.