### PR TITLE
mu4e: restrict deleting trailing whitespace to region

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -401,9 +401,11 @@ simply executes `fill-paragraph'."
   (if mu4e-compose-format-flowed
     (let ((fill-column (point-max))
        (use-hard-newlines nil)); rfill "across" hard newlines
-      (delete-trailing-whitespace)
+      (when (use-region-p)
+        (delete-trailing-whitespace (region-beginning) (region-end)))
       (fill-paragraph nil region))
-    (delete-trailing-whitespace)
+    (when (use-region-p)
+      (delete-trailing-whitespace (region-beginning) (region-end)))
     (fill-paragraph nil region)))
 
 (defun mu4e-toggle-use-hard-newlines ()


### PR DESCRIPTION
If no region is selected, mu4e-fill-paragraph will delete trailing whitespace on
all lines in the buffer.  This might not be desired, e.g. when adding a
signature to the mail which is delimited by the line '-- '.