### PR TITLE
Fix missing continuation in tests/Makefile.am

### DIFF
--- a/mu/tests/Makefile.am
+++ b/mu/tests/Makefile.am
@@ -38,8 +38,8 @@ AM_CFLAGS=								\
 	${WARN_CFLAGS}
 AM_CXXFLAGS=								\
 	$(ASAN_CFLAGS)							\
-	${WARN_CFLAGS}
-${WARN_CXXFLAGS}
+	${WARN_CFLAGS}							\
+	${WARN_CXXFLAGS}
 
 AM_LDFLAGS=								\
 	$(ASAN_LDFLAGS)


### PR DESCRIPTION
Fix tests/Makefile.am not expanding properly.
Probably caused by the recent asan changes.