### PR TITLE
Replace AM_PROG_LIBTOOL with LT_INIT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,10 +53,7 @@ AX_CXX_COMPILE_STDCXX_14
 m4_ifdef([AX_COMPILER_FLAGS],[AX_COMPILER_FLAGS(,,[yes],${extra_flags})])
 AX_VALGRIND_CHECK
 
-# for now, use AM_PROG_LIBTOOL, as we don't want to require too new
-# an autotools setup
-AM_PROG_LIBTOOL
-#LT_INIT([disable-shared])
+LT_INIT([disable-shared])
 
 AC_PROG_AWK
 AC_CHECK_PROG(SORT,sort,sort)


### PR DESCRIPTION
Since mu seems to already gate Autoconf to have version >= 2.68, which was released back in 2010, it seems rather silly to not use more modern m4 macros, like for instance `LT_INIT` which requires libtool version >= 1.9b, which itself was released in 2004 and where the first stable version, libtool 2.2 was released back in 2008.

Any distro that has a sufficiently recent Autoconf has a recent enough libtool.