### PR TITLE
Initialize my addresses

### DIFF
--- a/lib/mu-store.cc
+++ b/lib/mu-store.cc
@@ -709,7 +709,7 @@ mu_store_personal_addresses (const MuStore *store)
 
         const auto size = self(store)->personal_addresses().size();
         auto addrs = g_new0 (char*, 1 + size);
-        for (auto i = 0; i != size; ++i)
+        for (size_t i = 0; i != size; ++i)
                 addrs[i] = g_strdup(self(store)->personal_addresses()[i].c_str());
 
         return addrs;

--- a/lib/mu-store.cc
+++ b/lib/mu-store.cc
@@ -142,6 +142,8 @@ struct Store::Private {
         void set_personal_addresses (const Addresses& addresses) {
 
                 std::string all_addresses;
+                personal_addresses_.clear();
+
                 for (const auto& addr : addresses) {
                         // very basic check; just ensure there's no ',' in the address.
                         // we don't insist on full RFC5322
@@ -150,6 +152,7 @@ struct Store::Private {
                         if (!all_addresses.empty())
                                 all_addresses += ',';
                         all_addresses += addr;
+                        personal_addresses_.emplace_back(addr);
                 }
                 writable_db()->set_metadata (PersonalAddressesKey, all_addresses);
         }
@@ -172,7 +175,7 @@ struct Store::Private {
         const std::string                 maildir_;
         const time_t                      created_{};
         const std::string                 schema_version_;
-        const Addresses                   personal_addresses_;
+        Addresses                         personal_addresses_;
         Contacts                          contacts_;
 
         bool                              in_transaction_{};


### PR DESCRIPTION
Updated today to latest sources and found the "personal" flag didn't work as expected.

In set_personal_addresses(), aside from updating the db, we also need to refresh the addresses in the Store itself, as this is subsequently used during indexing (this would fail to pickup addresses put in --my-addresses during index --reindex otherwise).

I also fixed the "FIXME" in each_contact_check_if_personal using personal_addresses() directly. I assume a GSList was only necessary due to the old code, so let's avoid copies.

In the for(auto) statements I noticed I got a lot of gcc warnings regarding comparisons with size_t, as 0 is deduced as int. I fixed one such occurrence, but I think it's better to use size_t explicitly in these cases.