### PR TITLE
Fix pedantic -Wparentheses warning generated by gcc 9

### DIFF
--- a/lib/mu-msg.c
+++ b/lib/mu-msg.c
@@ -458,7 +458,7 @@ accumulate_body (MuMsg *msg, MuMsgPart *mpart, BodyData *bdata)
 
 	txt	    = NULL;
 	has_err	    = TRUE;
-	if (bdata->want_html && is_html || !bdata->want_html && is_plain)
+	if ((bdata->want_html && is_html) || (!bdata->want_html && is_plain))
 		txt = mu_msg_mime_part_to_string (mimepart, &has_err);
 
 	if (!has_err && txt)


### PR DESCRIPTION
The current code is perfectly fine, and this commit doesn't change any logic
because the C++ order of operations rules do the exact same thing here with or without the additional parentheses.

However, GCC 9 with the `-Wparentheses` flag is emitting a warning when compiling mu due to the fact that in general mixing `&&` and `||` in the same line can be a source of confusion. This could be an issue if you wanted to compile `mu` using `-Werror`, for example:
```
mu-msg.c: In function 'accumulate_body':
mu-msg.c:461:23: warning: suggest parentheses around '&&' within '||' [-Wparentheses]
  461 |  if (bdata->want_html && is_html || !bdata->want_html && is_plain)
      |      ~~~~~~~~~~~~~~~~~^~~~~~~~~~
```