### PR TITLE
mu4e: allow :query to accept a function returning a query string

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -454,7 +454,9 @@ KAR, or raise an error if none is found."
 		 (mu4e-bookmarks))
 	    (mu4e-warn "Unknown shortcut '%c'" kar)))
 	 (expr (mu4e-bookmark-query chosen-bm))
-	 (query (eval expr)))
+         (expr (if (not (functionp expr)) expr
+                 (funcall expr)))
+         (query (eval expr)))
     (if (stringp query)
       query
       (mu4e-warn "Expression must evaluate to query string ('%S')" expr))))

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -2012,10 +2012,11 @@ defined in the echo area, with the shortcut key highlighted. So, to invoke the
 bookmark we just defined (to get the list of "Big Messages"), all you need to
 type is @kbd{bb}.
 
-@subsection Lisp expressions as bookmarks
+@subsection Lisp expressions or functions as bookmarks
 
 Instead of using strings, it is also possible to use Lisp expressions as
-bookmarks. The only requirement is that they evaluate to a query string.
+bookmarks. Either the expression evaluates to a query string or the expression
+is a function taking no argument that returns a query string.
 
 For example, to get all the messages that are at most a week old in your
 inbox:
@@ -2024,11 +2025,30 @@ inbox:
 (add-to-list 'mu4e-bookmarks
   (make-mu4e-bookmark
    :name  "Inbox messages in the last 7 days"
-   :query (concat "maildir:/inbox AND date:"
+   :query (lambda () (concat "maildir:/inbox AND date:"
              (format-time-string "%Y%m%d"
-                (subtract-time (current-time) (days-to-time 7))))
+                (subtract-time (current-time) (days-to-time 7)))))
    :key ?w) t)
 @end lisp
+
+Another example where the user is prompted how many days old messages should be
+shown:
+
+@lisp
+(defun my/mu4e-bookmark-num-days-old-query (days-old)
+  (interactive (list (read-number "Show days old messages: " 7)))
+  (let ((start-date (subtract-time (current-time) (days-to-time days-old))))
+    (concat "maildir:/inbox AND date:"
+            (format-time-string "%Y%m%d" start-date))))
+
+(add-to-list 'mu4e-bookmarks
+  (make-mu4e-bookmark
+   :name  "Inbox messages in the last 7 days"
+   :query (lambda () (call-interactively 'my/mu4e-bookmark-num-days-old-query))
+   :key ?o) t)
+@end lisp
+
+It is defining a function to make the code more readable.
 
 @subsection Editing bookmarks before searching
 


### PR DESCRIPTION
This allows one to dynamically generate the query string, based for example on the value of a variable.

I added an example in the manual, but actually my real motivation is the following feature.

I'm subscribed to a bunch of mailing lists and they're quite noisy. So I don't want to see them in my standard unread bookmark. Because I don't want to hardcode this list of mailing lists to exclude, I store them in a variable.

I have a header view action to add the current message's mailing list to that variable.
And I have another bookmark that shows the unread messages for only one list, by asking me what list I want to look at.

```elisp
(defcustom ibizaman/mu4e-unread-excluded-lists nil
  "Mailing lists to be excluded from default unread view."
  :group 'mu4e
  :type '(repeat string))

(defun ibizaman/mu4e-add-message-list-to-excluded-lists (msg)
  (let ((list (mu4e-message-field msg :mailing-list)))
    (add-to-list 'ibizaman/mu4e-unread-excluded-lists list)
    (message "Added %s to excluded list" list)))

(add-to-list 'mu4e-headers-actions
             '("Exclude list" . ibizaman/mu4e-add-message-list-to-excluded-lists) t)

(defun ibizaman/mu4e-generate-unread-filter ()
  (concat "flag:unread AND NOT flag:trashed"
          (mapconcat (lambda (v) (concat " AND NOT list:" v))
                     ibizaman/mu4e-unread-excluded-lists "")))

(defun ibizaman/mu4e-get-unread-list-filter-query (wanted-list)
  (interactive (list (completing-read "List: " ibizaman/mu4e-unread-excluded-lists)))
  (concat "flag:unread AND NOT flag:trashed AND list:" wanted-list))

(setq mu4e-bookmarks
      `(,(make-mu4e-bookmark
          :name  "Unread messages not list"
          :query (lambda () (ibizaman/mu4e-generate-unread-filter))
          :key ?u)
        ,(make-mu4e-bookmark
          :name  "Unread list messages"
          :query (lambda () (call-interactively 'ibizaman/mu4e-get-unread-list-filter-query))
          :key ?l))
```