### PR TITLE
Push mark on beginning/end of buffer

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -900,11 +900,17 @@ buffer buried."
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defun mu4e-compose-goto-top ()
+(defun mu4e-compose-goto-top (&optional arg)
   "Go to the beginning of the message or buffer.
 Go to the beginning of the message or, if already there, go to the
-beginning of the buffer."
-  (interactive)
+beginning of the buffer.
+
+Push mark at previous position, unless either a \\[universal-argument] prefix
+is supplied, or Transient Mark mode is enabled and the mark is active."
+  (interactive "P")
+  (or arg
+      (region-active-p)
+      (push-mark))
   (let ((old-position (point)))
     (message-goto-body)
     (when (equal (point) old-position)
@@ -913,13 +919,19 @@ beginning of the buffer."
 (define-key mu4e-compose-mode-map
   (vector 'remap 'beginning-of-buffer) 'mu4e-compose-goto-top)
 
-(defun mu4e-compose-goto-bottom ()
+(defun mu4e-compose-goto-bottom (&optional arg)
   "Go to the end of the message or buffer.
 Go to the end of the message (before signature) or, if already there, go to the
-end of the buffer."
-  (interactive)
+end of the buffer.
+
+Push mark at previous position, unless either a \\[universal-argument] prefix
+is supplied, or Transient Mark mode is enabled and the mark is active."
+  (interactive "P")
+  (or arg
+      (region-active-p)
+      (push-mark))
   (let ((old-position (point))
-   (message-position (save-excursion (message-goto-body) (point))))
+	(message-position (save-excursion (message-goto-body) (point))))
     (goto-char (point-max))
     (when (re-search-backward message-signature-separator message-position t)
       (forward-line -1))

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -931,7 +931,7 @@ is supplied, or Transient Mark mode is enabled and the mark is active."
       (region-active-p)
       (push-mark))
   (let ((old-position (point))
-	(message-position (save-excursion (message-goto-body) (point))))
+   (message-position (save-excursion (message-goto-body) (point))))
     (goto-char (point-max))
     (when (re-search-backward message-signature-separator message-position t)
       (forward-line -1))


### PR DESCRIPTION
This has been driving me mad for a while: mu4e's M-< and M-> commands were not consistent with the standard ones.