### PR TITLE
lib: Allow hostname of newbase to match alnum

### DIFF
--- a/lib/tests/test-mu-maildir.c
+++ b/lib/tests/test-mu-maildir.c
@@ -484,7 +484,7 @@ test_mu_maildir_get_new_path_new (void)
 		assert_matches_regexp (newbase,
 				       "\\d+\\."
 				       "[[:xdigit:]]{16}\\."
-				       "[[:alpha:]]+(:2,.*)?");
+				       "[[:alnum:]][[:alnum:]-]+(:2,.*)?");
 		g_free (newbase);
 		g_free(str);
 	}


### PR DESCRIPTION
Possible hostnames might have digits and - in them.  Crude regex to
allow hostnames that start with alnum followed by alnum or "-".

Fixes #1399