### PR TITLE
mu4e: fix `make-mu4e-context-account` to see `name` keyword arg

### DIFF
--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -81,7 +81,7 @@ none."
 (defvar mu4e-no-trash-providers '("gmail.com" "googlemail.com")
   "List of email providers that don't support the trash flag.")
 
-(cl-defun make-mu4e-context-account (name &key
+(cl-defun make-mu4e-context-account (&key name
                                           enter-func
                                           leave-func
                                           match-func


### PR DESCRIPTION
Simple fix from #1455, to enable documented use of the `name` keyword argument in `make-mu4e-context-account`.