### PR TITLE
mu4e: Fix jumping to specific header in unselect window

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -717,9 +717,10 @@ after the end of the search results."
 	;; view the message at point when there is one.
 	(mu4e-headers-view-message))
       (setq mu4e~headers-view-target nil
-	mu4e~headers-msgid-target nil))
-    (when (mu4e~headers-docid-at-point)
-      (mu4e~headers-highlight (mu4e~headers-docid-at-point)))
+            mu4e~headers-msgid-target nil)
+      (when (mu4e~headers-docid-at-point)
+        (mu4e~headers-highlight (mu4e~headers-docid-at-point))))
+
     ;; run-hooks
     (run-hooks 'mu4e-headers-found-hook)))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -708,7 +708,11 @@ after the end of the search results."
       ;; if we need to jump to some specific message, do so now
       (goto-char (point-min))
       (when mu4e~headers-msgid-target
-	(mu4e-headers-goto-message-id mu4e~headers-msgid-target))
+        (if (eq (current-buffer) (window-buffer))
+            (mu4e-headers-goto-message-id mu4e~headers-msgid-target)
+          (let* ((pos (mu4e-headers-goto-message-id mu4e~headers-msgid-target)))
+            (when pos
+              (set-window-point (get-buffer-window) pos)))))
       (when (and mu4e~headers-view-target (mu4e-message-at-point 'noerror))
 	;; view the message at point when there is one.
 	(mu4e-headers-view-message))


### PR DESCRIPTION
While I am reading a message in a split view, the cursor of mu4e-headers window moves to top after auto updation and rerun-search.
I found mu4e call mu4e-headers-goto-message-id but it failed to jump to the specific header if the buffer is currently inside unselect window.

Also mu4e~headers-highlight function has similar problem, but it works with with-current-buffer macro.