### PR TITLE
mu-config: add NO_COLOR environment variable

### DIFF
--- a/man/mu-easy.1
+++ b/man/mu-easy.1
@@ -22,8 +22,9 @@ commands, but you won't be able to index/search your mail.
 
 By default, \fBmu\fR uses colorized output when it thinks your
 terminal is capable of doing so. If you don't like color, you can use
-the \fB--nocolor\fR command-line option, or set the \fBMU_NOCOLOR\fR
-environment variable to non-empty.
+the \fB--nocolor\fR command-line option, or set either the
+\fBMU_NOCOLOR\fR or the \fBNO_COLOR\fR environment variable to
+non-empty.
 
 .SH INDEXING YOUR E-MAIL
 

--- a/mu/mu-config.c
+++ b/mu/mu-config.c
@@ -81,7 +81,7 @@ set_group_mu_defaults (void)
 
 	/* check for the MU_NOCOLOR or NO_COLOR env vars; but in any case don't
 	 * use colors unless we're writing to a tty */
-	if (g_getenv (MU_NOCOLOR) != NULL || g_getenv (NO_COLOR) != NULL)
+	if (g_getenv (MU_NOCOLOR) != NULL || g_getenv ("NO_COLOR") != NULL)
 		MU_CONFIG.nocolor = TRUE;
 
 	if (!isatty(fileno(stdout)) || !isatty(fileno(stderr)))

--- a/mu/mu-config.c
+++ b/mu/mu-config.c
@@ -79,9 +79,9 @@ set_group_mu_defaults (void)
 		MU_CONFIG.muhome = exp;
 	}
 
-	/* check for the MU_NOCOLOR env var; but in any case don't
+	/* check for the MU_NOCOLOR or NO_COLOR env vars; but in any case don't
 	 * use colors unless we're writing to a tty */
-	if (g_getenv (MU_NOCOLOR) != NULL)
+	if (g_getenv (MU_NOCOLOR) != NULL || g_getenv (NO_COLOR) != NULL)
 		MU_CONFIG.nocolor = TRUE;
 
 	if (!isatty(fileno(stdout)) || !isatty(fileno(stderr)))


### PR DESCRIPTION
Other than `MU_NOCOLOR`, there is a conventional environment variable `NO_COLOR`, which is shared across many other projects – see https://no-color.org.

This is a very simple change which would make `mu` support that.
