### PR TITLE
Whitelist underscores if replying to mailing-list

### DIFF
--- a/lib/mu-msg-sexp.c
+++ b/lib/mu-msg-sexp.c
@@ -178,7 +178,7 @@ maybe_append_list_post_as_reply_to (GString *gstr, MuMsg *msg)
 	if (!list_post)
 		return;
 
-	rx = g_regex_new ("^(<?mailto:)?([a-z0-9%+@.-_]+)>?", G_REGEX_CASELESS, 0, NULL);
+	rx = g_regex_new ("^(<?mailto:)?([a-z0-9%+@._-]+)>?", G_REGEX_CASELESS, 0, NULL);
 	g_return_if_fail(rx);
 
 	if (g_regex_match (rx, list_post, 0, &minfo)) {

--- a/lib/mu-msg-sexp.c
+++ b/lib/mu-msg-sexp.c
@@ -178,7 +178,7 @@ maybe_append_list_post_as_reply_to (GString *gstr, MuMsg *msg)
 	if (!list_post)
 		return;
 
-	rx = g_regex_new ("^(<?mailto:)?([a-z0-9%+@.-]+)>?", G_REGEX_CASELESS, 0, NULL);
+	rx = g_regex_new ("^(<?mailto:)?([a-z0-9%+@.-_]+)>?", G_REGEX_CASELESS, 0, NULL);
 	g_return_if_fail(rx);
 
 	if (g_regex_match (rx, list_post, 0, &minfo)) {


### PR DESCRIPTION
When replying to a mailing list post from some_address@example.org, Mu4e incorrectly truncated the reply to down to just "some". Whitelisting underscores in the regex resolves the issue.