### PR TITLE
tests: fix cmd test_mu_find_04 stderr output

### DIFF
--- a/mu/tests/test-mu-cmd.c
+++ b/mu/tests/test-mu-cmd.c
@@ -219,8 +219,8 @@ test_mu_find_04 (void)
 {
 	gchar *cmdline, *erroutput;
 
-	cmdline = g_strdup_printf ("%s --muhome=%cfoo%cbar%cnonexistent "
-				   "find f:socrates",
+	cmdline = g_strdup_printf ("find %s --muhome=%cfoo%cbar%cnonexistent "
+				   "f:socrates",
 				   MU_PROGRAM,
 				   G_DIR_SEPARATOR,
 				   G_DIR_SEPARATOR,


### PR DESCRIPTION
Fix test_mu_find_04 such that stderr has expected output.
With the mu command after options/expression nothing was printed.
We now have expected nonexistent muhome error.