### PR TITLE
mu4e: fix a remaining local variable 'short'

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -81,7 +81,7 @@ Works for the message view."
                      (replace-regexp-in-string "[[:cntrl:]]" "" (cdr c))))
             (addr (if mu4e-view-show-addresses
                       (if name (format "%s <%s>" name email) email)
-                    (short (or name email)))) ;; name may be nil
+                    (or name email))) ;; name may be nil
             ;; Escape HTML entities
             (addr (replace-regexp-in-string "&" "&amp;" addr))
             (addr (replace-regexp-in-string "<" "&lt;" addr))


### PR DESCRIPTION
Hi,

There was a traceback which looked like "void function error short" when the function `mu4e~action-header-to-html` was called.

Great software, keep going :slightly_smiling_face: !!

Thanks!