### PR TITLE
mu4e: properly display messages in the draft folder (with gnus)

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -360,10 +360,14 @@ article-mode."
     (switch-to-buffer (get-buffer-create mu4e~view-buffer-name))
     (erase-buffer)
     (unless marked-read
-      ;; when we're being marked as read, no need to start rendering the messages; just the minimal
-      ;; so (update... ) can find us.
-      (mm-disable-multibyte)
+      ;; when we're being marked as read, no need to start rendering
+      ;; the messages; just the minimal so (update... ) can find us.
       (insert-file-contents-literally path)
+      (unless (message-fetch-field "Content-Type" t)
+        ;; For example, for messages in `mu4e-drafts-folder'
+        (let ((coding (or (default-value 'buffer-file-coding-system)
+                          'prefer-utf-8)))
+          (recode-region (point-min) (point-max) coding 'no-conversion)))
       (setq
 	gnus-summary-buffer (get-buffer-create " *appease-gnus*")
 	gnus-original-article-buffer (current-buffer))

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -367,9 +367,6 @@ article-mode."
       (setq
 	gnus-summary-buffer (get-buffer-create " *appease-gnus*")
 	gnus-original-article-buffer (current-buffer))
-      (mm-enable-multibyte)
-      (article-de-base64-unreadable)
-      (article-de-quoted-unreadable)
       (run-hooks 'gnus-article-decode-hook)
       (gnus-article-prepare-display)
       (mu4e-view-mode)


### PR DESCRIPTION
This is necessary to display messages with UFT-8 chars when visiting the draft folder.  Here is an [example of such a message](https://github.com/djcb/mu/files/2824530/draft.txt).