### PR TITLE
mu4e: inform alternative for getting confirmation before sending

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -4513,6 +4513,9 @@ wish.
       (signal 'quit nil))))
 @end lisp
 
+Another option is to simply set @code{message-confirm-send} to
+non-@t{nil} so the question ``Send message?'' is asked for confirmation.
+
 @node How it works
 @appendix How it works
 


### PR DESCRIPTION
The `message-send` command already uses the variable `message-confirm-send` to check if a confirmation should be asked before sending.  Then, setting this variable is a more straightforward alternative for getting those confirmations before sending.