### PR TITLE
Fix get_checked_path error message

### DIFF
--- a/mu/mu-cmd-server.c
+++ b/mu/mu-cmd-server.c
@@ -1027,7 +1027,7 @@ get_checked_path (const char *path)
         if (!cpath ||
             !mu_util_check_dir (cpath, TRUE, FALSE)) {
                 print_error (MU_ERROR_IN_PARAMETERS,
-                             "not a readable dir: '%s'");
+                             sprintf("not a readable dir: '%s'", path));
                 g_free (cpath);
                 return NULL;
         }


### PR DESCRIPTION
Related to #184, I realize the path was not part of the error but only '%s'. This is the minor fix which actually show the given path.