### PR TITLE
mu4e: switch mu4e-contexts from defvar to defcustom

### DIFF
--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -31,8 +31,9 @@
 (defvar smtpmail-smtp-user)
 (defvar mu4e-view-date-format)
 
-(defvar mu4e-contexts nil "The list of `mu4e-context' objects
-describing mu4e's contexts.")
+(defcustom mu4e-contexts nil "The list of `mu4e-context' objects
+describing mu4e's contexts."
+  :group 'mu4e)
 
 (defcustom mu4e-context-changed-hook nil
   "Hook run just *after* the context changed."


### PR DESCRIPTION
In document, mu4e-contexts is described which can be customed by user, why we don't define it with defcustom to let `custom-set-variables` work before loading mu4e.