### PR TITLE
Update bookmarks status from main buffer

### DIFF
--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -239,7 +239,7 @@ non-nil."
 	  (mu4e-context-vars context)))
       (setq mu4e~context-current context)
       (unless (eq mu4e-split-view 'single-window)
-        (mu4e~main-view-real nil nil))
+        (mu4e~main-view-real-1))
       (run-hooks 'mu4e-context-changed-hook)
       (mu4e-message "Switched context to %s" (mu4e-context-name context)))
     context))

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1879,7 +1879,9 @@ other windows."
       ;; now, all *other* windows should be gone. kill ourselves, and return
       ;; to the main view
       (kill-buffer)
-      (mu4e~main-view))))
+      (if (get-buffer-window mu4e~main-buffer-name 'visible)
+          (mu4e~main-view-real-1 t)
+        (mu4e~main-view 'refresh)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (provide 'mu4e-headers)

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -145,46 +145,52 @@ clicked."
 ;; buffer switching at the end.
 (defun mu4e~main-view-real (ignore-auto noconfirm)
   (let ((buf (get-buffer-create mu4e~main-buffer-name))
-	       (inhibit-read-only t))
+        (inhibit-read-only t)
+        (pos (point)))
+    (message "Reverting %s..." mu4e~main-buffer-name)
+    ;; Refresh infos from server.
+    (mu4e~start-1)
     (with-current-buffer buf
       (erase-buffer)
       (insert
-        "* "
-	      (propertize "mu4e - mu for emacs version " 'face 'mu4e-title-face)
-	      (propertize  mu4e-mu-version 'face 'mu4e-header-key-face)
-        (propertize "; (in store: " 'face 'mu4e-title-face)
-        (propertize (format "%s" (plist-get mu4e~server-props :doccount)) 'face 'mu4e-header-key-face)
-        (propertize " messages)" 'face 'mu4e-title-face)
+       "* "
+       (propertize "mu4e - mu for emacs version " 'face 'mu4e-title-face)
+       (propertize  mu4e-mu-version 'face 'mu4e-header-key-face)
+       (propertize "; (in store: " 'face 'mu4e-title-face)
+       (propertize (format "%s" (plist-get mu4e~server-props :doccount)) 'face 'mu4e-header-key-face)
+       (propertize " messages)" 'face 'mu4e-title-face)
 
-        "\n\n"
-        (propertize "  Basics\n\n" 'face 'mu4e-title-face)
-	      (mu4e~main-action-str
-	        "\t* [j]ump to some maildir\n" 'mu4e-jump-to-maildir)
-	      (mu4e~main-action-str
-	        "\t* enter a [s]earch query\n" 'mu4e-search)
-	      (mu4e~main-action-str
-	        "\t* [C]ompose a new message\n" 'mu4e-compose-new)
-        "\n"
-        (propertize "  Bookmarks\n\n" 'face 'mu4e-title-face)
-        (mu4e~main-bookmarks)
-        "\n"
-        (propertize "  Misc\n\n" 'face 'mu4e-title-face)
+       "\n\n"
+       (propertize "  Basics\n\n" 'face 'mu4e-title-face)
+       (mu4e~main-action-str
+	"\t* [j]ump to some maildir\n" 'mu4e-jump-to-maildir)
+       (mu4e~main-action-str
+	"\t* enter a [s]earch query\n" 'mu4e-search)
+       (mu4e~main-action-str
+	"\t* [C]ompose a new message\n" 'mu4e-compose-new)
+       "\n"
+       (propertize "  Bookmarks\n\n" 'face 'mu4e-title-face)
+       (mu4e~main-bookmarks)
+       "\n\n"
+       (propertize "  Misc\n\n" 'face 'mu4e-title-face)
 
-	      (mu4e~main-action-str "\t* [;]Switch context\n" 'mu4e-context-switch)
+       (mu4e~main-action-str "\t* [;]Switch context\n" 'mu4e-context-switch)
 
-	      (mu4e~main-action-str "\t* [U]pdate email & database\n"
-	        'mu4e-update-mail-and-index)
+       (mu4e~main-action-str "\t* [U]pdate email & database\n"
+	                     'mu4e-update-mail-and-index)
 
-	      ;; show the queue functions if `smtpmail-queue-dir' is defined
-	      (if (file-directory-p smtpmail-queue-dir)
-	        (mu4e~main-view-queue)
-	        "")
-	      "\n"
-	      (mu4e~main-action-str "\t* [N]ews\n" 'mu4e-news)
-	      (mu4e~main-action-str "\t* [A]bout mu4e\n" 'mu4e-about)
-	      (mu4e~main-action-str "\t* [H]elp\n" 'mu4e-display-manual)
-	      (mu4e~main-action-str "\t* [q]uit\n" 'mu4e-quit))
+       ;; show the queue functions if `smtpmail-queue-dir' is defined
+       (if (file-directory-p smtpmail-queue-dir)
+	   (mu4e~main-view-queue)
+	 "")
+       "\n"
+       (mu4e~main-action-str "\t* [N]ews\n" 'mu4e-news)
+       (mu4e~main-action-str "\t* [A]bout mu4e\n" 'mu4e-about)
+       (mu4e~main-action-str "\t* [H]elp\n" 'mu4e-display-manual)
+       (mu4e~main-action-str "\t* [q]uit\n" 'mu4e-quit))
       (mu4e-main-mode)
+      (goto-char pos)
+      (message "Reverting %s done" mu4e~main-buffer-name)
       )))
 
 (defun mu4e~main-view-queue ()

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -230,15 +230,17 @@ When REFRESH is non nil refresh infos from server."
 	    (count-lines (point-min) (point-max)))
     (error 0)))
 
-(defun mu4e~main-view ()
-  "Create the mu4e main-view, and switch to it."
+(defun mu4e~main-view (&optional refresh)
+  "Create the mu4e main-view, and switch to it.
+
+When REFRESH is non nil refresh infos from server."
   (if (eq mu4e-split-view 'single-window)
       (if (buffer-live-p (mu4e-get-headers-buffer))
 	  (switch-to-buffer (mu4e-get-headers-buffer))
 	(mu4e~main-menu))
     ;; `mu4e~main-view' is called from `mu4e~start', so don't call it
     ;; a second time here i.e. do not refresh. 
-    (mu4e~main-view-real-1)
+    (mu4e~main-view-real-1 refresh)
     (switch-to-buffer mu4e~main-buffer-name)
     (goto-char (point-min)))
   (add-to-list 'global-mode-string '(:eval (mu4e-context-label))))

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -239,7 +239,8 @@ When REFRESH is non nil refresh infos from server."
 	  (switch-to-buffer (mu4e-get-headers-buffer))
 	(mu4e~main-menu))
     ;; `mu4e~main-view' is called from `mu4e~start', so don't call it
-    ;; a second time here i.e. do not refresh. 
+    ;; a second time here i.e. do not refresh unless specified
+    ;; explicitely with REFRESH arg. 
     (mu4e~main-view-real-1 refresh)
     (switch-to-buffer mu4e~main-buffer-name)
     (goto-char (point-min)))

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -158,7 +158,7 @@ When REFRESH is non nil refresh infos from server."
     (when refresh
       (mu4e~start-1)
       ;; Wait for server update.
-      (sit-for 0.5))
+      (sit-for 0.1))
     (with-current-buffer buf
       (erase-buffer)
       (insert
@@ -166,7 +166,8 @@ When REFRESH is non nil refresh infos from server."
        (propertize "mu4e - mu for emacs version " 'face 'mu4e-title-face)
        (propertize  mu4e-mu-version 'face 'mu4e-header-key-face)
        (propertize "; (in store: " 'face 'mu4e-title-face)
-       (propertize (format "%s" (plist-get mu4e~server-props :doccount)) 'face 'mu4e-header-key-face)
+       (propertize (format "%s" (plist-get mu4e~server-props :doccount))
+                   'face 'mu4e-header-key-face)
        (propertize " messages)" 'face 'mu4e-title-face)
 
        "\n\n"

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -803,14 +803,27 @@ nothing."
 
 
 (defun mu4e~start (&optional func)
-  "If `mu4e-contexts' have been defined, but we don't have a
+  "Start mu4e and call FUNC if non nil.
+
+If mu4e is already running and FUNC is non nil
+only execute function FUNC.
+If mu4e is not running yet and FUNC is non nil
+start mu4e and execute FUNC.
+If FUNC is nil starts mu4e in background.
+
+Function FUNC when specified should display the `mu4e-main-mode'
+buffer (actually the one which is used is `mu4e-main-view').
+
+If `mu4e-contexts' have been defined, but we don't have a
 context yet, switch to the matching one, or none matches, the
-first. If mu4e is already running, execute function FUNC (if
-non-nil). Otherwise, check various requireme`'nts, then start mu4e.
-When successful, call FUNC (if non-nil) afterwards."
-  (mu4e~start-1 func))
+first. Otherwise, check various `requirements', then start mu4e."
+  (if (and func (mu4e-running-p))
+      (funcall func)
+    (mu4e~start-1 func)))
 
 (defun mu4e~start-1 (&optional func)
+  "Start the mu4e server and execute FUNC when non nil.
+Function FUNC when specified should display the `mu4e-main-mode' buffer."
   ;; Try to set a context, do some checks, set up pong handler and ping
   ;; the server maybe switching the context.
   (mu4e~context-autoswitch nil mu4e-context-policy)

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -637,7 +637,8 @@ changed.")
 (defun mu4e-info-handler (info)
   "Handler function for (:info ...) sexps received from the server
 process."
-  (let ((type (plist-get info :info)))
+  (let ((type (plist-get info :info))
+        (main-buf (get-buffer mu4e~main-buffer-name)))
     (cond
       ((eq type 'add) t) ;; do nothing
       ((eq type 'index)
@@ -652,7 +653,9 @@ process."
 	          (unless (and (not (string= mu4e~contacts-tstamp "0"))
                       (zerop (plist-get info :updated)))
 	            (mu4e~request-contacts-maybe)
-	            (run-hooks 'mu4e-index-updated-hook)))))
+	            (run-hooks 'mu4e-index-updated-hook))
+                  (when (and main-buf (buffer-live-p main-buf))
+                    (mu4e~main-view-real-1 t)))))
       ((plist-get info :message)
 	      (mu4e-index-message "%s" (plist-get info :message))))))
 


### PR DESCRIPTION
This PR allow refreshing the main buffer with `revert-buffer` (g). Before the unread count were not updated when hitting "g", now it does.
Also I tried clarifying the call to `mu4e~start` by separating it in two functions.
Same for the `revert-buffer-function`, it is now split in two functions.
Please have a look before merging.

Next step would be to refresh the unreads count after hitting "U" and update finish automatically without having to hit "g". Same after having read the unread and quitting `mu4e-headers` .