### PR TITLE
Look at all frames for header buffer when auto updating headers

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -982,7 +982,7 @@ no user-interaction ongoing."
     ;; rerun search if there's a live window with search results;
     ;; otherwise we'd trigger a headers view from out of nowhere.
     (when (and (buffer-live-p (mu4e-get-headers-buffer))
-	    (window-live-p (get-buffer-window (mu4e-get-headers-buffer))))
+	    (window-live-p (get-buffer-window (mu4e-get-headers-buffer) t)))
       (mu4e-headers-rerun-search))))
 
 (define-derived-mode mu4e-headers-mode special-mode


### PR DESCRIPTION
Currently if you have new messages but are in another frame `*mu4e-headers*` isn't auto updated.