### PR TITLE
lib: Use more portable locale en_US.UTF-8

### DIFF
--- a/lib/tests/test-mu-common.c
+++ b/lib/tests/test-mu-common.c
@@ -73,8 +73,8 @@ set_tz (const char* tz)
 gboolean
 set_en_us_utf8_locale (void)
 {
-	setenv ("LC_ALL", "en_US.utf8", 1);
-	setlocale (LC_ALL, "en_US.utf8");
+	setenv ("LC_ALL", "en_US.UTF-8", 1);
+	setlocale (LC_ALL, "en_US.UTF-8");
 
 	if (strcmp (nl_langinfo(CODESET), "UTF-8") != 0) {
 		g_print ("Note: Unit tests require the en_US.utf8 locale. "


### PR DESCRIPTION
On some systems (FreeBSD) en_US.utf8 doesn't exist.  Use a portable
locale en_US.UTF-8.