### PR TITLE
Completely use cl-lib and lexical-binding (rebase #1471)

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -1,4 +1,4 @@
-;; mu4e-compose.el -- part of mu4e, the mu mail user agent for emacs
+;; mu4e-compose.el -- part of mu4e, the mu mail user agent for emacs -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2011-2019 Dirk-Jan C. Binnema
 
@@ -66,8 +66,7 @@
 ;;
 
 ;;; Code:
-(eval-when-compile
-  (require 'cl))
+(require 'cl-lib)
 (require 'message)
 (require 'mail-parse)
 (require 'smtpmail)
@@ -270,7 +269,8 @@ If needed, set the Fcc header, and register the handler function."
       ;; etc. if you run it after mu4e so, (hack hack) we reset it to the old
       ;; handler after we've done our thing.
       (setq message-fcc-handler-function
-  (lexical-let ((maildir mdir) (old-handler message-fcc-handler-function))
+  (let ((maildir mdir)
+        (old-handler message-fcc-handler-function))
     (lambda (file)
       (setq message-fcc-handler-function old-handler) ;; reset the fcc handler
       (let ((mdir-path (concat mu4e-maildir maildir)))
@@ -278,8 +278,8 @@ If needed, set the Fcc header, and register the handler function."
         ;; `mu4e~proc-mkdir` runs asynchronously but no matter whether it runs before or after
         ;; `write-file`, the sent maildir ends up in the correct state.
         (unless (file-exists-p mdir-path)
-    (mu4e~proc-mkdir mdir-path)))
-      (write-file file)		       ;; writing maildirs files is easy
+          (mu4e~proc-mkdir mdir-path)))
+      (write-file file) ;; writing maildirs files is easy
       (mu4e~proc-add file (or maildir "/")))))))) ;; update the database
 
 (defvar mu4e-compose-hidden-headers
@@ -734,7 +734,7 @@ buffer."
       (while (re-search-forward "<[^ <]+@[^ <]+>" nil t)
         (push (match-string 0) refs))
       ;; the last will be the first
-      (setq forwarded-from (first refs))))))
+      (setq forwarded-from (cl-first refs))))))
     ;; remove the <>
     (when (and in-reply-to (string-match "<\\(.*\\)>" in-reply-to))
       (mu4e~proc-move (match-string 1 in-reply-to) nil "+R-N"))

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1,4 +1,4 @@
-;;; mu4e-headers.el -- part of mu4e, the mu mail user agent
+;;; mu4e-headers.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2011-2017 Dirk-Jan C. Binnema
 
@@ -1809,10 +1809,10 @@ do nothing."
 	 ;; emacs has weird ideas about what horizontal, vertical means...
 	 (horizontal
 	   (window-resize hwin n nil)
-	   (incf mu4e-headers-visible-lines n))
+	   (cl-incf mu4e-headers-visible-lines n))
 	 (vertical
 	   (window-resize hwin n t)
-	   (incf mu4e-headers-visible-columns n)))))))
+	   (cl-incf mu4e-headers-visible-columns n)))))))
 
 (defun mu4e-headers-split-view-shrink (&optional n)
   "In split-view, shrink the headers window.

--- a/mu4e/mu4e-icalendar.el
+++ b/mu4e/mu4e-icalendar.el
@@ -41,8 +41,7 @@
 
 (require 'mu4e)
 (require 'gnus-icalendar)
-
-(eval-when-compile (require 'cl))
+(require 'cl-lib)
 
 ;;;###autoload
 (defun mu4e-icalendar-setup ()

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -1,4 +1,4 @@
-;;; mu4e-main.el -- part of mu4e, the mu mail user agent
+;;; mu4e-main.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2011-2016 Dirk-Jan C. Binnema
 
@@ -27,9 +27,7 @@
 (require 'smtpmail)      ;; the queing stuff (silence elint)
 (require 'mu4e-utils)    ;; utility functions
 (require 'mu4e-context)  ;; the context
-
-(eval-when-compile
-  (require 'cl))
+(require 'cl-lib)
 
 (defconst mu4e~main-buffer-name " *mu4e-main*"
   "*internal* Name of the mu4e main view buffer.")
@@ -99,9 +97,8 @@ clicked."
 	(func (if (functionp func-or-shortcut)
 		  func-or-shortcut
 		(if (stringp func-or-shortcut)
-		    (lexical-let ((macro func-or-shortcut))
-		      (lambda()(interactive)
-			(execute-kbd-macro macro)))))))
+                    (lambda()(interactive)
+			   (execute-kbd-macro func-or-shortcut))))))
     (define-key map [mouse-2] func)
     (define-key map (kbd "RET") func)
     (put-text-property 0 (length newstr) 'keymap map newstr)

--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -197,9 +197,10 @@ and images in a multipart/related part."
                        url (file-name-directory current-file)))
                 (ext (file-name-extension path))
                 (id (replace-regexp-in-string "[\/\\\\]" "_" path)))
-           (add-to-list 'html-images
-                        (org~mu4e-mime-file
-        (concat "image/" ext) path id))
+           (cl-pushnew (org~mu4e-mime-file
+                         (concat "image/" ext) path id)
+                       html-images
+                       :test 'equal)
            id)))
       str)
      html-images)))

--- a/mu4e/org-old-mu4e.el
+++ b/mu4e/org-old-mu4e.el
@@ -143,9 +143,10 @@ and images in a multipart/related part."
                        url (file-name-directory current-file)))
                 (ext (file-name-extension path))
                 (id (replace-regexp-in-string "[\/\\\\]" "_" path)))
-           (add-to-list 'html-images
-                        (org~mu4e-mime-file
-			  (concat "image/" ext) path id))
+           (cl-pushnew (org~mu4e-mime-file
+			  (concat "image/" ext) path id)
+                       html-images
+                       :test 'equal)
            id)))
       str)
      html-images)))


### PR DESCRIPTION
Previously both cl-lib.el and cl.el were used, now use only cl-lib.el.
Use lexical-binding where needed instead of requiring cl just for
`lexical-let`.
Replace some add-to-list with cl-pushnew as add-to-list is not
recommended in lisp program and anyway doesn't work properly with
lexical binding.