### PR TITLE
Load gnus-art when compiling

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -35,6 +35,7 @@
 (require 'mu4e-actions)
 (require 'mu4e-message)
 
+(eval-when-compile (require 'gnus-art))
 (require 'comint)
 (require 'browse-url)
 (require 'button)


### PR DESCRIPTION
Commit edce6354160eccaf7559e038996421f7e5a885ec only loads it
dynamically when executing the function mu4e~view-gnus but as a
consequence many variables are undefined at compile time and, more
importantly, it is no longer possible to override the variable
gnus-display-mime-function with a let binding before calling
gnus-article-prepare-display