### PR TITLE
mu4e-util: allow ESC to exit a choice selection

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -253,6 +253,7 @@ trying an exact match."
     (while (not chosen)
       (message nil);; this seems needed...
       (setq choice (read-char-exclusive prompt))
+      (if (eq choice 27) (keyboard-quit)) ;; quit if ESC is pressed
       (setq chosen (or (member choice choices)
 		     (member (downcase choice) choices)
 		     (member (upcase choice) choices))))


### PR DESCRIPTION
I occasionally find myself pressing escape to exit a menu choice in mu4e
and it's a bit unfortunate that nothing happens. As best I could tell,
since this is a C call, none of the keymaps are checked for
`(keyboard-quit)' so we need to explicitly check for ESC here.


----

#