### PR TITLE
Issue #1385: get mu4e-action-view-in-browser to show headers

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -85,6 +85,10 @@ return the filename."
       (mu4e-error "No body part for this message"))
     (with-temp-buffer
       (insert "<head><meta charset=\"UTF-8\"></head>\n")
+      (insert (concat "<p><strong>From</strong>: " (mu4e-html-construct-contacts-header msg :from) "</br>"))
+      (insert (concat "<strong>To</strong>: " (mu4e-html-construct-contacts-header msg :to) "</br>"))
+      (insert (concat "<strong>Date</strong>: " (format-time-string mu4e-view-date-format (mu4e-message-field msg :date)) "</br>"))
+      (insert (concat "<strong>Subject</strong>: " (mu4e-message-field msg :subject) "</p>"))
       (insert (or html (concat "<pre>" txt "</pre>")))
       (write-file tmpfile)
       ;; rewrite attachment urls


### PR DESCRIPTION
Here is a very simple patch that achieves what I want, though I am sure there are nicer ways of doing it.