### PR TITLE
Keep editorconfig from misconfiguring indentation for Emacs lisp files

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+((emacs-lisp-mode
+  (indent-tabs-mode . nil)))

--- a/.editorconfig
+++ b/.editorconfig
@@ -34,8 +34,3 @@ max_line_length             = 100
 indent_style                = tab
 indent_size                 = 8
 max_line_length             = 100
-
-[*.el]
-indent_style                = space
-indent_size                 = 2
-max_line_length             = 100

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ GTAGS
 *.gcda
 *.gcno
 *.trs
+aminclude_static.am
 elisp-comp
 elc-stamp
 dummy.cc
@@ -94,6 +95,9 @@ build-aux/
 /lib/parser/test-tokenizer
 /lib/parser/test-utils
 /lib/parser/tokenize
+/lib/utils/test-command-parser
+/lib/utils/test-mu-utils
+/lib/utils/test-sexp-parser
 *_flymake.*
 *_flymake_*
 /perf.data

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>

--- a/man/mu-server.1
+++ b/man/mu-server.1
@@ -11,7 +11,7 @@ mu server \- the mu backend for the mu4e e-mail client
 .SH DESCRIPTION
 
 \fBmu server\fR starts a simple shell in which one can query and manipulate the
-mu database. The output uses s-expressiong. \fBmu server\fR is not meant for use
+mu database. The output uses s-expressions. \fBmu server\fR is not meant for use
 by humans, except for debugging purposes. Instead, it is designed specifically
 for the \fBmu4e\fR e-mail client.
 
@@ -30,7 +30,7 @@ For example, to view a certain message, the command would be:
 .fi
 
 Parameters can be sent in any order; they must be of the correct type though.
-See \fBlib/utils/mu-sexp-parser.hh\fR and \fBlib/utils/mu-sexp-parser.hh\fR in
+See \fBlib/utils/mu-sexp-parser.hh\fR and \fBlib/utils/mu-sexp-parser.cc\fR in
 source-tree for the details.
 
 

--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -296,14 +296,13 @@ messages can lead to messages with multiple tags headers.")
   "List of tags for completion in `mu4e-action-retag-message'.")
 
 (defun mu4e~contains-line-matching (regexp path)
-  "Does file at PATH contain a line matching the given REGEXP?"
+  "Return non-nil if the file at PATH contain a line matching REGEXP.
+Otherwise return nil."
   (with-temp-buffer
     (insert-file-contents path)
     (save-excursion
       (goto-char (point-min))
-      (if (re-search-forward regexp nil t)
-          t
-        nil))))
+      (re-search-forward regexp nil t))))
 
 (defun mu4e~replace-first-line-matching (regexp to-string path)
   "Replace first line matching REGEXP in PATH with TO-STRING."

--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -47,8 +47,8 @@
   "Count the number of lines in the e-mail MSG.
 Works for headers view and message-view."
   (message "Number of lines: %s"
-    (shell-command-to-string
-      (concat "wc -l < " (shell-quote-argument (mu4e-message-field msg :path))))))
+           (shell-command-to-string
+            (concat "wc -l < " (shell-quote-argument (mu4e-message-field msg :path))))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
@@ -66,12 +66,12 @@ Works for the message view."
   (unless (file-executable-p mu4e-msg2pdf)
     (mu4e-error "Program msg2pdf not found; please set `mu4e-msg2pdf'"))
   (let* ((pdf
-           (shell-command-to-string
-             (concat mu4e-msg2pdf " "
-               (shell-quote-argument (mu4e-message-field msg :path))
-               " 2> /dev/null")))
-          (pdf (and pdf (> (length pdf) 5)
-                 (substring pdf 0 -1)))) ;; chop \n
+          (shell-command-to-string
+           (concat mu4e-msg2pdf " "
+                   (shell-quote-argument (mu4e-message-field msg :path))
+                   " 2> /dev/null")))
+         (pdf (and pdf (> (length pdf) 5)
+                   (substring pdf 0 -1)))) ;; chop \n
     (unless (and pdf (file-exists-p pdf))
       (mu4e-warn "Failed to create PDF file"))
     (find-file pdf)))
@@ -100,22 +100,22 @@ Works for the message view."
   "Write MSG's body (either html or text) to a temporary file;
 return the filename."
   (let* ((html (mu4e-message-field msg :body-html))
-          (txt (mu4e-message-field msg :body-txt))
-          (tmpfile (mu4e-make-temp-file "html"))
-          (attachments (cl-remove-if (lambda (part)
-                                       (or (null (plist-get part :attachment))
-                                         (null (plist-get part :cid))))
-                         (mu4e-message-field msg :parts))))
+         (txt (mu4e-message-field msg :body-txt))
+         (tmpfile (mu4e-make-temp-file "html"))
+         (attachments (cl-remove-if (lambda (part)
+                                      (or (null (plist-get part :attachment))
+                                          (null (plist-get part :cid))))
+                                    (mu4e-message-field msg :parts))))
     (unless (or html txt)
       (mu4e-error "No body part for this message"))
     (with-temp-buffer
       (insert "<head><meta charset=\"UTF-8\"></head>\n")
       (insert (concat "<p><strong>From</strong>: "
-                (mu4e~action-header-to-html msg :from) "</br>"))
+                      (mu4e~action-header-to-html msg :from) "</br>"))
       (insert (concat "<strong>To</strong>: "
-                (mu4e~action-header-to-html msg :to) "</br>"))
+                      (mu4e~action-header-to-html msg :to) "</br>"))
       (insert (concat "<strong>Date</strong>: "
-                (format-time-string mu4e-view-date-format (mu4e-message-field msg :date)) "</br>"))
+                      (format-time-string mu4e-view-date-format (mu4e-message-field msg :date)) "</br>"))
       (insert (concat "<strong>Subject</strong>: " (mu4e-message-field msg :subject) "</p>"))
       (insert (or html (concat "<pre>" txt "</pre>")))
       (write-file tmpfile)
@@ -123,20 +123,20 @@ return the filename."
       (mapc (lambda (attachment)
               (goto-char (point-min))
               (while (re-search-forward (format "src=\"cid:%s\""
-                                          (plist-get attachment :cid)) nil t)
+                                                (plist-get attachment :cid)) nil t)
                 (if (plist-get attachment :temp)
-                  (replace-match (format "src=\"%s\""
-                                   (plist-get attachment :temp)))
+                    (replace-match (format "src=\"%s\""
+                                           (plist-get attachment :temp)))
                   (replace-match (format "src=\"%s%s\"" temporary-file-directory
-                                   (plist-get attachment :name)))
+                                         (plist-get attachment :name)))
                   (let ((tmp-attachment-name
-                          (format "%s%s" temporary-file-directory
-                            (plist-get attachment :name))))
+                         (format "%s%s" temporary-file-directory
+                                 (plist-get attachment :name))))
                     (mu4e~proc-extract 'save (mu4e-message-field msg :docid)
-                      (plist-get attachment :index)
-                      mu4e-decryption-policy tmp-attachment-name)
+                                       (plist-get attachment :index)
+                                       mu4e-decryption-policy tmp-attachment-name)
                     (mu4e-remove-file-later tmp-attachment-name)))))
-        attachments)
+            attachments)
       (save-buffer)
       tmpfile)))
 
@@ -146,7 +146,7 @@ You can influence the browser to use with the variable
 `browse-url-generic-program', and see the discussion of privacy
 aspects in `(mu4e) Displaying rich-text messages'."
   (browse-url (concat "file://"
-                (mu4e~write-body-to-html msg))))
+                      (mu4e~write-body-to-html msg))))
 
 (defun mu4e-action-view-with-xwidget (msg)
   "View the body of MSG inside xwidget-webkit.
@@ -155,7 +155,7 @@ privacy aspects in `(mu4e) Displaying rich-text messages'."
   (unless (fboundp 'xwidget-webkit-browse-url)
     (mu4e-error "No xwidget support available"))
   (xwidget-webkit-browse-url
-    (concat "file://" (mu4e~write-body-to-html msg)) t))
+   (concat "file://" (mu4e~write-body-to-html msg)) t))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
@@ -172,7 +172,7 @@ privacy aspects in `(mu4e) Displaying rich-text messages'."
   (with-temp-buffer
     (insert (mu4e-message-field msg :body-txt))
     (shell-command-on-region (point-min) (point-max)
-      mu4e-text2speech-command)))
+                             mu4e-text2speech-command)))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
@@ -216,23 +216,23 @@ file where you store your org-contacts."
   (unless mu4e-org-contacts-file
     (mu4e-error "Variable `mu4e-org-contacts-file' is nil"))
   (let* ((sender (car-safe (mu4e-message-field msg :from)))
-          (name (car-safe sender)) (email (cdr-safe sender))
-          (blurb
-            (format
-              (concat
-                "* %%?%s\n"
-                ":PROPERTIES:\n"
-                ":EMAIL: %s\n"
-                ":NICK:\n"
-                ":BIRTHDAY:\n"
-                ":END:\n\n")
-              (or name email "")
-              (or email "")))
-          (key "mu4e-add-org-contact-key")
-          (org-capture-templates
-            (append org-capture-templates
-              (list (list key "contacts" 'entry
-                      (list 'file mu4e-org-contacts-file) blurb)))))
+         (name (car-safe sender)) (email (cdr-safe sender))
+         (blurb
+          (format
+           (concat
+            "* %%?%s\n"
+            ":PROPERTIES:\n"
+            ":EMAIL: %s\n"
+            ":NICK:\n"
+            ":BIRTHDAY:\n"
+            ":END:\n\n")
+           (or name email "")
+           (or email "")))
+         (key "mu4e-add-org-contact-key")
+         (org-capture-templates
+          (append org-capture-templates
+                  (list (list key "contacts" 'entry
+                              (list 'file mu4e-org-contacts-file) blurb)))))
     (message "%S" org-capture-templates)
     (when (fboundp 'org-capture)
       (org-capture nil key))))
@@ -252,16 +252,16 @@ file where you store your org-contacts."
   (unless prompt
     (setq prompt "Target directory:"))
   (file-truename
-    (completing-read prompt 'read-file-name-internal #'file-directory-p
-      nil nil 'mu4e~patch-directory-history)))
+   (completing-read prompt 'read-file-name-internal #'file-directory-p
+                    nil nil 'mu4e~patch-directory-history)))
 
 (defun mu4e-action-git-apply-patch (msg)
   "Apply `MSG' as a git patch."
   (let ((path (mu4e~read-patch-directory "Target directory: ")))
     (let ((default-directory path))
       (shell-command
-        (format "git apply %s"
-          (shell-quote-argument (mu4e-message-field msg :path)))))))
+       (format "git apply %s"
+               (shell-quote-argument (mu4e-message-field msg :path)))))))
 
 (defun mu4e-action-git-apply-mbox (msg &optional signoff)
   "Apply `MSG' a git patch with optional `SIGNOFF'.
@@ -270,15 +270,15 @@ If the `default-directory' matches the most recent history entry don't
 bother asking for the git tree again (useful for bulk actions)."
 
   (let ((cwd (substring-no-properties
-               (or (car mu4e~patch-directory-history)
-                 "not-a-dir"))))
+              (or (car mu4e~patch-directory-history)
+                  "not-a-dir"))))
     (unless (and (stringp cwd) (string= default-directory cwd))
       (setq cwd (mu4e~read-patch-directory "Target directory: ")))
     (let ((default-directory cwd))
       (shell-command
-        (format "git am %s %s"
-          (if signoff "--signoff" "")
-          (shell-quote-argument (mu4e-message-field msg :path)))))))
+       (format "git am %s %s"
+               (if signoff "--signoff" "")
+               (shell-quote-argument (mu4e-message-field msg :path)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -302,7 +302,7 @@ messages can lead to messages with multiple tags headers.")
     (save-excursion
       (goto-char (point-min))
       (if (re-search-forward regexp nil t)
-        t
+          t
         nil))))
 
 (defun mu4e~replace-first-line-matching (regexp to-string path)
@@ -312,7 +312,7 @@ messages can lead to messages with multiple tags headers.")
     (save-excursion
       (goto-char (point-min))
       (if (re-search-forward regexp nil t)
-        (replace-match to-string nil nil)))))
+          (replace-match to-string nil nil)))))
 
 (defun mu4e-action-retag-message (msg &optional retag-arg)
   "Change tags of MSG with RETAG-ARG.
@@ -322,33 +322,33 @@ RETAG-ARG is a comma-separated list of additions and removals.
 Example: +tag,+long tag,-oldtag
 would add 'tag' and 'long tag', and remove 'oldtag'."
   (let* (
-          (path (mu4e-message-field msg :path))
-          (oldtags (mu4e-message-field msg :tags))
-          (tags-completion
-            (append
-              mu4e-action-tags-completion-list
-              (mapcar (lambda (tag) (format "+%s" tag))
-                mu4e-action-tags-completion-list)
-              (mapcar (lambda (tag) (format "-%s" tag))
-                oldtags)))
-          (retag (if retag-arg
-                   (split-string retag-arg ",")
-                   (completing-read-multiple "Tags: " tags-completion)))
-          (header  mu4e-action-tags-header)
-          (sep     (cond ((string= header "Keywords") ", ")
-                     ((string= header "X-Label") " ")
-                     ((string= header "X-Keywords") ", ")
-                     (t ", ")))
-          (taglist (if oldtags (copy-sequence oldtags) '()))
-          tagstr)
+         (path (mu4e-message-field msg :path))
+         (oldtags (mu4e-message-field msg :tags))
+         (tags-completion
+          (append
+           mu4e-action-tags-completion-list
+           (mapcar (lambda (tag) (format "+%s" tag))
+                   mu4e-action-tags-completion-list)
+           (mapcar (lambda (tag) (format "-%s" tag))
+                   oldtags)))
+         (retag (if retag-arg
+                    (split-string retag-arg ",")
+                  (completing-read-multiple "Tags: " tags-completion)))
+         (header  mu4e-action-tags-header)
+         (sep     (cond ((string= header "Keywords") ", ")
+                        ((string= header "X-Label") " ")
+                        ((string= header "X-Keywords") ", ")
+                        (t ", ")))
+         (taglist (if oldtags (copy-sequence oldtags) '()))
+         tagstr)
     (dolist (tag retag taglist)
       (cond
-        ((string-match "^\\+\\(.+\\)" tag)
-          (setq taglist (push (match-string 1 tag) taglist)))
-        ((string-match "^\\-\\(.+\\)" tag)
-          (setq taglist (delete (match-string 1 tag) taglist)))
-        (t
-          (setq taglist (push tag taglist)))))
+       ((string-match "^\\+\\(.+\\)" tag)
+        (setq taglist (push (match-string 1 tag) taglist)))
+       ((string-match "^\\-\\(.+\\)" tag)
+        (setq taglist (delete (match-string 1 tag) taglist)))
+       (t
+        (setq taglist (push tag taglist)))))
 
     (setq taglist (sort (delete-dups taglist) 'string<))
     (setq tagstr (mapconcat 'identity taglist sep))
@@ -357,15 +357,15 @@ would add 'tag' and 'long tag', and remove 'oldtag'."
     (setq tagstr (replace-regexp-in-string "[/]"   "\\&" tagstr))
 
     (if (not (mu4e~contains-line-matching (concat header ":.*") path))
-      ;; Add tags header just before the content
-      (mu4e~replace-first-line-matching
-        "^$" (concat header ": " tagstr "\n") path)
+        ;; Add tags header just before the content
+        (mu4e~replace-first-line-matching
+         "^$" (concat header ": " tagstr "\n") path)
 
       ;; replaces keywords, restricted to the header
       (mu4e~replace-first-line-matching
-        (concat header ":.*")
-        (concat header ": " tagstr)
-        path))
+       (concat header ":.*")
+       (concat header ": " tagstr)
+       path))
 
     (mu4e-message (concat "tagging: " (mapconcat 'identity taglist ", ")))
     (mu4e-refresh-message path)))
@@ -378,12 +378,12 @@ the message."
   (let ((msgid (mu4e-message-field msg :message-id)))
     (when msgid
       (let ((mu4e-headers-show-threads t)
-             (mu4e-headers-include-related t))
+            (mu4e-headers-include-related t))
         (mu4e-headers-search
-          (format "msgid:%s" msgid)
-          nil nil nil
-          msgid (and (eq major-mode 'mu4e-view-mode)
-                  (not (eq mu4e-split-view 'single-window))))))))
+         (format "msgid:%s" msgid)
+         nil nil nil
+         msgid (and (eq major-mode 'mu4e-view-mode)
+                    (not (eq mu4e-split-view 'single-window))))))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (provide 'mu4e-actions)

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -1,4 +1,4 @@
-;; mu4e-compose.el -- part of mu4e, the mu mail user agent for emacs -*- lexical-binding: t -*-
+;;; mu4e-compose.el -- part of mu4e, the mu mail user agent for emacs -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2011-2020 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -109,8 +109,8 @@ symbols, for example:
 The various `message-' functions from `message-mode' are available
 for querying the message information."
   :type '(choice (const :tag "move message to mu4e-sent-folder" sent)
-           (const :tag "move message to mu4e-trash-folder" trash)
-           (const :tag "delete message" delete))
+                 (const :tag "move message to mu4e-trash-folder" trash)
+                 (const :tag "delete message" delete))
   :group 'mu4e-compose)
 
 (defcustom mu4e-compose-context-policy 'ask
@@ -129,11 +129,11 @@ contexts match, we have the following choices:
 
 Also see `mu4e-context-policy'."
   :type '(choice
-           (const :tag "Always ask what context to use" always-ask)
-           (const :tag "Ask if none of the contexts match" ask)
-           (const :tag "Ask when there's no context yet" ask-if-none)
-           (const :tag "Pick the first context if none match" pick-first)
-           (const :tag "Don't change the context when none match" nil))
+          (const :tag "Always ask what context to use" always-ask)
+          (const :tag "Ask if none of the contexts match" ask)
+          (const :tag "Ask when there's no context yet" ask-if-none)
+          (const :tag "Pick the first context if none match" pick-first)
+          (const :tag "Don't change the context when none match" nil))
   :safe 'symbolp
   :group 'mu4e-compose)
 
@@ -146,10 +146,10 @@ We have the following choices:
 - `encrypt': encrypt the reply, but don't sign it.
 -  anything else: do nothing."
   :type '(choice
-           (const :tag "Sign the reply" sign)
-           (const :tag "Sign and encrypt the reply" sign-and-encrypt)
-           (const :tag "Encrypt the reply" encrypt)
-           (const :tag "Don't do anything" nil))
+          (const :tag "Sign the reply" sign)
+          (const :tag "Sign and encrypt the reply" sign-and-encrypt)
+          (const :tag "Encrypt the reply" encrypt)
+          (const :tag "Don't do anything" nil))
   :safe 'symbolp
   :group 'mu4e-compose)
 
@@ -162,10 +162,10 @@ We have the following choices:
 - `encrypt': encrypt the reply, but don't sign it.
 -  anything else: do nothing."
   :type '(choice
-           (const :tag "Sign the reply" sign)
-           (const :tag "Sign and encrypt the reply" sign-and-encrypt)
-           (const :tag "Encrypt the reply" encrypt)
-           (const :tag "Don't do anything" nil))
+          (const :tag "Sign the reply" sign)
+          (const :tag "Sign and encrypt the reply" sign-and-encrypt)
+          (const :tag "Encrypt the reply" encrypt)
+          (const :tag "Don't do anything" nil))
   :safe 'symbolp
   :group 'mu4e-compose)
 
@@ -173,7 +173,7 @@ We have the following choices:
  'mu4e-compose-crypto-reply-policy' variable is deprecated.
  'mu4e-compose-crypto-reply-plain-policy' and
  'mu4e-compose-crypto-reply-encrypted-policy' should be used instead"
-      "2017-09-02")
+                        "2017-09-02")
 
 (defcustom mu4e-compose-format-flowed nil
   "Whether to compose messages to be sent as format=flowed.
@@ -211,10 +211,10 @@ This is a symbol, `new', `forward', `reply' or `edit'.")
     (unless (file-exists-p path)
       (mu4e-warn "Message file not found"))
     (mml-attach-file
-      path
-      "message/rfc822"
-      (or (plist-get msg :subject) "No subject")
-      "attachment")))
+     path
+     "message/rfc822"
+     (or (plist-get msg :subject) "No subject")
+     "attachment")))
 
 (defun mu4e-compose-attach-captured-message ()
   "Insert the last captured message file as an attachment.
@@ -243,25 +243,25 @@ Messages are captured with `mu4e-action-capture-message'."
   "Maybe setup Fcc, based on `mu4e-sent-messages-behavior'.
 If needed, set the Fcc header, and register the handler function."
   (let* ((sent-behavior
-     ;; Note; we cannot simply use functionp here, since at least
-     ;; delete is a function, too...
-     (if (member mu4e-sent-messages-behavior '(delete trash sent))
-       mu4e-sent-messages-behavior
-       (if (functionp mu4e-sent-messages-behavior)
-         (funcall mu4e-sent-messages-behavior)
-         mu4e-sent-messages-behavior)))
-    (mdir
-      (cl-case sent-behavior
-        (delete nil)
-        (trash (mu4e-get-trash-folder mu4e-compose-parent-message))
-        (sent (mu4e-get-sent-folder mu4e-compose-parent-message))
-        (otherwise
-    (mu4e-error "Unsupported value '%S'
+          ;; Note; we cannot simply use functionp here, since at least
+          ;; delete is a function, too...
+          (if (member mu4e-sent-messages-behavior '(delete trash sent))
+              mu4e-sent-messages-behavior
+            (if (functionp mu4e-sent-messages-behavior)
+                (funcall mu4e-sent-messages-behavior)
+              mu4e-sent-messages-behavior)))
+         (mdir
+          (cl-case sent-behavior
+            (delete nil)
+            (trash (mu4e-get-trash-folder mu4e-compose-parent-message))
+            (sent (mu4e-get-sent-folder mu4e-compose-parent-message))
+            (otherwise
+             (mu4e-error "Unsupported value '%S'
       `mu4e-sent-messages-behavior'"
-      mu4e-sent-messages-behavior))))
-    (fccfile (and mdir
-               (concat (mu4e-root-maildir) mdir "/cur/"
-                 (mu4e~draft-message-filename-construct "S")))))
+                         mu4e-sent-messages-behavior))))
+         (fccfile (and mdir
+                       (concat (mu4e-root-maildir) mdir "/cur/"
+                               (mu4e~draft-message-filename-construct "S")))))
     ;; if there's an fcc header, add it to the file
     (when fccfile
       (message-add-header (concat "Fcc: " fccfile "\n"))
@@ -269,22 +269,22 @@ If needed, set the Fcc header, and register the handler function."
       ;; etc. if you run it after mu4e so, (hack hack) we reset it to the old
       ;; handler after we've done our thing.
       (setq message-fcc-handler-function
-  (let ((maildir mdir)
-        (old-handler message-fcc-handler-function))
-    (lambda (file)
-      (setq message-fcc-handler-function old-handler) ;; reset the fcc handler
-      (let ((mdir-path (concat (mu4e-root-maildir) maildir)))
-        ;; Create the full maildir structure for the sent folder if it doesn't exist.
-        ;; `mu4e~proc-mkdir` runs asynchronously but no matter whether it runs before or after
-        ;; `write-file`, the sent maildir ends up in the correct state.
-        (unless (file-exists-p mdir-path)
-          (mu4e~proc-mkdir mdir-path)))
-      (write-file file) ;; writing maildirs files is easy
-      (mu4e~proc-add file))))))) ;; update the database
+            (let ((maildir mdir)
+                  (old-handler message-fcc-handler-function))
+              (lambda (file)
+                (setq message-fcc-handler-function old-handler) ;; reset the fcc handler
+                (let ((mdir-path (concat (mu4e-root-maildir) maildir)))
+                  ;; Create the full maildir structure for the sent folder if it doesn't exist.
+                  ;; `mu4e~proc-mkdir` runs asynchronously but no matter whether it runs before or after
+                  ;; `write-file`, the sent maildir ends up in the correct state.
+                  (unless (file-exists-p mdir-path)
+                    (mu4e~proc-mkdir mdir-path)))
+                (write-file file) ;; writing maildirs files is easy
+                (mu4e~proc-add file))))))) ;; update the database
 
 (defvar mu4e-compose-hidden-headers
   `("^References:" "^Face:" "^X-Face:"
-     "^X-Draft-From:" "^User-agent:")
+    "^X-Draft-From:" "^User-agent:")
   "Hidden headers when composing.")
 
 (defun mu4e~compose-hide-headers ()
@@ -301,25 +301,25 @@ Just after saving we restore it; thus, the separator should never
 appear on disk. Also update the Date and ensure we have a
 Message-ID."
   (add-hook 'before-save-hook
-    (lambda()
-      ;; replace the date
-      (save-excursion
-        (message-remove-header "Date")
-        (message-generate-headers '(Date Message-ID))
-        (save-match-data
-          (mu4e~draft-remove-mail-header-separator)))) nil t)
+            (lambda()
+              ;; replace the date
+              (save-excursion
+                (message-remove-header "Date")
+                (message-generate-headers '(Date Message-ID))
+                (save-match-data
+                  (mu4e~draft-remove-mail-header-separator)))) nil t)
   (add-hook 'after-save-hook
-    (lambda ()
-      (save-match-data
-        (mu4e~compose-set-friendly-buffer-name)
-        (mu4e~draft-insert-mail-header-separator)
-        ;; hide some headers again
-        (mu4e~compose-hide-headers)
-        (widen)
-        (set-buffer-modified-p nil)
-        (mu4e-message "Saved (%d lines)" (count-lines (point-min) (point-max)))
-        ;; update the file on disk -- ie., without the separator
-        (mu4e~proc-add (buffer-file-name)))) nil t))
+            (lambda ()
+              (save-match-data
+                (mu4e~compose-set-friendly-buffer-name)
+                (mu4e~draft-insert-mail-header-separator)
+                ;; hide some headers again
+                (mu4e~compose-hide-headers)
+                (widen)
+                (set-buffer-modified-p nil)
+                (mu4e-message "Saved (%d lines)" (count-lines (point-min) (point-max)))
+                ;; update the file on disk -- ie., without the separator
+                (mu4e~proc-add (buffer-file-name)))) nil t))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; address completion; inspired by org-contacts.el and
@@ -327,37 +327,37 @@ Message-ID."
 (defun mu4e~compose-complete-handler (str pred action)
   "Complete address STR with predication PRED for ACTION."
   (cond
-    ((eq action nil)
-      (try-completion str mu4e~contacts pred))
-    ((eq action t)
-      (all-completions str mu4e~contacts pred))
-    ((eq action 'metadata)
-      ;; our contacts are already sorted - just need to tell the
-      ;; completion machinery not to try to undo that...
-      '(metadata
-   (display-sort-function . identity)
-   (cycle-sort-function   . identity)))))
+   ((eq action nil)
+    (try-completion str mu4e~contacts pred))
+   ((eq action t)
+    (all-completions str mu4e~contacts pred))
+   ((eq action 'metadata)
+    ;; our contacts are already sorted - just need to tell the
+    ;; completion machinery not to try to undo that...
+    '(metadata
+      (display-sort-function . identity)
+      (cycle-sort-function   . identity)))))
 
 (defun mu4e~compose-complete-contact (&optional start)
   "Complete the text at START with a contact.
 Ie. either 'name <email>' or 'email')."
   (interactive)
   (let ((mail-abbrev-mode-regexp mu4e~compose-address-fields-regexp)
-   (eoh ;; end-of-headers
-     (save-excursion
-       (goto-char (point-min))
-       (search-forward-regexp mail-header-separator nil t))))
+        (eoh ;; end-of-headers
+         (save-excursion
+           (goto-char (point-min))
+           (search-forward-regexp mail-header-separator nil t))))
     ;; try to complete only when we're in the headers area,
     ;; looking  at an address field.
     (when (and eoh (> eoh (point)) (mail-abbrev-in-expansion-header-p))
       (let* ((end (point))
-        (start
-    (or start
-      (save-excursion
-        (re-search-backward "\\(\\`\\|[\n:,]\\)[ \t]*")
-        (goto-char (match-end 0))
-        (point)))))
-  (list start end 'mu4e~compose-complete-handler)))))
+             (start
+              (or start
+                  (save-excursion
+                    (re-search-backward "\\(\\`\\|[\n:,]\\)[ \t]*")
+                    (goto-char (match-end 0))
+                    (point)))))
+        (list start end 'mu4e~compose-complete-handler)))))
 
 (defun mu4e~compose-setup-completion ()
   "Set up auto-completion of addresses."
@@ -365,7 +365,7 @@ Ie. either 'name <email>' or 'email')."
   (set (make-local-variable 'completion-cycle-threshold) 7)
   (add-to-list (make-local-variable 'completion-styles) 'substring)
   (add-hook 'completion-at-point-functions
-    'mu4e~compose-complete-contact nil t))
+            'mu4e~compose-complete-contact nil t))
 
 (defun mu4e~remove-refs-maybe ()
   "Remove References: if In-Reply-To: is missing.
@@ -379,12 +379,12 @@ removing the In-Reply-To header."
   "Keymap for \"*mu4e-compose*\" buffers.")
 (unless mu4e-compose-mode-map
   (setq mu4e-compose-mode-map
-    (let ((map (make-sparse-keymap)))
-      (define-key map (kbd "C-S-u")   'mu4e-update-mail-and-index)
-      (define-key map (kbd "C-c C-u") 'mu4e-update-mail-and-index)
-      (define-key map (kbd "C-c C-k") 'mu4e-message-kill-buffer)
-      (define-key map (kbd "M-q")     'mu4e-fill-paragraph)
-      map)))
+        (let ((map (make-sparse-keymap)))
+          (define-key map (kbd "C-S-u")   'mu4e-update-mail-and-index)
+          (define-key map (kbd "C-c C-u") 'mu4e-update-mail-and-index)
+          (define-key map (kbd "C-c C-k") 'mu4e-message-kill-buffer)
+          (define-key map (kbd "M-q")     'mu4e-fill-paragraph)
+          map)))
 
 (defun mu4e-fill-paragraph (&optional region)
   "Re-layout either the whole message or REGION.
@@ -395,11 +395,11 @@ set, this simply executes `fill-paragraph'."
   ;; Inspired by https://www.emacswiki.org/emacs/UnfillParagraph
   (interactive (progn (barf-if-buffer-read-only) '(t)))
   (if mu4e-compose-format-flowed
-    (let ((fill-column (point-max))
-       (use-hard-newlines nil)); rfill "across" hard newlines
-      (when (use-region-p)
-        (delete-trailing-whitespace (region-beginning) (region-end)))
-      (fill-paragraph nil region))
+      (let ((fill-column (point-max))
+            (use-hard-newlines nil)); rfill "across" hard newlines
+        (when (use-region-p)
+          (delete-trailing-whitespace (region-beginning) (region-end)))
+        (fill-paragraph nil region))
     (when (use-region-p)
       (delete-trailing-whitespace (region-beginning) (region-end)))
     (fill-paragraph nil region)))
@@ -408,7 +408,7 @@ set, this simply executes `fill-paragraph'."
   (interactive)
   (setq use-hard-newlines (not use-hard-newlines))
   (if use-hard-newlines
-    (turn-off-auto-fill)
+      (turn-off-auto-fill)
     (turn-on-auto-fill)))
 
 (defun mu4e~compose-remap-faces ()
@@ -417,23 +417,23 @@ Our parent `message-mode' uses font-locking for the compose
 buffers; lets remap its faces so it uses the ones for mu4e."
   ;; normal headers
   (face-remap-add-relative 'message-header-name
-    '((:inherit mu4e-header-key-face)))
+                           '((:inherit mu4e-header-key-face)))
   (face-remap-add-relative 'message-header-other
-    '((:inherit mu4e-header-value-face)))
+                           '((:inherit mu4e-header-value-face)))
   ;; special headers
   (face-remap-add-relative 'message-header-from
-    '((:inherit mu4e-contact-face)))
+                           '((:inherit mu4e-contact-face)))
   (face-remap-add-relative 'message-header-to
-    '((:inherit mu4e-contact-face)))
+                           '((:inherit mu4e-contact-face)))
   (face-remap-add-relative 'message-header-cc
-    '((:inherit mu4e-contact-face)))
+                           '((:inherit mu4e-contact-face)))
   (face-remap-add-relative 'message-header-bcc
-    '((:inherit mu4e-contact-face)))
+                           '((:inherit mu4e-contact-face)))
   (face-remap-add-relative 'message-header-subject
-    '((:inherit mu4e-special-header-value-face)))
+                           '((:inherit mu4e-special-header-value-face)))
   ;; citation
   (face-remap-add-relative 'message-cited-text
-    '((:inherit mu4e-cited-1-face))))
+                           '((:inherit mu4e-cited-1-face))))
 
 (define-derived-mode mu4e-compose-mode message-mode "mu4e:compose"
   "Major mode for the mu4e message composition, derived from `message-mode'.
@@ -465,68 +465,68 @@ buffers; lets remap its faces so it uses the ones for mu4e."
     ;; offer completion for e-mail addresses
     (when mu4e-compose-complete-addresses
       (unless mu4e~contacts   ;; work-around for https://github.com/djcb/mu/issues/1016
-  (mu4e~request-contacts-maybe))
+        (mu4e~request-contacts-maybe))
       (mu4e~compose-setup-completion))
     (if mu4e-compose-format-flowed
-  (progn
-    (turn-off-auto-fill)
-    (setq truncate-lines nil
-    word-wrap t
-    mml-enable-flowed t
-    use-hard-newlines t)
-    (visual-line-mode t))
+        (progn
+          (turn-off-auto-fill)
+          (setq truncate-lines nil
+                word-wrap t
+                mml-enable-flowed t
+                use-hard-newlines t)
+          (visual-line-mode t))
       (setq mml-enable-flowed nil))
 
     (let ((keymap (lookup-key message-mode-map [menu-bar text])))
       (when keymap
-  (define-key-after
-    keymap
-    [mu4e-hard-newlines]
-    '(menu-item "Format=flowed" mu4e-toggle-use-hard-newlines
-          :button (:toggle . use-hard-newlines)
-          :help "Toggle format=flowed"
-          :visible (eq major-mode 'mu4e-compose-mode)
-          :enable mu4e-compose-format-flowed)
-    'sep)
+        (define-key-after
+          keymap
+          [mu4e-hard-newlines]
+          '(menu-item "Format=flowed" mu4e-toggle-use-hard-newlines
+                      :button (:toggle . use-hard-newlines)
+                      :help "Toggle format=flowed"
+                      :visible (eq major-mode 'mu4e-compose-mode)
+                      :enable mu4e-compose-format-flowed)
+          'sep)
 
-  (define-key-after
-    keymap
-    [mu4e-electric-quote-mode]
-    '(menu-item "Electric quote" electric-quote-local-mode
-          :button (:toggle . electric-quote-mode)
-          :help "Toggle Electric quote mode"
-          :visible (and (eq major-mode 'mu4e-compose-mode)
-            (functionp 'electric-quote-local-mode)))
-    'mu4e-hard-newlines)))
+        (define-key-after
+          keymap
+          [mu4e-electric-quote-mode]
+          '(menu-item "Electric quote" electric-quote-local-mode
+                      :button (:toggle . electric-quote-mode)
+                      :help "Toggle Electric quote mode"
+                      :visible (and (eq major-mode 'mu4e-compose-mode)
+                                    (functionp 'electric-quote-local-mode)))
+          'mu4e-hard-newlines)))
 
     (when (lookup-key mml-mode-map [menu-bar Attachments])
       (define-key-after
-  (lookup-key mml-mode-map [menu-bar Attachments])
-  [mu4e-compose-attach-captured-message]
-  '(menu-item "Attach captured message"
-     mu4e-compose-attach-captured-message
-     :help "Attach message captured in Headers View (with 'a c')"
-     :visible (eq major-mode 'mu4e-compose-mode))
-  (quote Attach\ External...)))
+        (lookup-key mml-mode-map [menu-bar Attachments])
+        [mu4e-compose-attach-captured-message]
+        '(menu-item "Attach captured message"
+                    mu4e-compose-attach-captured-message
+                    :help "Attach message captured in Headers View (with 'a c')"
+                    :visible (eq major-mode 'mu4e-compose-mode))
+        (quote Attach\ External...)))
 
     ;; setup the fcc-stuff, if needed
     (add-hook 'message-send-hook
-      (lambda () ;; mu4e~compose-save-before-sending
-  ;; when in-reply-to was removed, remove references as well.
-  (when (eq mu4e-compose-type 'reply)
-    (mu4e~remove-refs-maybe))
-  (when use-hard-newlines
-    (mu4e-send-harden-newlines))
-  ;; for safety, always save the draft before sending
-  (set-buffer-modified-p t)
-  (save-buffer)
-  (mu4e~compose-setup-fcc-maybe)
-  (widen)) nil t)
+              (lambda () ;; mu4e~compose-save-before-sending
+                ;; when in-reply-to was removed, remove references as well.
+                (when (eq mu4e-compose-type 'reply)
+                  (mu4e~remove-refs-maybe))
+                (when use-hard-newlines
+                  (mu4e-send-harden-newlines))
+                ;; for safety, always save the draft before sending
+                (set-buffer-modified-p t)
+                (save-buffer)
+                (mu4e~compose-setup-fcc-maybe)
+                (widen)) nil t)
     ;; when the message has been sent.
     (add-hook 'message-sent-hook
-      (lambda () ;;  mu4e~compose-mark-after-sending
-  (setq mu4e-sent-func 'mu4e-sent-handler)
-  (mu4e~proc-sent (buffer-file-name))) nil t))
+              (lambda () ;;  mu4e~compose-mark-after-sending
+                (setq mu4e-sent-func 'mu4e-sent-handler)
+                (mu4e~proc-sent (buffer-file-name))) nil t))
   ;; mark these two hooks as permanent-local, so they'll survive mode-changes
   ;;  (put 'mu4e~compose-save-before-sending 'permanent-local-hook t)
   (put 'mu4e~compose-mark-after-sending 'permanent-local-hook t))
@@ -544,17 +544,17 @@ buffers; lets remap its faces so it uses the ones for mu4e."
 (defun mu4e~compose-set-friendly-buffer-name (&optional compose-type)
   "Set some user-friendly buffer name based on the COMPOSE-TYPE."
   (let* ((subj (message-field-value "subject"))
-    (subj (unless (and subj (string-match "^[:blank:]*$" subj)) subj))
-    (str (or subj
-     (cl-case compose-type
-       (reply       "*reply*")
-       (forward     "*forward*")
-       (otherwise   "*draft*")))))
+         (subj (unless (and subj (string-match "^[:blank:]*$" subj)) subj))
+         (str (or subj
+                  (cl-case compose-type
+                    (reply       "*reply*")
+                    (forward     "*forward*")
+                    (otherwise   "*draft*")))))
     (rename-buffer (generate-new-buffer-name
-         (truncate-string-to-width str
-           mu4e~compose-buffer-max-name-length
-           nil nil t)
-         (buffer-name)))))
+                    (truncate-string-to-width str
+                                              mu4e~compose-buffer-max-name-length
+                                              nil nil t)
+                    (buffer-name)))))
 
 (defun mu4e~compose-crypto-reply (parent compose-type)
   "Possibly encrypt or sign a message based on PARENT and COMPOSE-TYPE.
@@ -562,17 +562,17 @@ When composing a reply to an encrypted message, we can
 automatically encrypt that reply. When the message is unencrypted,
 we can decide what we want to do."
   (if (and  (eq compose-type 'reply)
-    (and parent (member 'encrypted (mu4e-message-field parent :flags))))
-  (cl-case mu4e-compose-crypto-reply-encrypted-policy
-    (sign (mml-secure-message-sign))
-    (encrypt (mml-secure-message-encrypt))
-    (sign-and-encrypt (mml-secure-message-sign-encrypt))
-    (message "Do nothing"))
-  (cl-case mu4e-compose-crypto-reply-plain-policy
-    (sign (mml-secure-message-sign))
-    (encrypt (mml-secure-message-encrypt))
-    (sign-and-encrypt (mml-secure-message-sign-encrypt))
-    (message "Do nothing")))
+            (and parent (member 'encrypted (mu4e-message-field parent :flags))))
+      (cl-case mu4e-compose-crypto-reply-encrypted-policy
+        (sign (mml-secure-message-sign))
+        (encrypt (mml-secure-message-encrypt))
+        (sign-and-encrypt (mml-secure-message-sign-encrypt))
+        (message "Do nothing"))
+    (cl-case mu4e-compose-crypto-reply-plain-policy
+      (sign (mml-secure-message-sign))
+      (encrypt (mml-secure-message-encrypt))
+      (sign-and-encrypt (mml-secure-message-sign-encrypt))
+      (message "Do nothing")))
   )
 
 
@@ -599,21 +599,21 @@ tempfile)."
   ;; message being forwarded or replied to, otherwise it is nil.
   (set (make-local-variable 'mu4e-compose-parent-message) original-msg)
   (put 'mu4e-compose-parent-message 'permanent-local t)
-    ;; remember the compose-type
+  ;; remember the compose-type
   (set (make-local-variable 'mu4e-compose-type) compose-type)
   (put 'mu4e-compose-type 'permanent-local t)
   ;; maybe switch the context
   (mu4e~context-autoswitch mu4e-compose-parent-message
-    mu4e-compose-context-policy)
+                           mu4e-compose-context-policy)
   (run-hooks 'mu4e-compose-pre-hook)
 
   ;; this opens (or re-opens) a messages with all the basic headers set.
   (let ((winconf (current-window-configuration)))
     (condition-case nil
-      (mu4e-draft-open compose-type original-msg)
+        (mu4e-draft-open compose-type original-msg)
       (quit (set-window-configuration winconf)
-  (mu4e-message "Operation aborted")
-  (cl-return-from mu4e~compose-handler))))
+            (mu4e-message "Operation aborted")
+            (cl-return-from mu4e~compose-handler))))
   ;; insert mail-header-separator, which is needed by message mode to separate
   ;; headers and body. will be removed before saving to disk
   (mu4e~draft-insert-mail-header-separator)
@@ -625,23 +625,23 @@ tempfile)."
     (goto-char (point-max)) ;; put attachments at the end
 
     (if (and (eq compose-type 'forward) mu4e-compose-forward-as-attachment)
-  (mu4e-compose-attach-message original-msg)
+        (mu4e-compose-attach-message original-msg)
       (dolist (att includes)
-  (mml-attach-file
-   (plist-get att :file-name) (plist-get att :mime-type)))))
+        (mml-attach-file
+         (plist-get att :file-name) (plist-get att :mime-type)))))
 
   (mu4e~compose-set-friendly-buffer-name compose-type)
 
   ;; now jump to some useful positions, and start writing that mail!
   (if (member compose-type '(new forward))
-    (message-goto-to)
+      (message-goto-to)
     ;; otherwise, it depends...
     (cl-case message-cite-reply-position
       ((above traditional)
-  (message-goto-body))
+       (message-goto-body))
       (t
-  (when (message-goto-signature)
-    (forward-line -2)))))
+       (when (message-goto-signature)
+         (forward-line -2)))))
 
   ;; bind to `mu4e-compose-parent-message' of compose buffer
   (set (make-local-variable 'mu4e-compose-parent-message) original-msg)
@@ -670,11 +670,11 @@ tempfile)."
   "Try to go back to some previous buffer, in the order view->headers->main."
   (unless (eq mu4e-split-view 'single-window)
     (if (buffer-live-p (mu4e-get-view-buffer))
-  (switch-to-buffer (mu4e-get-view-buffer))
+        (switch-to-buffer (mu4e-get-view-buffer))
       (if (buffer-live-p (mu4e-get-headers-buffer))
-    (switch-to-buffer (mu4e-get-headers-buffer))
-  ;; if all else fails, back to the main view
-  (when (fboundp 'mu4e) (mu4e))))))
+          (switch-to-buffer (mu4e-get-headers-buffer))
+        ;; if all else fails, back to the main view
+        (when (fboundp 'mu4e) (mu4e))))))
 
 (defun mu4e-sent-handler (docid path)
   "Handler called with DOCID and PATH for the just-sent message.
@@ -687,9 +687,9 @@ appropriate flag at the message forwarded or replied-to."
   ;; this seems a bit hamfisted...
   (dolist (buf (buffer-list))
     (when (and (buffer-file-name buf)
-      (string= (buffer-file-name buf) path))
+               (string= (buffer-file-name buf) path))
       (if message-kill-buffer-on-exit
-    (kill-buffer buf))))
+          (kill-buffer buf))))
   (mu4e~switch-back-to-mu4e-buffer)
   (mu4e-message "Message sent"))
 
@@ -703,8 +703,8 @@ It restores mu4e window layout after killing the compose-buffer."
     (when (not (equal current-buffer (current-buffer)))
       ;; Restore mu4e
       (if mu4e-compose-in-new-frame
-    (delete-frame)
-  (mu4e~switch-back-to-mu4e-buffer)))))
+          (delete-frame)
+        (mu4e~switch-back-to-mu4e-buffer)))))
 
 (defun mu4e~compose-set-parent-flag (path)
   "Set flags for replied-t and forwarded for the message at PATH.
@@ -728,25 +728,25 @@ buffer."
   (let ((buf (find-file-noselect path)))
     (when buf
       (with-current-buffer buf
-  (message-narrow-to-headers-or-head)
-  (let ((in-reply-to (message-fetch-field "in-reply-to"))
-         (forwarded-from)
-         (references (message-fetch-field "references")))
-    (unless in-reply-to
-      (when references
-        (with-temp-buffer ;; inspired by `message-shorten-references'.
-    (insert references)
-    (goto-char (point-min))
-    (let ((refs))
-      (while (re-search-forward "<[^ <]+@[^ <]+>" nil t)
-        (push (match-string 0) refs))
-      ;; the last will be the first
-      (setq forwarded-from (cl-first refs))))))
-    ;; remove the <>
-    (when (and in-reply-to (string-match "<\\(.*\\)>" in-reply-to))
-      (mu4e~proc-move (match-string 1 in-reply-to) nil "+R-N"))
-    (when (and forwarded-from (string-match "<\\(.*\\)>" forwarded-from))
-      (mu4e~proc-move (match-string 1 forwarded-from) nil "+P-N")))))))
+        (message-narrow-to-headers-or-head)
+        (let ((in-reply-to (message-fetch-field "in-reply-to"))
+              (forwarded-from)
+              (references (message-fetch-field "references")))
+          (unless in-reply-to
+            (when references
+              (with-temp-buffer ;; inspired by `message-shorten-references'.
+                (insert references)
+                (goto-char (point-min))
+                (let ((refs))
+                  (while (re-search-forward "<[^ <]+@[^ <]+>" nil t)
+                    (push (match-string 0) refs))
+                  ;; the last will be the first
+                  (setq forwarded-from (cl-first refs))))))
+          ;; remove the <>
+          (when (and in-reply-to (string-match "<\\(.*\\)>" in-reply-to))
+            (mu4e~proc-move (match-string 1 in-reply-to) nil "+R-N"))
+          (when (and forwarded-from (string-match "<\\(.*\\)>" forwarded-from))
+            (mu4e~proc-move (match-string 1 forwarded-from) nil "+P-N")))))))
 
 (defun mu4e-compose (compose-type)
   "Start composing a message of COMPOSE-TYPE.
@@ -760,31 +760,31 @@ Symbol `edit' is only allowed for draft messages."
     (unless (member compose-type '(reply forward edit resend new))
       (mu4e-error "Invalid compose type '%S'" compose-type))
     (when (and (eq compose-type 'edit)
-      (not (member 'draft (mu4e-message-field msg :flags))))
+               (not (member 'draft (mu4e-message-field msg :flags))))
       (mu4e-warn "Editing is only allowed for draft messages"))
 
     ;; 'new is special, since it takes no existing message as arg; therefore, we
     ;; don't need to involve the backend, and call the handler *directly*
     (if (eq compose-type 'new)
-      (mu4e~compose-handler 'new)
+        (mu4e~compose-handler 'new)
       ;; otherwise, we need the doc-id
       (let* ((docid (mu4e-message-field msg :docid))
-        ;; decrypt (or not), based on `mu4e-decryption-policy'.
-        (decrypt
-    (and (member 'encrypted (mu4e-message-field msg :flags))
-      (if (eq mu4e-decryption-policy 'ask)
-        (yes-or-no-p (mu4e-format "Decrypt message?"))
-        mu4e-decryption-policy))))
-  ;; if there's a visible view window, select that before starting
-  ;; composing a new message, so that one will be replaced by the compose
-  ;; window. The 10-or-so line headers buffer is not a good place to write
-  ;; it...
-  (unless (eq mu4e-split-view 'single-window)
-    (let ((viewwin (get-buffer-window (mu4e-get-view-buffer))))
-      (when (window-live-p viewwin)
-        (select-window viewwin))))
-  ;; talk to the backend
-  (mu4e~proc-compose compose-type decrypt docid)))))
+             ;; decrypt (or not), based on `mu4e-decryption-policy'.
+             (decrypt
+              (and (member 'encrypted (mu4e-message-field msg :flags))
+                   (if (eq mu4e-decryption-policy 'ask)
+                       (yes-or-no-p (mu4e-format "Decrypt message?"))
+                     mu4e-decryption-policy))))
+        ;; if there's a visible view window, select that before starting
+        ;; composing a new message, so that one will be replaced by the compose
+        ;; window. The 10-or-so line headers buffer is not a good place to write
+        ;; it...
+        (unless (eq mu4e-split-view 'single-window)
+          (let ((viewwin (get-buffer-window (mu4e-get-view-buffer))))
+            (when (window-live-p viewwin)
+              (select-window viewwin))))
+        ;; talk to the backend
+        (mu4e~proc-compose compose-type decrypt docid)))))
 
 (defun mu4e-compose-reply ()
   "Compose a reply for the message at point in the headers buffer."
@@ -820,7 +820,7 @@ draft message."
 
 ;;;###autoload
 (defun mu4e~compose-mail (&optional to subject other-headers _continue
-         _switch-function yank-action _send-actions _return-action)
+                                    _switch-function yank-action _send-actions _return-action)
   "This is mu4e's implementation of `compose-mail'.
 Quoting its docstring:
 Start composing a mail message to send.
@@ -874,14 +874,14 @@ buffer buried."
 
   ;; yank message
   (if (bufferp yank-action)
-    (list 'insert-buffer yank-action)
+      (list 'insert-buffer yank-action)
     yank-action)
 
   ;; try to put the user at some reasonable spot...
   (if (not to)
-    (message-goto-to)
+      (message-goto-to)
     (if (not subject)
-      (message-goto-subject)
+        (message-goto-subject)
       (message-goto-body))))
 
 ;; happily, we can re-use most things from message mode
@@ -933,7 +933,7 @@ is supplied, or Transient Mark mode is enabled and the mark is active."
       (region-active-p)
       (push-mark))
   (let ((old-position (point))
-   (message-position (save-excursion (message-goto-body) (point))))
+        (message-position (save-excursion (message-goto-body) (point))))
     (goto-char (point-max))
     (when (re-search-backward message-signature-separator message-position t)
       (forward-line -1))

--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -1,4 +1,4 @@
-; mu4e-context.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
+;;; mu4e-context.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2015-2020 Dirk-Jan C. Binnema
 
@@ -49,16 +49,16 @@ none."
   (let ((ctx mu4e~context-current))
     (when output
       (mu4e-message "Current context: %s"
-	(if ctx (mu4e-context-name ctx) "<none>")))
+                    (if ctx (mu4e-context-name ctx) "<none>")))
     ctx))
 
 (defun mu4e-context-label ()
   "Propertized string with the current context name, or \"\" if
   there is none."
   (if (mu4e-context-current)
-    (concat "[" (propertize (mu4e~quote-for-modeline
-			      (mu4e-context-name (mu4e-context-current)))
-		  'face 'mu4e-context-face) "]") ""))
+      (concat "[" (propertize (mu4e~quote-for-modeline
+                               (mu4e-context-name (mu4e-context-current)))
+                              'face 'mu4e-context-face) "]") ""))
 
 (cl-defstruct mu4e-context
   "A mu4e context object with the following members:
@@ -194,9 +194,9 @@ default folders (see `make-mu4e-context' and `mu4e-context'):
   "Let user choose some context based on its name."
   (when mu4e-contexts
     (let* ((names (cl-map 'list (lambda (context)
-			       (cons (mu4e-context-name context) context))
-		    mu4e-contexts))
-	    (context (mu4e-read-option prompt names)))
+                                  (cons (mu4e-context-name context) context))
+                          mu4e-contexts))
+           (context (mu4e-read-option prompt names)))
       (or context (mu4e-error "No such context")))))
 
 (defun mu4e-context-switch (&optional force name)
@@ -210,25 +210,25 @@ non-nil."
   (unless mu4e-contexts
     (mu4e-error "No contexts defined"))
   (let* ((names (cl-map 'list (lambda (context)
-			     (cons (mu4e-context-name context) context))
-		  mu4e-contexts))
-	  (context
-	    (if name
-	      (cdr-safe (assoc name names))
-	      (mu4e~context-ask-user "Switch to context: "))))
+                                (cons (mu4e-context-name context) context))
+                        mu4e-contexts))
+         (context
+          (if name
+              (cdr-safe (assoc name names))
+            (mu4e~context-ask-user "Switch to context: "))))
     (unless context (mu4e-error "No such context"))
     ;; if new context is same as old one one switch with FORCE is set.
     (when (or force (not (eq context (mu4e-context-current))))
       (when (and (mu4e-context-current)
-	      (mu4e-context-leave-func mu4e~context-current))
-	(funcall (mu4e-context-leave-func mu4e~context-current)))
+                 (mu4e-context-leave-func mu4e~context-current))
+        (funcall (mu4e-context-leave-func mu4e~context-current)))
       ;; enter the new context
       (when (mu4e-context-enter-func context)
-	(funcall (mu4e-context-enter-func context)))
+        (funcall (mu4e-context-enter-func context)))
       (when (mu4e-context-vars context)
-	(mapc (lambda (cell)
-		  (set (car cell) (cdr cell)))
-	  (mu4e-context-vars context)))
+        (mapc (lambda (cell)
+                (set (car cell) (cdr cell)))
+              (mu4e-context-vars context)))
       (setq mu4e~context-current context)
 
       (run-hooks 'mu4e-context-changed-hook)
@@ -242,7 +242,7 @@ match, return the first. For MSG and POLICY, see `mu4e-context-determine'."
   (when (and mu4e-contexts (not mu4e~context-current))
     (let ((context (mu4e-context-determine msg policy)))
       (when context (mu4e-context-switch
-		      nil (mu4e-context-name context))))))
+                     nil (mu4e-context-name context))))))
 
 (defun mu4e-context-determine (msg &optional policy)
   "Return the first context with a match-func that returns t. MSG
@@ -263,18 +263,18 @@ match, POLICY determines what to do:
 - otherwise, return nil. Effectively, this leaves the current context as it is."
   (when mu4e-contexts
     (if (eq policy 'always-ask)
-      (mu4e~context-ask-user "Select context: ")
+        (mu4e~context-ask-user "Select context: ")
       (or ;; is there a matching one?
-	(cl-find-if (lambda (context)
-		     (when (mu4e-context-match-func context)
-		       (funcall (mu4e-context-match-func context) msg)))
-	  mu4e-contexts)
-	;; no context found yet; consult policy
-	(cl-case policy
-	  (pick-first (car mu4e-contexts))
-	  (ask (mu4e~context-ask-user "Select context: "))
-	  (ask-if-none (or (mu4e-context-current)
-			 (mu4e~context-ask-user "Select context: ")))
-	  (otherwise nil))))))
+       (cl-find-if (lambda (context)
+                     (when (mu4e-context-match-func context)
+                       (funcall (mu4e-context-match-func context) msg)))
+                   mu4e-contexts)
+       ;; no context found yet; consult policy
+       (cl-case policy
+         (pick-first (car mu4e-contexts))
+         (ask (mu4e~context-ask-user "Select context: "))
+         (ask-if-none (or (mu4e-context-current)
+                          (mu4e~context-ask-user "Select context: ")))
+         (otherwise nil))))))
 
 (provide 'mu4e-context)

--- a/mu4e/mu4e-contrib.el
+++ b/mu4e/mu4e-contrib.el
@@ -61,13 +61,13 @@
 ;; Probably this can be moved to mu4e-view.el.
 (add-hook 'mu4e-view-mode-hook
           (lambda ()
-              (set (make-local-variable 'bookmark-make-record-function)
-                   'mu4e-view-bookmark-make-record)))
+            (set (make-local-variable 'bookmark-make-record-function)
+                 'mu4e-view-bookmark-make-record)))
 ;; And this can be moved to mu4e-headers.el.
 (add-hook 'mu4e-headers-mode-hook
           (lambda ()
-              (set (make-local-variable 'bookmark-make-record-function)
-                   'mu4e-view-bookmark-make-record)))
+            (set (make-local-variable 'bookmark-make-record-function)
+                 'mu4e-view-bookmark-make-record)))
 
 (defun mu4e-view-bookmark-make-record ()
   "Make a bookmark entry for a mu4e buffer. Note that this is an
@@ -81,9 +81,9 @@ emacs bookmark, not to be confused with `mu4e-bookmarks'."
          (subject (or (plist-get msg :subject) "No subject")))
     `(,subject
       ,@(bookmark-make-record-default 'no-file 'no-context)
-        (location . (,query . ,docid))
-        (mode . ,mode)
-        (handler . mu4e-bookmark-jump))))
+      (location . (,query . ,docid))
+      (mode . ,mode)
+      (handler . mu4e-bookmark-jump))))
 
 (defun mu4e-bookmark-jump (bookmark)
   "Handler function for record returned by `mu4e-view-bookmark-make-record'.
@@ -102,8 +102,8 @@ BOOKMARK is a bookmark name or a bookmark record."
       (run-with-timer 0.1 nil
                       (lambda (bmk)
                         (bookmark-default-handler
-			  `("" (buffer . ,(current-buffer)) .
-			     ,(bookmark-get-bookmark-record bmk))))
+                         `("" (buffer . ,(current-buffer)) .
+                           ,(bookmark-get-bookmark-record bmk))))
                       bookmark))))
 
 
@@ -132,7 +132,7 @@ For example for bogofile, use \"/usr/bin/bogofilter -Sn < %s\"")
   (let* ((path (shell-quote-argument (mu4e-message-field msg :path)))
          (command (format mu4e-register-as-spam-cmd path))) ;; re-register msg as spam
     (shell-command command))
-(mu4e-mark-at-point 'delete nil))
+  (mu4e-mark-at-point 'delete nil))
 
 (defun mu4e-register-msg-as-ham (msg)
   "Mark message as ham."
@@ -140,7 +140,7 @@ For example for bogofile, use \"/usr/bin/bogofilter -Sn < %s\"")
   (let* ((path (shell-quote-argument(mu4e-message-field msg :path)))
          (command (format mu4e-register-as-ham-cmd path))) ;; re-register msg as ham
     (shell-command command))
-(mu4e-mark-at-point 'something nil))
+  (mu4e-mark-at-point 'something nil))
 
 ;; (add-to-list 'mu4e-view-actions
 ;;              '("sMark as spam" . mu4e-view-register-msg-as-spam) t)
@@ -178,8 +178,8 @@ buffers found, compose a new message and then attach the file."
         (files-to-attach
          (delq nil (mapcar
                     (lambda (f) (if (or (not (file-exists-p f)) (file-directory-p f))
-                                    nil
-                                  (expand-file-name f)))
+                               nil
+                             (expand-file-name f)))
                     (eshell-flatten-list (reverse args))))))
     ;; warn if user tries to attach without any files marked
     (if (null files-to-attach)
@@ -205,7 +205,7 @@ buffers found, compose a new message and then attach the file."
       ;; if buffer was found, set buffer to destination buffer, and attach files
       (if (not (eq destination 'nil))
           (progn (set-buffer destination)
-                 (goto-char (point-max))		;attach at end of buffer
+                 (goto-char (point-max)) ; attach at end of buffer
                  (while files-to-attach
                    (mml-attach-file (car files-to-attach)
                                     (or (mm-default-file-encoding (car files-to-attach))

--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -56,9 +56,9 @@ This is the mu4e-specific version of
 \(i.e. the blob at the bottom of messages). This is the
 mu4e-specific version of `message-signature'."
   :type '(choice string
-           (const :tag "None" nil)
-           (const :tag "Contents of signature file" t)
-           function sexp)
+                 (const :tag "None" nil)
+                 (const :tag "Contents of signature file" t)
+                 function sexp)
   :risky t
   :group 'mu4e-compose)
 
@@ -68,7 +68,7 @@ mu4e-specific version of `message-signature'."
   :group 'mu4e-compose)
 
 (make-obsolete-variable 'mu4e-compose-auto-include-date
-  "This is done unconditionally now" "1.3.5")
+                        "This is done unconditionally now" "1.3.5")
 
 (defcustom mu4e-compose-in-new-frame nil
   "Whether to compose messages in a new frame."
@@ -95,7 +95,7 @@ its settings apply."
       ;; set the the signature separator to 'loose', since in the real world,
       ;; many message don't follow the standard...
       (let ((message-signature-separator "^-- *$")
-             (message-signature-insert-empty-line t))
+            (message-signature-insert-empty-line t))
         (funcall mu4e-compose-cite-function))
       (pop-mark)
       (goto-char (point-min))
@@ -107,8 +107,8 @@ If VAL is nil, return nil."
   ;; note: the propertize here is currently useless, since gnus sets its own
   ;; later.
   (when val (format "%s: %s\n"
-              (propertize hdr 'face 'mu4e-header-key-face)
-              (propertize val 'face 'mu4e-header-value-face))))
+                    (propertize hdr 'face 'mu4e-header-key-face)
+                    (propertize val 'face 'mu4e-header-value-face))))
 
 (defconst mu4e~max-reference-num 21
   "Specifies the maximum number of References:.
@@ -119,7 +119,7 @@ As suggested by `message-shorten-references'.")
 Beginning with CUTth
 one. Code borrowed from `message-shorten-1'."
   (setcdr (nthcdr (- cut 2) list)
-    (nthcdr (+ (- cut 2) surplus 1) list)))
+          (nthcdr (+ (- cut 2) surplus 1) list)))
 
 (defun mu4e~draft-references-construct (msg)
   "Construct the value of the References: header based on MSG.
@@ -129,15 +129,15 @@ that :references includes the old in-reply-to as well) and the
 message-id. If the message-id is empty, returns the old
 References. If both are empty, return nil."
   (let* ( ;; these are the ones from the message being replied to / forwarded
-          (refs (mu4e-message-field msg :references))
-          (msgid (mu4e-message-field msg :message-id))
-          ;; now, append in
-          (refs (if (and msgid (not (string= msgid "")))
-                  (append refs (list msgid)) refs))
-          ;; no doubles
-          (refs (cl-delete-duplicates refs :test #'equal))
-          (refnum (length refs))
-          (cut 2))
+         (refs (mu4e-message-field msg :references))
+         (msgid (mu4e-message-field msg :message-id))
+         ;; now, append in
+         (refs (if (and msgid (not (string= msgid "")))
+                   (append refs (list msgid)) refs))
+         ;; no doubles
+         (refs (cl-delete-duplicates refs :test #'equal))
+         (refnum (length refs))
+         (cut 2))
     ;; remove some refs when there are too many
     (when (> refnum mu4e~max-reference-num)
       (let ((surplus (- refnum mu4e~max-reference-num)))
@@ -154,13 +154,13 @@ This is specified as a comma-separated list of e-mail addresses.
 If LST is nil, returns nil."
   (when lst
     (mapconcat
-      (lambda (addrcell)
-        (let ((name (car addrcell))
-               (email (cdr addrcell)))
-          (if name
-            (format "%s <%s>" (mu4e~rfc822-quoteit name) email)
-            (format "%s" email))))
-      lst ", ")))
+     (lambda (addrcell)
+       (let ((name (car addrcell))
+             (email (cdr addrcell)))
+         (if name
+             (format "%s <%s>" (mu4e~rfc822-quoteit name) email)
+           (format "%s" email))))
+     lst ", ")))
 
 (defun mu4e~draft-address-cell-equal (cell1 cell2)
   "Return t if CELL1 and CELL2 have the same e-mail address.
@@ -168,8 +168,8 @@ The comparison is done case-insensitively. If the cells done
 match return nil. CELL1 and CELL2 are cons cells of the
 form (NAME . EMAIL)."
   (string=
-    (downcase (or (cdr cell1) ""))
-    (downcase (or (cdr cell2) ""))))
+   (downcase (or (cdr cell1) ""))
+   (downcase (or (cdr cell2) ""))))
 
 
 (defun mu4e~draft-create-to-lst (origmsg)
@@ -180,16 +180,16 @@ whatever was in the To: field before, goes to the Cc:-list (if
 we're doing a reply-to-all). Special case: if we were the sender
 of the original, we simple copy the list form the original."
   (let ((reply-to
-          (or (plist-get origmsg :reply-to) (plist-get origmsg :from))))
+         (or (plist-get origmsg :reply-to) (plist-get origmsg :from))))
     (cl-delete-duplicates reply-to :test #'mu4e~draft-address-cell-equal)
     (if mu4e-compose-dont-reply-to-self
-      (cl-delete-if
-        (lambda (to-cell)
-          (cl-member-if
+        (cl-delete-if
+         (lambda (to-cell)
+           (cl-member-if
             (lambda (addr)
               (string= (downcase addr) (downcase (cdr to-cell))))
             (mu4e-personal-addresses)))
-        reply-to)
+         reply-to)
       reply-to)))
 
 
@@ -198,24 +198,24 @@ of the original, we simple copy the list form the original."
 I.e. return all the addresses in ADDRS not matching
 `mu4e-compose-reply-ignore-address'."
   (cond
-    ((null mu4e-compose-reply-ignore-address)
-      addrs)
-    ((functionp mu4e-compose-reply-ignore-address)
+   ((null mu4e-compose-reply-ignore-address)
+    addrs)
+   ((functionp mu4e-compose-reply-ignore-address)
+    (cl-remove-if
+     (lambda (elt)
+       (funcall mu4e-compose-reply-ignore-address (cdr elt)))
+     addrs))
+   (t
+    ;; regexp or list of regexps
+    (let* ((regexp mu4e-compose-reply-ignore-address)
+           (regexp (if (listp regexp)
+                       (mapconcat (lambda (elt) (concat "\\(" elt "\\)"))
+                                  regexp "\\|")
+                     regexp)))
       (cl-remove-if
-        (lambda (elt)
-          (funcall mu4e-compose-reply-ignore-address (cdr elt)))
-        addrs))
-    (t
-      ;; regexp or list of regexps
-      (let* ((regexp mu4e-compose-reply-ignore-address)
-              (regexp (if (listp regexp)
-                        (mapconcat (lambda (elt) (concat "\\(" elt "\\)"))
-                          regexp "\\|")
-                        regexp)))
-        (cl-remove-if
-          (lambda (elt)
-            (string-match regexp (cdr elt)))
-          addrs)))))
+       (lambda (elt)
+         (string-match regexp (cdr elt)))
+       addrs)))))
 
 (defun mu4e~draft-create-cc-lst (origmsg &optional reply-all include-from)
   "Create a list of address for the Cc: in a new message.
@@ -223,37 +223,37 @@ This is based on the original message ORIGMSG, and whether it's a
 REPLY-ALL."
   (when reply-all
     (let* ((cc-lst ;; get the cc-field from the original, remove dups
-             (cl-delete-duplicates
-               (append
-                 (plist-get origmsg :to)
-                 (plist-get origmsg :cc)
-                 (when include-from(plist-get origmsg :from))
-                 (plist-get origmsg :list-post))
-               :test #'mu4e~draft-address-cell-equal))
-            ;; now we have the basic list, but we must remove
-            ;; addresses also in the To: list
-            (cc-lst
-              (cl-delete-if
-                (lambda (cc-cell)
-                  (cl-find-if
-                    (lambda (to-cell)
-                      (mu4e~draft-address-cell-equal cc-cell to-cell))
-                    (mu4e~draft-create-to-lst origmsg)))
-                cc-lst))
-            ;; remove ignored addresses
-            (cc-lst (mu4e~strip-ignored-addresses cc-lst))
-            ;; finally, we need to remove ourselves from the cc-list
-            ;; unless mu4e-compose-keep-self-cc is non-nil
-            (cc-lst
-              (if (or mu4e-compose-keep-self-cc (null user-mail-address))
+            (cl-delete-duplicates
+             (append
+              (plist-get origmsg :to)
+              (plist-get origmsg :cc)
+              (when include-from(plist-get origmsg :from))
+              (plist-get origmsg :list-post))
+             :test #'mu4e~draft-address-cell-equal))
+           ;; now we have the basic list, but we must remove
+           ;; addresses also in the To: list
+           (cc-lst
+            (cl-delete-if
+             (lambda (cc-cell)
+               (cl-find-if
+                (lambda (to-cell)
+                  (mu4e~draft-address-cell-equal cc-cell to-cell))
+                (mu4e~draft-create-to-lst origmsg)))
+             cc-lst))
+           ;; remove ignored addresses
+           (cc-lst (mu4e~strip-ignored-addresses cc-lst))
+           ;; finally, we need to remove ourselves from the cc-list
+           ;; unless mu4e-compose-keep-self-cc is non-nil
+           (cc-lst
+            (if (or mu4e-compose-keep-self-cc (null user-mail-address))
                 cc-lst
-                (cl-delete-if
-                  (lambda (cc-cell)
-                    (cl-member-if
-                      (lambda (addr)
-                        (string= (downcase addr) (downcase (cdr cc-cell))))
-                      (mu4e-personal-addresses)))
-                  cc-lst))))
+              (cl-delete-if
+               (lambda (cc-cell)
+                 (cl-member-if
+                  (lambda (addr)
+                    (string= (downcase addr) (downcase (cdr cc-cell))))
+                  (mu4e-personal-addresses)))
+               cc-lst))))
       cc-lst)))
 
 (defun mu4e~draft-recipients-construct (field origmsg &optional reply-all include-from)
@@ -262,13 +262,13 @@ REPLY-ALL."
 and (optionally) REPLY-ALL which indicates this is a reply-to-all
 message. Return nil if there are no recipients for the particular field."
   (mu4e~draft-recipients-list-to-string
-    (cl-case field
-      (:to
-        (mu4e~draft-create-to-lst origmsg))
-      (:cc
-        (mu4e~draft-create-cc-lst origmsg reply-all include-from))
-      (otherwise
-        (mu4e-error "Unsupported field")))))
+   (cl-case field
+     (:to
+      (mu4e~draft-create-to-lst origmsg))
+     (:cc
+      (mu4e~draft-create-cc-lst origmsg reply-all include-from))
+     (otherwise
+      (mu4e-error "Unsupported field")))))
 
 ;;; RFC2822 handling of phrases in mail-addresses
 ;;; The optional display-name contains a phrase, it sits before the angle-addr
@@ -284,14 +284,14 @@ The reverse of the RFC atext definition is then tested.
 If it matches, nil is returned, if not, it is an 'rfc822-atom, which
 is returned."
   (cond
-    ((= (length ph) 0) 'rfc822-empty)
-    ((= (aref ph 0) ?\")
-      (if (string-match "\"\\([^\"\\\n]\\|\\\\.\\|\\\\\n\\)*\"" ph)
+   ((= (length ph) 0) 'rfc822-empty)
+   ((= (aref ph 0) ?\")
+    (if (string-match "\"\\([^\"\\\n]\\|\\\\.\\|\\\\\n\\)*\"" ph)
         'rfc822-quoted-string
-        'rfc822-containing-quote)) ; starts with quote, but doesn't end with one
-    ((string-match-p "[\"]" ph) 'rfc822-containing-quote)
-    ((string-match-p "[\000-\037()\*<>@,;:\\\.]+" ph) nil)
-    (t 'rfc822-atom)))
+      'rfc822-containing-quote)) ; starts with quote, but doesn't end with one
+   ((string-match-p "[\"]" ph) 'rfc822-containing-quote)
+   ((string-match-p "[\000-\037()\*<>@,;:\\\.]+" ph) nil)
+   (t 'rfc822-atom)))
 
 (defun mu4e~rfc822-quoteit (ph)
   "Quote an RFC822 phrase PH only if necessary.
@@ -299,12 +299,12 @@ Atoms and quoted strings don't need quotes. The rest do.  In
 case a phrase contains a quote, it will be escaped."
   (let ((type (mu4e~rfc822-phrase-type ph)))
     (cond
-      ((eq type 'rfc822-atom) ph)
-      ((eq type 'rfc822-quoted-string) ph)
-      ((eq type 'rfc822-containing-quote)
-        (format "\"%s\""
-          (replace-regexp-in-string "\"" "\\\\\"" ph)))
-      (t (format "\"%s\"" ph)))))
+     ((eq type 'rfc822-atom) ph)
+     ((eq type 'rfc822-quoted-string) ph)
+     ((eq type 'rfc822-containing-quote)
+      (format "\"%s\""
+              (replace-regexp-in-string "\"" "\\\\\"" ph)))
+     (t (format "\"%s\"" ph)))))
 
 
 (defun mu4e~draft-from-construct ()
@@ -313,7 +313,7 @@ This is based on the variable `user-full-name' and
 `user-mail-address'; if the latter is nil, function returns nil."
   (when user-mail-address
     (if user-full-name
-      (format "%s <%s>" (mu4e~rfc822-quoteit user-full-name) user-mail-address)
+        (format "%s <%s>" (mu4e~rfc822-quoteit user-full-name) user-mail-address)
       (format "%s" user-mail-address))))
 
 
@@ -333,23 +333,23 @@ separator is never written to the message file. Also see
     ;; make sure there's not one already
     (mu4e~draft-remove-mail-header-separator)
     (let ((sepa (propertize mail-header-separator
-                  'intangible t
-                  ;; don't make this read-only, message-mode
-                  ;; seems to require it being writable in some cases
-                  ;;'read-only "Can't touch this"
-                  'rear-nonsticky t
-                  'font-lock-face 'mu4e-compose-separator-face)))
+                            'intangible t
+                            ;; don't make this read-only, message-mode
+                            ;; seems to require it being writable in some cases
+                            ;;'read-only "Can't touch this"
+                            'rear-nonsticky t
+                            'font-lock-face 'mu4e-compose-separator-face)))
       (widen)
       ;; search for the first empty line
       (goto-char (point-min))
       (if (search-forward-regexp "^$" nil t)
-        (progn
-          (replace-match sepa)
-          ;; `message-narrow-to-headers` searches for a
-          ;; `mail-header-separator` followed by a new line. Therefore, we
-          ;; must insert a newline if on the last line of the buffer.
-          (when (= (point) (point-max))
-            (insert "\n")))
+          (progn
+            (replace-match sepa)
+            ;; `message-narrow-to-headers` searches for a
+            ;; `mail-header-separator` followed by a new line. Therefore, we
+            ;; must insert a newline if on the last line of the buffer.
+            (when (= (point) (point-max))
+              (insert "\n")))
         (progn ;; no empty line? then prepend one
           (goto-char (point-max))
           (insert "\n" sepa))))))
@@ -372,15 +372,15 @@ never hits the disk. Also see
   "Ask user whether she wants to reply to *all* recipients.
 If there is just one recipient of ORIGMSG do nothing."
   (let* ((recipnum
-           (+ (length (mu4e~draft-create-to-lst origmsg))
+          (+ (length (mu4e~draft-create-to-lst origmsg))
              (length (mu4e~draft-create-cc-lst origmsg t))))
-          (response
-            (if (< recipnum 2)
+         (response
+          (if (< recipnum 2)
               'all ;; with less than 2 recipients, we can reply to 'all'
-              (mu4e-read-option
-                "Reply to "
-                `( (,(format "all %d recipients" recipnum) . all)
-                   ("sender only" . sender-only))))))
+            (mu4e-read-option
+             "Reply to "
+             `( (,(format "all %d recipients" recipnum) . all)
+                ("sender only" . sender-only))))))
     (eq response 'all)))
 
 (defun mu4e~draft-message-filename-construct (&optional flagstr)
@@ -389,25 +389,25 @@ It looks something like
   <time>-<random>.<hostname>:2,
 You can append flags."
   (let* ((sysname (if (fboundp 'system-name)
-                    (system-name)
+                      (system-name)
                     (with-no-warnings system-name)))
-          (sysname (if (string= sysname "") "localhost" sysname))
-          (hostname (downcase
-                      (save-match-data
-                        (substring sysname
-                          (string-match "^[^.]+" sysname)
-                          (match-end 0))))))
+         (sysname (if (string= sysname "") "localhost" sysname))
+         (hostname (downcase
+                    (save-match-data
+                      (substring sysname
+                                 (string-match "^[^.]+" sysname)
+                                 (match-end 0))))))
     (format "%s.%04x%04x%04x%04x.%s:2,%s"
-      (format-time-string "%s" (current-time))
-      (random 65535) (random 65535) (random 65535) (random 65535)
-      hostname (or flagstr ""))))
+            (format-time-string "%s" (current-time))
+            (random 65535) (random 65535) (random 65535) (random 65535)
+            hostname (or flagstr ""))))
 
 (defun mu4e~draft-common-construct ()
   "Construct the common headers for each message."
   (concat
-    (when mu4e-user-agent-string
-      (mu4e~draft-header "User-agent" mu4e-user-agent-string))
-    (mu4e~draft-header "Date" (message-make-date))))
+   (when mu4e-user-agent-string
+     (mu4e~draft-header "User-agent" mu4e-user-agent-string))
+   (mu4e~draft-header "Date" (message-make-date))))
 
 (defconst mu4e~draft-reply-prefix "Re: "
   "String to prefix replies with.")
@@ -415,81 +415,81 @@ You can append flags."
 (defun mu4e~draft-reply-construct-recipients (origmsg)
   "Determine the to/cc recipients for a reply message."
   (let* ((reply-to-self (mu4e-message-contact-field-matches-me origmsg :from))
-	        ;; reply-to-self implies reply-all
-	        (reply-all (or reply-to-self
-                       (eq mu4e-compose-reply-recipients 'all)
-                       (and (not (eq mu4e-compose-reply-recipients 'sender))
-                         (mu4e~draft-reply-all-p origmsg)))))
+         ;; reply-to-self implies reply-all
+         (reply-all (or reply-to-self
+                        (eq mu4e-compose-reply-recipients 'all)
+                        (and (not (eq mu4e-compose-reply-recipients 'sender))
+                             (mu4e~draft-reply-all-p origmsg)))))
     (concat
-      (if reply-to-self
-        ;; When we're replying to ourselves, simply keep the same headers.
-        (concat
+     (if reply-to-self
+         ;; When we're replying to ourselves, simply keep the same headers.
+         (concat
           (mu4e~draft-header "To" (mu4e~draft-recipients-list-to-string
-                                    (mu4e-message-field origmsg :to)))
+                                   (mu4e-message-field origmsg :to)))
           (mu4e~draft-header "Cc" (mu4e~draft-recipients-list-to-string
-                                    (mu4e-message-field origmsg :cc))))
+                                   (mu4e-message-field origmsg :cc))))
 
-        ;; if there's no-one in To, copy the CC-list
-        (if (zerop (length (mu4e~draft-create-to-lst origmsg)))
-          (mu4e~draft-header "To" (mu4e~draft-recipients-construct
+       ;; if there's no-one in To, copy the CC-list
+       (if (zerop (length (mu4e~draft-create-to-lst origmsg)))
+           (mu4e~draft-header "To" (mu4e~draft-recipients-construct
                                     :cc origmsg reply-all))
-          ;; otherwise...
-          (concat
-            (mu4e~draft-header "To" (mu4e~draft-recipients-construct :to origmsg))
-            (mu4e~draft-header "Cc" (mu4e~draft-recipients-construct :cc origmsg reply-all))))))))
+         ;; otherwise...
+         (concat
+          (mu4e~draft-header "To" (mu4e~draft-recipients-construct :to origmsg))
+          (mu4e~draft-header "Cc" (mu4e~draft-recipients-construct :cc origmsg reply-all))))))))
 
 (defun mu4e~draft-reply-construct-recipients-list (origmsg)
   "Determine the to/cc recipients for a reply message to a
 mailing-list."
   (let* ( ;; reply-to-self implies reply-all
-          (list-post (plist-get origmsg :list-post))
-          (from      (plist-get origmsg :from))
-          (recipnum
-            (+ (length (mu4e~draft-create-to-lst origmsg))
-              (length (mu4e~draft-create-cc-lst origmsg t t))))
-          (reply-type
-            (mu4e-read-option
-                "Reply to mailing-list "
-              `( (,(format "all %d recipient(s)" recipnum)     . all)
-                 (,(format "list-only (%s)" (cdar list-post))  . list-only)
-                 (,(format "sender-only (%s)" (cdar from))     . sender-only)))))
+         (list-post (plist-get origmsg :list-post))
+         (from      (plist-get origmsg :from))
+         (recipnum
+          (+ (length (mu4e~draft-create-to-lst origmsg))
+             (length (mu4e~draft-create-cc-lst origmsg t t))))
+         (reply-type
+          (mu4e-read-option
+           "Reply to mailing-list "
+           `( (,(format "all %d recipient(s)" recipnum)     . all)
+              (,(format "list-only (%s)" (cdar list-post))  . list-only)
+              (,(format "sender-only (%s)" (cdar from))     . sender-only)))))
     (cl-case reply-type
       (all
-        (concat
-          (mu4e~draft-header "To" (mu4e~draft-recipients-construct :to origmsg))
-          (mu4e~draft-header "Cc" (mu4e~draft-recipients-construct :cc origmsg t t))))
+       (concat
+        (mu4e~draft-header "To" (mu4e~draft-recipients-construct :to origmsg))
+        (mu4e~draft-header "Cc" (mu4e~draft-recipients-construct :cc origmsg t t))))
       (list-only
-        (mu4e~draft-header "To"
-          (mu4e~draft-recipients-list-to-string list-post)))
+       (mu4e~draft-header "To"
+                          (mu4e~draft-recipients-list-to-string list-post)))
       (sender-only
-        (mu4e~draft-header "To"
-          (mu4e~draft-recipients-list-to-string from))))))
+       (mu4e~draft-header "To"
+                          (mu4e~draft-recipients-list-to-string from))))))
 
 (defun mu4e~draft-reply-construct (origmsg)
   "Create a draft message as a reply to ORIGMSG.
 Replying-to-self is special; in that case, the To and Cc fields
 will be the same as in the original."
   (let* ((old-msgid (plist-get origmsg :message-id))
-	        (subject (concat mu4e~draft-reply-prefix
-	                   (message-strip-subject-re
-                       (or (plist-get origmsg :subject) ""))))
-          (list-post (plist-get origmsg :list-post)))
+         (subject (concat mu4e~draft-reply-prefix
+                          (message-strip-subject-re
+                           (or (plist-get origmsg :subject) ""))))
+         (list-post (plist-get origmsg :list-post)))
     (concat
-      (mu4e~draft-header "From" (or (mu4e~draft-from-construct) ""))
-      (mu4e~draft-header "Reply-To" mu4e-compose-reply-to-address)
+     (mu4e~draft-header "From" (or (mu4e~draft-from-construct) ""))
+     (mu4e~draft-header "Reply-To" mu4e-compose-reply-to-address)
 
-      (if list-post ;; mailing-lists are a bit special.
-        (mu4e~draft-reply-construct-recipients-list origmsg)
-        (mu4e~draft-reply-construct-recipients origmsg))
+     (if list-post ;; mailing-lists are a bit special.
+         (mu4e~draft-reply-construct-recipients-list origmsg)
+       (mu4e~draft-reply-construct-recipients origmsg))
 
-      (mu4e~draft-header "Subject" subject)
-      (mu4e~draft-header "References"
-        (mu4e~draft-references-construct origmsg))
-      (mu4e~draft-common-construct)
-      (when old-msgid
-        (mu4e~draft-header "In-reply-to" (format "<%s>" old-msgid)))
-      "\n\n"
-      (mu4e~draft-cite-original origmsg))))
+     (mu4e~draft-header "Subject" subject)
+     (mu4e~draft-header "References"
+                        (mu4e~draft-references-construct origmsg))
+     (mu4e~draft-common-construct)
+     (when old-msgid
+       (mu4e~draft-header "In-reply-to" (format "<%s>" old-msgid)))
+     "\n\n"
+     (mu4e~draft-cite-original origmsg))))
 
 (defconst mu4e~draft-forward-prefix "Fwd: "
   "String to prefix replies with.")
@@ -497,34 +497,34 @@ will be the same as in the original."
 (defun mu4e~draft-forward-construct (origmsg)
   "Create a draft forward message for original message ORIGMSG."
   (let ((subject
-          (or (plist-get origmsg :subject) "")))
+         (or (plist-get origmsg :subject) "")))
     (concat
-      (mu4e~draft-header "From" (or (mu4e~draft-from-construct) ""))
-      (mu4e~draft-header "Reply-To" mu4e-compose-reply-to-address)
-      (mu4e~draft-header "To" "")
-      (mu4e~draft-common-construct)
-      (mu4e~draft-header "References"
-        (mu4e~draft-references-construct origmsg))
-      (mu4e~draft-header "Subject"
-        (concat
-          ;; if there's no Fwd: yet, prepend it
-          (if (string-match "^Fwd:" subject)
-            ""
-            mu4e~draft-forward-prefix)
-          subject))
-      (unless mu4e-compose-forward-as-attachment
-        (concat
-          "\n\n"
-          (mu4e~draft-cite-original origmsg))))))
+     (mu4e~draft-header "From" (or (mu4e~draft-from-construct) ""))
+     (mu4e~draft-header "Reply-To" mu4e-compose-reply-to-address)
+     (mu4e~draft-header "To" "")
+     (mu4e~draft-common-construct)
+     (mu4e~draft-header "References"
+                        (mu4e~draft-references-construct origmsg))
+     (mu4e~draft-header "Subject"
+                        (concat
+                         ;; if there's no Fwd: yet, prepend it
+                         (if (string-match "^Fwd:" subject)
+                             ""
+                           mu4e~draft-forward-prefix)
+                         subject))
+     (unless mu4e-compose-forward-as-attachment
+       (concat
+        "\n\n"
+        (mu4e~draft-cite-original origmsg))))))
 
 (defun mu4e~draft-newmsg-construct ()
   "Create a new message."
   (concat
-    (mu4e~draft-header "From" (or (mu4e~draft-from-construct) ""))
-    (mu4e~draft-header "Reply-To" mu4e-compose-reply-to-address)
-    (mu4e~draft-header "To" "")
-    (mu4e~draft-header "Subject" "")
-    (mu4e~draft-common-construct)))
+   (mu4e~draft-header "From" (or (mu4e~draft-from-construct) ""))
+   (mu4e~draft-header "Reply-To" mu4e-compose-reply-to-address)
+   (mu4e~draft-header "To" "")
+   (mu4e~draft-header "Subject" "")
+   (mu4e~draft-common-construct)))
 
 (defvar mu4e~draft-drafts-folder nil
   "The drafts-folder for this compose buffer.
@@ -533,13 +533,13 @@ This is based on `mu4e-drafts-folder', which is evaluated once.")
 (defun mu4e~draft-open-file (path)
   "Open the the draft file at PATH."
   (if mu4e-compose-in-new-frame
-    (find-file-other-frame path)
+      (find-file-other-frame path)
     (find-file path)))
 
 (defun mu4e~draft-determine-path (draft-dir)
   "Determines the path for a new draft file in DRAFT-DIR."
   (format "%s/%s/cur/%s"
-    (mu4e-root-maildir) draft-dir (mu4e~draft-message-filename-construct "DS")))
+          (mu4e-root-maildir) draft-dir (mu4e~draft-message-filename-construct "DS")))
 
 
 (defun mu4e-draft-open (compose-type &optional msg)
@@ -558,39 +558,39 @@ will be created from either `mu4e~draft-reply-construct', or
     (cl-case compose-type
 
       (edit
-        ;; case-1: re-editing a draft messages. in this case, we do know the
-        ;; full path, but we cannot really know 'drafts folder'... we make a
-        ;; guess
-        (setq draft-dir (mu4e~guess-maildir (mu4e-message-field msg :path)))
-        (mu4e~draft-open-file (mu4e-message-field msg :path)))
+       ;; case-1: re-editing a draft messages. in this case, we do know the
+       ;; full path, but we cannot really know 'drafts folder'... we make a
+       ;; guess
+       (setq draft-dir (mu4e~guess-maildir (mu4e-message-field msg :path)))
+       (mu4e~draft-open-file (mu4e-message-field msg :path)))
 
       (resend
-        ;; case-2: copy some exisisting message to a draft message, then edit
-        ;; that.
-        (setq draft-dir (mu4e~guess-maildir (mu4e-message-field msg :path)))
-        (let ((draft-path (mu4e~draft-determine-path draft-dir)))
-          (copy-file (mu4e-message-field msg :path) draft-path)
-          (mu4e~draft-open-file draft-path)))
+       ;; case-2: copy some exisisting message to a draft message, then edit
+       ;; that.
+       (setq draft-dir (mu4e~guess-maildir (mu4e-message-field msg :path)))
+       (let ((draft-path (mu4e~draft-determine-path draft-dir)))
+         (copy-file (mu4e-message-field msg :path) draft-path)
+         (mu4e~draft-open-file draft-path)))
 
       ((reply forward new)
-        ;; case-3: creating a new message; in this case, we can determine
-        ;; mu4e-get-drafts-folder
-        (setq draft-dir (mu4e-get-drafts-folder msg))
-        (let ((draft-path (mu4e~draft-determine-path draft-dir))
-               (initial-contents
-                 (cl-case compose-type
-                   (reply   (mu4e~draft-reply-construct msg))
-                   (forward (mu4e~draft-forward-construct msg))
-                   (new     (mu4e~draft-newmsg-construct)))))
-          (mu4e~draft-open-file draft-path)
-          (insert initial-contents)
-          (newline)
-          ;; include the message signature (if it's set)
-          (if (and mu4e-compose-signature-auto-include mu4e-compose-signature)
-            (let ((message-signature mu4e-compose-signature))
-              (save-excursion
-                (message-insert-signature)
-                (mu4e~fontify-signature))))))
+       ;; case-3: creating a new message; in this case, we can determine
+       ;; mu4e-get-drafts-folder
+       (setq draft-dir (mu4e-get-drafts-folder msg))
+       (let ((draft-path (mu4e~draft-determine-path draft-dir))
+             (initial-contents
+              (cl-case compose-type
+                (reply   (mu4e~draft-reply-construct msg))
+                (forward (mu4e~draft-forward-construct msg))
+                (new     (mu4e~draft-newmsg-construct)))))
+         (mu4e~draft-open-file draft-path)
+         (insert initial-contents)
+         (newline)
+         ;; include the message signature (if it's set)
+         (if (and mu4e-compose-signature-auto-include mu4e-compose-signature)
+             (let ((message-signature mu4e-compose-signature))
+               (save-excursion
+                 (message-insert-signature)
+                 (mu4e~fontify-signature))))))
       (t (mu4e-error "Unsupported compose-type %S" compose-type)))
     ;; if we didn't find a draft folder yet, try some default
     (unless draft-dir

--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -1,4 +1,4 @@
-;; mu4e-draft.el -- part of mu4e, the mu mail user agent for emacs -*- lexical-binding: t -*-
+;;; mu4e-draft.el -- part of mu4e, the mu mail user agent for emacs -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2011-2020 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -64,12 +64,12 @@ field. Note that emacs may become very slow with excessively long
 lines (1000s of characters), so if you regularly get such messages,
 you want to avoid fields with `nil' altogether."
   :type `(repeat (cons (choice ,@(mapcar (lambda (h)
-					                                 (list 'const :tag
-						                                 (plist-get (cdr h) :help)
-						                                 (car h)))
-					                         mu4e-header-info))
-		               (choice (integer :tag "width")
-			               (const :tag "unrestricted width" nil))))
+                                           (list 'const :tag
+                                                 (plist-get (cdr h) :help)
+                                                 (car h)))
+                                         mu4e-header-info))
+                       (choice (integer :tag "width")
+                               (const :tag "unrestricted width" nil))))
   :group 'mu4e-headers)
 
 (defcustom mu4e-headers-date-format "%x"
@@ -124,11 +124,11 @@ matches. We then limit this second result as well, favoring the
 messages that were found in the first set (the \"leaders\").
 "
   :type '(choice (const :tag "Unlimited" -1)
-	         (integer :tag "Limit"))
+                 (integer :tag "Limit"))
   :group 'mu4e-headers)
 
 (make-obsolete-variable 'mu4e-search-results-limit
-  'mu4e-headers-results-limit "0.9.9.5-dev6")
+                        'mu4e-headers-results-limit "0.9.9.5-dev6")
 
 (defcustom mu4e-headers-skip-duplicates t
   "With this option set to non-nil, show only one of duplicate
@@ -171,17 +171,17 @@ Note that this is merely a display filter.")
 element is a symbol in the list (DRAFT FLAGGED NEW PASSED
 REPLIED SEEN TRASHED ATTACH ENCRYPTED SIGNED UNREAD)."
   :type '(set
-	         (const :tag "Draft" draft)
-	         (const :tag "Flagged" flagged)
-	         (const :tag "New" new)
-	         (const :tag "Passed" passed)
-	         (const :tag "Replied" replied)
-	         (const :tag "Seen" seen)
-	         (const :tag "Trashed" trashed)
-	         (const :tag "Attach" attach)
-	         (const :tag "Encrypted" encrypted)
-	         (const :tag "Signed" signed)
-	         (const :tag "Unread" unread))
+          (const :tag "Draft" draft)
+          (const :tag "Flagged" flagged)
+          (const :tag "New" new)
+          (const :tag "Passed" passed)
+          (const :tag "Replied" replied)
+          (const :tag "Seen" seen)
+          (const :tag "Trashed" trashed)
+          (const :tag "Attach" attach)
+          (const :tag "Encrypted" encrypted)
+          (const :tag "Signed" signed)
+          (const :tag "Unread" unread))
   :group 'mu4e-headers)
 
 (defcustom mu4e-headers-found-hook nil
@@ -278,14 +278,14 @@ The first character of NAME is used as the shortcut.")
 
 (defvar mu4e-headers-custom-markers
   '(("Older than"
-      (lambda (msg date) (time-less-p (mu4e-msg-field msg :date) date))
-      (lambda () (mu4e-get-time-date "Match messages before: ")))
-     ("Newer than"
-       (lambda (msg date) (time-less-p date (mu4e-msg-field msg :date)))
-       (lambda () (mu4e-get-time-date "Match messages after: ")))
-     ("Bigger than"
-       (lambda (msg bytes) (> (mu4e-msg-field msg :size) (* 1024 bytes)))
-       (lambda () (read-number "Match messages bigger than (Kbytes): "))))
+     (lambda (msg date) (time-less-p (mu4e-msg-field msg :date) date))
+     (lambda () (mu4e-get-time-date "Match messages before: ")))
+    ("Newer than"
+     (lambda (msg date) (time-less-p date (mu4e-msg-field msg :date)))
+     (lambda () (mu4e-get-time-date "Match messages after: ")))
+    ("Bigger than"
+     (lambda (msg bytes) (> (mu4e-msg-field msg :size) (* 1024 bytes)))
+     (lambda () (read-number "Match messages bigger than (Kbytes): "))))
   "List of custom markers -- functions to mark message that match
 some custom function. Each of the list members has the following format:
   (NAME PREDICATE-FUNC PARAM-FUNC)
@@ -320,14 +320,14 @@ followed by the docid, followed by `mu4e~headers-docid-post'.")
   "The view window connected to this headers view.")
 
 (defvar mu4e~headers-sort-field-choices
-  '( ("date"	. :date)
-     ("from"	. :from)
+  '( ("date"    . :date)
+     ("from"    . :from)
      ("list"    . :list)
      ("maildir" . :maildir)
-     ("prio"	. :prio)
-     ("zsize"	. :size)
-     ("subject"	. :subject)
-     ("to"	. :to))
+     ("prio"    . :prio)
+     ("zsize"   . :size)
+     ("subject" . :subject)
+     ("to"      . :to))
   "List of cells describing the various sort-options.
 In the format needed for `mu4e-read-option'.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -337,11 +337,11 @@ In the format needed for `mu4e-read-option'.")
   (when (buffer-live-p (mu4e-get-headers-buffer))
     (let ((inhibit-read-only t))
       (with-current-buffer (mu4e-get-headers-buffer)
-	      (mu4e~mark-clear)
-	      (erase-buffer)
-	      (when msg
-	        (goto-char (point-min))
-	        (insert (propertize msg 'face 'mu4e-system-face 'intangible t)))))))
+        (mu4e~mark-clear)
+        (erase-buffer)
+        (when msg
+          (goto-char (point-min))
+          (insert (propertize msg 'face 'mu4e-system-face 'intangible t)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; handler functions
@@ -366,48 +366,48 @@ headers."
   (when (buffer-live-p (mu4e-get-headers-buffer))
     (with-current-buffer (mu4e-get-headers-buffer)
       (let* ((docid (mu4e-message-field msg :docid))
-	            (initial-message-at-point (mu4e~headers-docid-at-point))
-	            (initial-column (current-column))
-	            (point (mu4e~headers-docid-pos docid)))
+             (initial-message-at-point (mu4e~headers-docid-at-point))
+             (initial-column (current-column))
+             (point (mu4e~headers-docid-pos docid)))
 
-	      (when point ;; is the message present in this list?
+        (when point ;; is the message present in this list?
 
-	        ;; if it's marked, unmark it now
-	        (when (mu4e-mark-docid-marked-p docid)
-	          (mu4e-mark-set 'unmark))
+          ;; if it's marked, unmark it now
+          (when (mu4e-mark-docid-marked-p docid)
+            (mu4e-mark-set 'unmark))
 
-	        ;; re-use the thread info from the old one; this is needed because
-	        ;; *update* messages don't have thread info by themselves (unlike
-	        ;; search results)
-	        ;; since we still have the search results, re-use
-	        ;; those
-	        (plist-put msg :thread
-	          (mu4e~headers-field-for-docid docid :thread))
+          ;; re-use the thread info from the old one; this is needed because
+          ;; *update* messages don't have thread info by themselves (unlike
+          ;; search results)
+          ;; since we still have the search results, re-use
+          ;; those
+          (plist-put msg :thread
+                     (mu4e~headers-field-for-docid docid :thread))
 
-	        ;; first, remove the old one (otherwise, we'd have two headers with
-	        ;; the same docid...
-	        (mu4e~headers-remove-header docid t)
+          ;; first, remove the old one (otherwise, we'd have two headers with
+          ;; the same docid...
+          (mu4e~headers-remove-header docid t)
 
-	        ;; if we're actually viewing this message (in mu4e-view mode), we
-	        ;; update it; that way, the flags can be updated, as well as the path
-	        ;; (which is useful for viewing the raw message)
-	        (when (and maybe-view (mu4e~headers-view-this-message-p docid))
-	          (mu4e-view msg))
-	        ;; now, if this update was about *moving* a message, we don't show it
-	        ;; anymore (of course, we cannot be sure if the message really no
-	        ;; longer matches the query, but this seem a good heuristic.  if it
-	        ;; was only a flag-change, show the message with its updated flags.
-	        (unless is-move
-	          (mu4e~headers-header-handler msg point))
+          ;; if we're actually viewing this message (in mu4e-view mode), we
+          ;; update it; that way, the flags can be updated, as well as the path
+          ;; (which is useful for viewing the raw message)
+          (when (and maybe-view (mu4e~headers-view-this-message-p docid))
+            (mu4e-view msg))
+          ;; now, if this update was about *moving* a message, we don't show it
+          ;; anymore (of course, we cannot be sure if the message really no
+          ;; longer matches the query, but this seem a good heuristic.  if it
+          ;; was only a flag-change, show the message with its updated flags.
+          (unless is-move
+            (mu4e~headers-header-handler msg point))
 
-	        (if (and initial-message-at-point
-		            (mu4e~headers-goto-docid initial-message-at-point))
-	          (progn
-		          (move-to-column initial-column)
-		          (mu4e~headers-highlight initial-message-at-point))
-	          ;; attempt to highlight the corresponding line and make it visible
-	          (mu4e~headers-highlight docid))
-	        (run-hooks 'mu4e-message-changed-hook))))))
+          (if (and initial-message-at-point
+                   (mu4e~headers-goto-docid initial-message-at-point))
+              (progn
+                (move-to-column initial-column)
+                (mu4e~headers-highlight initial-message-at-point))
+            ;; attempt to highlight the corresponding line and make it visible
+            (mu4e~headers-highlight docid))
+          (run-hooks 'mu4e-message-changed-hook))))))
 
 (defun mu4e~headers-remove-handler (docid &optional skip-hook)
   "Remove handler, will be called when a message with DOCID has
@@ -420,10 +420,10 @@ If SKIP-HOOK is absent or nil, `mu4e-message-changed-hook' will be invoked."
     (mu4e~headers-remove-header docid t))
   ;; if we were viewing this message, close it now.
   (when (and (mu4e~headers-view-this-message-p docid)
-	        (buffer-live-p (mu4e-get-view-buffer)))
+             (buffer-live-p (mu4e-get-view-buffer)))
     (unless (eq mu4e-split-view 'single-window)
       (mapc #'delete-window (get-buffer-window-list
-			                        (mu4e-get-view-buffer) nil t)))
+                             (mu4e-get-view-buffer) nil t)))
     (kill-buffer (mu4e-get-view-buffer)))
   (unless skip-hook
     (run-hooks 'mu4e-message-changed-hook)))
@@ -434,16 +434,16 @@ If SKIP-HOOK is absent or nil, `mu4e-message-changed-hook' will be invoked."
   "Turn the list of contacts CONTACTS (with elements (NAME . EMAIL)
 into a string."
   (mapconcat
-    (lambda (ct)
-      (let ((name (car ct)) (email (cdr ct)))
-	      (or name email "?"))) contacts ", "))
+   (lambda (ct)
+     (let ((name (car ct)) (email (cdr ct)))
+       (or name email "?"))) contacts ", "))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun mu4e~headers-thread-prefix-map (type)
   "Return the thread prefix based on the symbol TYPE."
   (let ((get-prefix
-	        (lambda (cell)
-	          (if mu4e-use-fancy-chars (cdr cell) (car cell)))))
+         (lambda (cell)
+           (if mu4e-use-fancy-chars (cdr cell) (car cell)))))
     (cl-case type
       ('child         (funcall get-prefix mu4e-headers-thread-child-prefix))
       ('last-child    (funcall get-prefix mu4e-headers-thread-last-child-prefix))
@@ -474,15 +474,15 @@ docid DOCID, or nil if it cannot be found."
   "Create an invisible string containing DOCID; this is to be used
 at the beginning of lines to identify headers."
   (propertize (format "%s%d%s"
-		            mu4e~headers-docid-pre docid mu4e~headers-docid-post)
-    'docid docid 'invisible t));;
+                      mu4e~headers-docid-pre docid mu4e~headers-docid-post)
+              'docid docid 'invisible t));;
 
 (defun mu4e~headers-docid-at-point (&optional point)
   "Get the docid for the header at POINT, or at current (point) if
 nil. Returns the docid, or nil if there is none."
   (save-excursion
     (when point
-	    (goto-char point))
+      (goto-char point))
     (get-text-property (line-beginning-position) 'docid)))
 
 
@@ -494,13 +494,13 @@ of the beginning of the line."
   (let ((oldpoint (point)) (newpoint))
     (goto-char (point-min))
     (setq newpoint
-      (search-forward (mu4e~headers-docid-cookie docid) nil t))
+          (search-forward (mu4e~headers-docid-cookie docid) nil t))
     (unless to-mark
       (if (null newpoint)
-	      (goto-char oldpoint) ;; not found; restore old pos
-	      (progn
-	        (beginning-of-line) ;; found, move to beginning of line
-	        (setq newpoint (point)))))
+          (goto-char oldpoint) ;; not found; restore old pos
+        (progn
+          (beginning-of-line) ;; found, move to beginning of line
+          (setq newpoint (point)))))
     newpoint)) ;; return the point, or nil if not found
 
 (defun mu4e~headers-field-for-docid (docid field)
@@ -521,54 +521,54 @@ with DOCID which must be present in the headers buffer."
   "Calculate the thread prefix based on thread info THREAD."
   (when thread
     (let ((prefix       "")
-	         (level        (plist-get thread :level))
-	         (has-child    (plist-get thread :has-child))
-	         (empty-parent (plist-get thread :empty-parent))
-	         (first-child  (plist-get thread :first-child))
-	         (last-child   (plist-get thread :last-child))
-	         (duplicate    (plist-get thread :duplicate)))
+          (level        (plist-get thread :level))
+          (has-child    (plist-get thread :has-child))
+          (empty-parent (plist-get thread :empty-parent))
+          (first-child  (plist-get thread :first-child))
+          (last-child   (plist-get thread :last-child))
+          (duplicate    (plist-get thread :duplicate)))
       ;; Do not prefix root messages.
       (if (= level 0)
-	      (setq mu4e~headers-thread-state '()))
+          (setq mu4e~headers-thread-state '()))
       (if (> level 0)
-	      (let* ((length (length mu4e~headers-thread-state))
-		            (padding (make-list (max 0 (- level length)) nil)))
-	        ;; Trim and pad the state to ensure a message will
-	        ;; always be shown with the correct indentation, even if
-	        ;; a broken thread is returned. It's trimmed to level-1
-	        ;; because the current level has always an connection
-	        ;; and it used a special formatting.
-	        (setq mu4e~headers-thread-state
-		        (cl-subseq (append mu4e~headers-thread-state padding)
-			        0 (- level 1)))
-	        ;; Prepare the thread prefix.
-	        (setq prefix
-		        (concat
-		          ;; Current mu4e~headers-thread-state, composed by
-		          ;; connections or blanks.
-		          (mapconcat
-		            (lambda (s)
-		              (mu4e~headers-thread-prefix-map
-		                (if s 'connection 'blank)))
-		            mu4e~headers-thread-state "")
-		          ;; Current entry.
-		          (mu4e~headers-thread-prefix-map
-		            (if (and empty-parent first-child)
-			            (if last-child 'single-orphan 'orphan)
-		              (if last-child 'last-child 'child)))))))
+          (let* ((length (length mu4e~headers-thread-state))
+                 (padding (make-list (max 0 (- level length)) nil)))
+            ;; Trim and pad the state to ensure a message will
+            ;; always be shown with the correct indentation, even if
+            ;; a broken thread is returned. It's trimmed to level-1
+            ;; because the current level has always an connection
+            ;; and it used a special formatting.
+            (setq mu4e~headers-thread-state
+                  (cl-subseq (append mu4e~headers-thread-state padding)
+                             0 (- level 1)))
+            ;; Prepare the thread prefix.
+            (setq prefix
+                  (concat
+                   ;; Current mu4e~headers-thread-state, composed by
+                   ;; connections or blanks.
+                   (mapconcat
+                    (lambda (s)
+                      (mu4e~headers-thread-prefix-map
+                       (if s 'connection 'blank)))
+                    mu4e~headers-thread-state "")
+                   ;; Current entry.
+                   (mu4e~headers-thread-prefix-map
+                    (if (and empty-parent first-child)
+                        (if last-child 'single-orphan 'orphan)
+                      (if last-child 'last-child 'child)))))))
       ;; If a new sub-thread will follow (has-child) and the current
       ;; one is still not done (not last-child), then a new
       ;; connection needs to be added to the tree-state.  It's not
       ;; necessary to a blank (nil), because padding will handle
       ;; that.
       (if (and has-child (not last-child))
-	      (setq mu4e~headers-thread-state
-		      (append mu4e~headers-thread-state '(t))))
+          (setq mu4e~headers-thread-state
+                (append mu4e~headers-thread-state '(t))))
       ;; Return the thread prefix.
       (format "%s%s"
-	      prefix
-	      (if duplicate
-		      (mu4e~headers-thread-prefix-map 'duplicate) "")))))
+              prefix
+              (if duplicate
+                  (mu4e~headers-thread-prefix-map 'duplicate) "")))))
 
 (defun mu4e~headers-flags-str (flags)
   "Get a display string for the flags.
@@ -577,24 +577,24 @@ function is for display. (This difference is significant, since
 internally, the Maildir spec determines what the flags look like,
 while our display may be different)."
   (let ((str "")
-	       (get-prefix
-	         (lambda (cell)  (if mu4e-use-fancy-chars (cdr cell) (car cell)))))
+        (get-prefix
+         (lambda (cell)  (if mu4e-use-fancy-chars (cdr cell) (car cell)))))
     (dolist (flag mu4e-headers-visible-flags)
       (when (member flag flags)
-	      (setq str
-	        (concat str
-	          (cl-case flag
-	            ('draft     (funcall get-prefix mu4e-headers-draft-mark))
-	            ('flagged   (funcall get-prefix mu4e-headers-flagged-mark))
-	            ('new       (funcall get-prefix mu4e-headers-new-mark))
-	            ('passed    (funcall get-prefix mu4e-headers-passed-mark))
-	            ('replied   (funcall get-prefix mu4e-headers-replied-mark))
-	            ('seen      (funcall get-prefix mu4e-headers-seen-mark))
-	            ('trashed   (funcall get-prefix mu4e-headers-trashed-mark))
-	            ('attach    (funcall get-prefix mu4e-headers-attach-mark))
-	            ('encrypted (funcall get-prefix mu4e-headers-encrypted-mark))
-	            ('signed    (funcall get-prefix mu4e-headers-signed-mark))
-	            ('unread    (funcall get-prefix mu4e-headers-unread-mark)))))))
+        (setq str
+              (concat str
+                      (cl-case flag
+                        ('draft     (funcall get-prefix mu4e-headers-draft-mark))
+                        ('flagged   (funcall get-prefix mu4e-headers-flagged-mark))
+                        ('new       (funcall get-prefix mu4e-headers-new-mark))
+                        ('passed    (funcall get-prefix mu4e-headers-passed-mark))
+                        ('replied   (funcall get-prefix mu4e-headers-replied-mark))
+                        ('seen      (funcall get-prefix mu4e-headers-seen-mark))
+                        ('trashed   (funcall get-prefix mu4e-headers-trashed-mark))
+                        ('attach    (funcall get-prefix mu4e-headers-attach-mark))
+                        ('encrypted (funcall get-prefix mu4e-headers-encrypted-mark))
+                        ('signed    (funcall get-prefix mu4e-headers-signed-mark))
+                        ('unread    (funcall get-prefix mu4e-headers-unread-mark)))))))
     str))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -610,10 +610,10 @@ otherwise ; show the from address; prefixed with the appropriate
 `mu4e-headers-from-or-to-prefix'."
   (let ((addr (cdr-safe (car-safe (mu4e-message-field msg :from)))))
     (if (mu4e-user-mail-address-p addr)
-      (concat (cdr mu4e-headers-from-or-to-prefix)
-	      (mu4e~headers-contact-str (mu4e-message-field msg :to)))
+        (concat (cdr mu4e-headers-from-or-to-prefix)
+                (mu4e~headers-contact-str (mu4e-message-field msg :to)))
       (concat (car mu4e-headers-from-or-to-prefix)
-	      (mu4e~headers-contact-str (mu4e-message-field msg :from))))))
+              (mu4e~headers-contact-str (mu4e-message-field msg :from))))))
 
 (defun mu4e~headers-human-date (msg)
   "Show a 'human' date.
@@ -622,53 +622,53 @@ date. The formats used for date and time are
 `mu4e-headers-date-format' and `mu4e-headers-time-format'."
   (let ((date (mu4e-msg-field msg :date)))
     (if (equal date '(0 0 0))
-      "None"
+        "None"
       (let ((day1 (decode-time date))
-	           (day2 (decode-time (current-time))))
-	      (if (and
-	            (eq (nth 3 day1) (nth 3 day2))     ;; day
-	            (eq (nth 4 day1) (nth 4 day2))     ;; month
-	            (eq (nth 5 day1) (nth 5 day2)))    ;; year
-	        (format-time-string mu4e-headers-time-format date)
-	        (format-time-string mu4e-headers-date-format date))))))
+            (day2 (decode-time (current-time))))
+        (if (and
+             (eq (nth 3 day1) (nth 3 day2))     ;; day
+             (eq (nth 4 day1) (nth 4 day2))     ;; month
+             (eq (nth 5 day1) (nth 5 day2)))    ;; year
+            (format-time-string mu4e-headers-time-format date)
+          (format-time-string mu4e-headers-date-format date))))))
 
 (defun mu4e~headers-thread-subject (msg)
   "Get the subject if it is the first one in a thread; otherwise,
 return the thread-prefix without the subject-text. In other words,
 show the subject of a thread only once, similar to e.g. 'mutt'."
   (let* ((tinfo  (mu4e-message-field msg :thread))
-	        (subj (mu4e-msg-field msg :subject)))
+         (subj (mu4e-msg-field msg :subject)))
     (concat ;; prefix subject with a thread indicator
-      (mu4e~headers-thread-prefix tinfo)
-      (if (or (not tinfo) (zerop (plist-get tinfo :level))
-	          (plist-get tinfo :empty-parent))
-	      (truncate-string-to-width subj 600) ""))))
+     (mu4e~headers-thread-prefix tinfo)
+     (if (or (not tinfo) (zerop (plist-get tinfo :level))
+             (plist-get tinfo :empty-parent))
+         (truncate-string-to-width subj 600) ""))))
 
 (defun mu4e~headers-mailing-list (list)
   "Get some identifier for the mailing list."
   (if list
-    (propertize (mu4e-get-mailing-list-shortname list) 'help-echo list)
+      (propertize (mu4e-get-mailing-list-shortname list) 'help-echo list)
     ""))
 
 (defun mu4e~headers-custom-field (msg field)
   "Show some custom header field, or raise an error if it is not
 found."
   (let* ((item (or (assoc field mu4e-header-info-custom)
-		             (mu4e-error "field %S not found" field)))
-	        (func (or (plist-get (cdr-safe item) :function)
-		              (mu4e-error "no :function defined for field %S %S"
-		                field (cdr item)))))
+                   (mu4e-error "field %S not found" field)))
+         (func (or (plist-get (cdr-safe item) :function)
+                   (mu4e-error "no :function defined for field %S %S"
+                               field (cdr item)))))
     (funcall func msg)))
 
 (defun mu4e~headers-field-apply-basic-properties (msg field val _width)
   (cl-case field
     (:subject
-      (concat ;; prefix subject with a thread indicator
-        (mu4e~headers-thread-prefix (mu4e-message-field msg :thread))
-        ;;  "["(plist-get (mu4e-message-field msg :thread) :path) "] "
-        ;; work-around: emacs' display gets really slow when lines are too long;
-        ;; so limit subject length to 600
-        (truncate-string-to-width val 600)))
+     (concat ;; prefix subject with a thread indicator
+      (mu4e~headers-thread-prefix (mu4e-message-field msg :thread))
+      ;;  "["(plist-get (mu4e-message-field msg :thread) :path) "] "
+      ;; work-around: emacs' display gets really slow when lines are too long;
+      ;; so limit subject length to 600
+      (truncate-string-to-width val 600)))
     (:thread-subject (mu4e~headers-thread-subject msg))
     ((:maildir :path :message-id) val)
     ((:to :from :cc :bcc) (mu4e~headers-contact-str val))
@@ -678,11 +678,11 @@ found."
     (:date (format-time-string mu4e-headers-date-format val))
     (:mailing-list (mu4e~headers-mailing-list val))
     (:human-date (propertize (mu4e~headers-human-date msg)
-			             'help-echo (format-time-string
-					                      mu4e-headers-long-date-format
-					                      (mu4e-msg-field msg :date))))
+                             'help-echo (format-time-string
+                                         mu4e-headers-long-date-format
+                                         (mu4e-msg-field msg :date))))
     (:flags (propertize (mu4e~headers-flags-str val)
-			        'help-echo (format "%S" val)))
+                        'help-echo (format "%S" val)))
     (:tags (propertize (mapconcat 'identity val ", ")))
     (:size (mu4e-display-size val))
     (t (mu4e~headers-custom-field msg field))))
@@ -690,18 +690,18 @@ found."
 (defun mu4e~headers-field-truncate-to-width (_msg _field val width)
   "Truncate VAL to WIDTH."
   (if width
-    (truncate-string-to-width val width 0 ?\s t)
+      (truncate-string-to-width val width 0 ?\s t)
     val))
 
 (defvar mu4e~headers-field-handler-functions
   '(mu4e~headers-field-apply-basic-properties
-     mu4e~headers-field-truncate-to-width))
+    mu4e~headers-field-truncate-to-width))
 
 (defun mu4e~headers-field-handler (f-w msg)
   "Create a description of the field of MSG described by F-W."
   (let* ((field (car f-w))
-	        (width (cdr f-w))
-	        (val (mu4e-message-field msg (car f-w))))
+         (width (cdr f-w))
+         (val (mu4e-message-field msg (car f-w))))
     (dolist (func mu4e~headers-field-handler-functions)
       (setq val (funcall func msg field val width)))
     val))
@@ -712,15 +712,15 @@ found."
 (defun mu4e~headers-line-apply-flag-face (msg line)
   "Adjust LINE's face property based on FLAGS."
   (let* ((flags (mu4e-message-field msg :flags))
-	        (face (cond
-		              ((memq 'trashed flags) 'mu4e-trashed-face)
-		              ((memq 'draft flags)   'mu4e-draft-face)
-		              ((or (memq 'unread flags) (memq 'new flags))
-		                'mu4e-unread-face)
-		              ((memq 'flagged flags) 'mu4e-flagged-face)
-		              ((memq 'replied flags) 'mu4e-replied-face)
-		              ((memq 'passed flags)  'mu4e-forwarded-face)
-		              (t                     'mu4e-header-face))))
+         (face (cond
+                ((memq 'trashed flags) 'mu4e-trashed-face)
+                ((memq 'draft flags)   'mu4e-draft-face)
+                ((or (memq 'unread flags) (memq 'new flags))
+                 'mu4e-unread-face)
+                ((memq 'flagged flags) 'mu4e-flagged-face)
+                ((memq 'replied flags) 'mu4e-replied-face)
+                ((memq 'passed flags)  'mu4e-forwarded-face)
+                (t                     'mu4e-header-face))))
     ;; hmmm, this only works with emacs 24.4+
     (when (fboundp 'add-face-text-property)
       (add-face-text-property 0 (length line) face t line))
@@ -738,18 +738,18 @@ if provided, or at the end of the buffer otherwise."
   (when (buffer-live-p (mu4e-get-headers-buffer))
     (with-current-buffer (mu4e-get-headers-buffer)
       (let ((line (mu4e~message-header-description msg)))
-	      (when line
-	        (mu4e~headers-add-header line (mu4e-message-field msg :docid)
-				    point msg))))))
+        (when line
+          (mu4e~headers-add-header line (mu4e-message-field msg :docid)
+                                   point msg))))))
 
 (defun mu4e~message-header-description (msg)
   "Return a propertized description of MSG suitable for
 displaying in the header view."
   (unless (and mu4e-headers-hide-predicate
-	          (funcall mu4e-headers-hide-predicate msg))
+               (funcall mu4e-headers-hide-predicate msg))
     (let ((line (mapconcat
-		              (lambda (f-w) (mu4e~headers-field-handler f-w msg))
-		              mu4e-headers-fields " ")))
+                 (lambda (f-w) (mu4e~headers-field-handler f-w msg))
+                 mu4e-headers-fields " ")))
       (mu4e~headers-line-handler msg line))))
 
 (defconst mu4e~searching      "Searching...")
@@ -770,26 +770,26 @@ after the end of the search results."
   (when (buffer-live-p (mu4e-get-headers-buffer))
     (with-current-buffer (mu4e-get-headers-buffer)
       (save-excursion
-	      (goto-char (point-max))
-	      (let ((inhibit-read-only t)
-	             (str (if (zerop count) mu4e~no-matches mu4e~end-of-results)))
-	        (insert (propertize str 'face 'mu4e-system-face 'intangible t))
-	        (unless (zerop count)
-	          (mu4e-message "Found %d matching message%s"
-	            count (if (= 1 count) "" "s")))))
+        (goto-char (point-max))
+        (let ((inhibit-read-only t)
+              (str (if (zerop count) mu4e~no-matches mu4e~end-of-results)))
+          (insert (propertize str 'face 'mu4e-system-face 'intangible t))
+          (unless (zerop count)
+            (mu4e-message "Found %d matching message%s"
+                          count (if (= 1 count) "" "s")))))
       ;; if we need to jump to some specific message, do so now
       (goto-char (point-min))
       (when mu4e~headers-msgid-target
         (if (eq (current-buffer) (window-buffer))
-          (mu4e-headers-goto-message-id mu4e~headers-msgid-target)
+            (mu4e-headers-goto-message-id mu4e~headers-msgid-target)
           (let* ((pos (mu4e-headers-goto-message-id mu4e~headers-msgid-target)))
             (when pos
               (set-window-point (get-buffer-window) pos)))))
       (when (and mu4e~headers-view-target (mu4e-message-at-point 'noerror))
-	      ;; view the message at point when there is one.
-	      (mu4e-headers-view-message))
+        ;; view the message at point when there is one.
+        (mu4e-headers-view-message))
       (setq mu4e~headers-view-target nil
-        mu4e~headers-msgid-target nil)
+            mu4e~headers-msgid-target nil)
       (when (mu4e~headers-docid-at-point)
         (mu4e~headers-highlight (mu4e~headers-docid-at-point))))
 
@@ -801,11 +801,11 @@ after the end of the search results."
 (defmacro mu4e~headers-defun-mark-for (mark)
   "Define a function mu4e~headers-mark-MARK."
   (let ((funcname (intern (format "mu4e-headers-mark-for-%s" mark)))
-	       (docstring (format "Mark header at point with %s." mark)))
+        (docstring (format "Mark header at point with %s." mark)))
     `(progn
        (defun ,funcname () ,docstring
-	       (interactive)
-	       (mu4e-headers-mark-and-next ',mark))
+              (interactive)
+              (mu4e-headers-mark-and-next ',mark))
        (put ',funcname 'definition-name ',mark))))
 
 (mu4e~headers-defun-mark-for refile)
@@ -837,10 +837,10 @@ Also see `mu4e-view-mark-or-move-to-trash'."
   (let ((msg-dir (mu4e-message-field (mu4e-message-at-point) :maildir)))
     (if (not (seq-filter (lambda (re)
                            (string-match re msg-dir))
-               mu4e-move-to-trash-patterns))
-      (mu4e-headers-mark-for-trash)
+                         mu4e-move-to-trash-patterns))
+        (mu4e-headers-mark-for-trash)
       (mu4e-mark-set 'move (if (functionp mu4e-trash-folder)
-                             (funcall mu4e-trash-folder (mu4e-message-at-point))
+                               (funcall mu4e-trash-folder (mu4e-message-at-point))
                              mu4e-trash-folder))
       (mu4e-headers-next))))
 
@@ -849,228 +849,228 @@ Also see `mu4e-view-mark-or-move-to-trash'."
   "Keymap for *mu4e-headers* buffers.")
 (unless mu4e-headers-mode-map
   (setq mu4e-headers-mode-map
-    (let ((map (make-sparse-keymap)))
+        (let ((map (make-sparse-keymap)))
 
-      (define-key map  (kbd "C-S-u")   'mu4e-update-mail-and-index)
-      ;; for terminal users
-      (define-key map  (kbd "C-c C-u") 'mu4e-update-mail-and-index)
+          (define-key map  (kbd "C-S-u")   'mu4e-update-mail-and-index)
+          ;; for terminal users
+          (define-key map  (kbd "C-c C-u") 'mu4e-update-mail-and-index)
 
-      (define-key map "s" 'mu4e-headers-search)
-      (define-key map "S" 'mu4e-headers-search-edit)
+          (define-key map "s" 'mu4e-headers-search)
+          (define-key map "S" 'mu4e-headers-search-edit)
 
-      (define-key map "/" 'mu4e-headers-search-narrow)
+          (define-key map "/" 'mu4e-headers-search-narrow)
 
-      (define-key map "j" 'mu4e~headers-jump-to-maildir)
+          (define-key map "j" 'mu4e~headers-jump-to-maildir)
 
-      (define-key map (kbd "<M-left>")  'mu4e-headers-query-prev)
-      (define-key map (kbd "\\")        'mu4e-headers-query-prev)
-      (define-key map (kbd "<M-right>") 'mu4e-headers-query-next)
+          (define-key map (kbd "<M-left>")  'mu4e-headers-query-prev)
+          (define-key map (kbd "\\")        'mu4e-headers-query-prev)
+          (define-key map (kbd "<M-right>") 'mu4e-headers-query-next)
 
-      (define-key map "b" 'mu4e-headers-search-bookmark)
-      (define-key map "B" 'mu4e-headers-search-bookmark-edit)
+          (define-key map "b" 'mu4e-headers-search-bookmark)
+          (define-key map "B" 'mu4e-headers-search-bookmark-edit)
 
-      (define-key map "O" 'mu4e-headers-change-sorting)
-      (define-key map "P" 'mu4e-headers-toggle-threading)
-      (define-key map "Q" 'mu4e-headers-toggle-full-search)
-      (define-key map "W" 'mu4e-headers-toggle-include-related)
-      (define-key map "V" 'mu4e-headers-toggle-skip-duplicates)
+          (define-key map "O" 'mu4e-headers-change-sorting)
+          (define-key map "P" 'mu4e-headers-toggle-threading)
+          (define-key map "Q" 'mu4e-headers-toggle-full-search)
+          (define-key map "W" 'mu4e-headers-toggle-include-related)
+          (define-key map "V" 'mu4e-headers-toggle-skip-duplicates)
 
-      (define-key map "q" 'mu4e~headers-quit-buffer)
-      (define-key map "g" 'mu4e-headers-rerun-search) ;; for compatibility
+          (define-key map "q" 'mu4e~headers-quit-buffer)
+          (define-key map "g" 'mu4e-headers-rerun-search) ;; for compatibility
 
-      (define-key map "%" 'mu4e-headers-mark-pattern)
-      (define-key map "t" 'mu4e-headers-mark-subthread)
-      (define-key map "T" 'mu4e-headers-mark-thread)
+          (define-key map "%" 'mu4e-headers-mark-pattern)
+          (define-key map "t" 'mu4e-headers-mark-subthread)
+          (define-key map "T" 'mu4e-headers-mark-thread)
 
-      ;; navigation between messages
-      (define-key map "p" 'mu4e-headers-prev)
-      (define-key map "n" 'mu4e-headers-next)
-      (define-key map (kbd "<M-up>") 'mu4e-headers-prev)
-      (define-key map (kbd "<M-down>") 'mu4e-headers-next)
+          ;; navigation between messages
+          (define-key map "p" 'mu4e-headers-prev)
+          (define-key map "n" 'mu4e-headers-next)
+          (define-key map (kbd "<M-up>") 'mu4e-headers-prev)
+          (define-key map (kbd "<M-down>") 'mu4e-headers-next)
 
-      (define-key map (kbd "[") 'mu4e-headers-prev-unread)
-      (define-key map (kbd "]") 'mu4e-headers-next-unread)
+          (define-key map (kbd "[") 'mu4e-headers-prev-unread)
+          (define-key map (kbd "]") 'mu4e-headers-next-unread)
 
-      ;; change the number of headers
-      (define-key map (kbd "C-+") 'mu4e-headers-split-view-grow)
-      (define-key map (kbd "C--") 'mu4e-headers-split-view-shrink)
-      (define-key map (kbd "<C-kp-add>") 'mu4e-headers-split-view-grow)
-      (define-key map (kbd "<C-kp-subtract>") 'mu4e-headers-split-view-shrink)
+          ;; change the number of headers
+          (define-key map (kbd "C-+") 'mu4e-headers-split-view-grow)
+          (define-key map (kbd "C--") 'mu4e-headers-split-view-shrink)
+          (define-key map (kbd "<C-kp-add>") 'mu4e-headers-split-view-grow)
+          (define-key map (kbd "<C-kp-subtract>") 'mu4e-headers-split-view-shrink)
 
-      (define-key map ";" 'mu4e-context-switch)
+          (define-key map ";" 'mu4e-context-switch)
 
-      ;; switching to view mode (if it's visible)
-      (define-key map "y" 'mu4e-select-other-view)
+          ;; switching to view mode (if it's visible)
+          (define-key map "y" 'mu4e-select-other-view)
 
-      ;; marking/unmarking ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-      (define-key map (kbd "<backspace>")  'mu4e-headers-mark-or-move-to-trash)
-      (define-key map (kbd "d")            'mu4e-headers-mark-or-move-to-trash)
-      (define-key map (kbd "<delete>")     'mu4e-headers-mark-for-delete)
-      (define-key map (kbd "<deletechar>") 'mu4e-headers-mark-for-delete)
-      (define-key map (kbd "D")            'mu4e-headers-mark-for-delete)
-      (define-key map (kbd "m")            'mu4e-headers-mark-for-move)
-      (define-key map (kbd "r")            'mu4e-headers-mark-for-refile)
+          ;; marking/unmarking ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+          (define-key map (kbd "<backspace>")  'mu4e-headers-mark-or-move-to-trash)
+          (define-key map (kbd "d")            'mu4e-headers-mark-or-move-to-trash)
+          (define-key map (kbd "<delete>")     'mu4e-headers-mark-for-delete)
+          (define-key map (kbd "<deletechar>") 'mu4e-headers-mark-for-delete)
+          (define-key map (kbd "D")            'mu4e-headers-mark-for-delete)
+          (define-key map (kbd "m")            'mu4e-headers-mark-for-move)
+          (define-key map (kbd "r")            'mu4e-headers-mark-for-refile)
 
-      (define-key map (kbd "?")            'mu4e-headers-mark-for-unread)
-      (define-key map (kbd "!")            'mu4e-headers-mark-for-read)
-      (define-key map (kbd "A")            'mu4e-headers-mark-for-action)
+          (define-key map (kbd "?")            'mu4e-headers-mark-for-unread)
+          (define-key map (kbd "!")            'mu4e-headers-mark-for-read)
+          (define-key map (kbd "A")            'mu4e-headers-mark-for-action)
 
-      (define-key map (kbd "u")            'mu4e-headers-mark-for-unmark)
-      (define-key map (kbd "+")            'mu4e-headers-mark-for-flag)
-      (define-key map (kbd "-")            'mu4e-headers-mark-for-unflag)
-      (define-key map (kbd "=")            'mu4e-headers-mark-for-untrash)
-      (define-key map (kbd "&")            'mu4e-headers-mark-custom)
+          (define-key map (kbd "u")            'mu4e-headers-mark-for-unmark)
+          (define-key map (kbd "+")            'mu4e-headers-mark-for-flag)
+          (define-key map (kbd "-")            'mu4e-headers-mark-for-unflag)
+          (define-key map (kbd "=")            'mu4e-headers-mark-for-untrash)
+          (define-key map (kbd "&")            'mu4e-headers-mark-custom)
 
-      (define-key map (kbd "*")              'mu4e-headers-mark-for-something)
-      (define-key map (kbd "<kp-multiply>")  'mu4e-headers-mark-for-something)
-      (define-key map (kbd "<insertchar>")   'mu4e-headers-mark-for-something)
-      (define-key map (kbd "<insert>")       'mu4e-headers-mark-for-something)
+          (define-key map (kbd "*")              'mu4e-headers-mark-for-something)
+          (define-key map (kbd "<kp-multiply>")  'mu4e-headers-mark-for-something)
+          (define-key map (kbd "<insertchar>")   'mu4e-headers-mark-for-something)
+          (define-key map (kbd "<insert>")       'mu4e-headers-mark-for-something)
 
-      (define-key map (kbd "#")   'mu4e-mark-resolve-deferred-marks)
+          (define-key map (kbd "#")   'mu4e-mark-resolve-deferred-marks)
 
-      (define-key map "U" 'mu4e-mark-unmark-all)
-      (define-key map "x" 'mu4e-mark-execute-all)
+          (define-key map "U" 'mu4e-mark-unmark-all)
+          (define-key map "x" 'mu4e-mark-execute-all)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-      (define-key map "a" 'mu4e-headers-action)
+          (define-key map "a" 'mu4e-headers-action)
 
-      ;; message composition
-      (define-key map "R" 'mu4e-compose-reply)
-      (define-key map "F" 'mu4e-compose-forward)
-      (define-key map "C" 'mu4e-compose-new)
-      (define-key map "E" 'mu4e-compose-edit)
+          ;; message composition
+          (define-key map "R" 'mu4e-compose-reply)
+          (define-key map "F" 'mu4e-compose-forward)
+          (define-key map "C" 'mu4e-compose-new)
+          (define-key map "E" 'mu4e-compose-edit)
 
-      (define-key map (kbd "RET") 'mu4e-headers-view-message)
-      (define-key map [mouse-2]   'mu4e-headers-view-message)
+          (define-key map (kbd "RET") 'mu4e-headers-view-message)
+          (define-key map [mouse-2]   'mu4e-headers-view-message)
 
-      (define-key map "$" 'mu4e-show-log)
-      (define-key map "H" 'mu4e-display-manual)
+          (define-key map "$" 'mu4e-show-log)
+          (define-key map "H" 'mu4e-display-manual)
 
-      ;; menu
-      (define-key map [menu-bar] (make-sparse-keymap))
-      (let ((menumap (make-sparse-keymap "Headers")))
-	      (define-key map [menu-bar headers] (cons "Headers" menumap))
+          ;; menu
+          (define-key map [menu-bar] (make-sparse-keymap))
+          (let ((menumap (make-sparse-keymap "Headers")))
+            (define-key map [menu-bar headers] (cons "Headers" menumap))
 
-	      (define-key menumap [mu4e~headers-quit-buffer]
-	        '("Quit view" . mu4e~headers-quit-buffer))
-	      (define-key menumap [display-help] '("Help" . mu4e-display-manual))
+            (define-key menumap [mu4e~headers-quit-buffer]
+              '("Quit view" . mu4e~headers-quit-buffer))
+            (define-key menumap [display-help] '("Help" . mu4e-display-manual))
 
-	      (define-key menumap [sepa0] '("--"))
+            (define-key menumap [sepa0] '("--"))
 
-	      (define-key menumap [toggle-include-related]
-	        '(menu-item "Toggle related messages"
-	           mu4e-headers-toggle-include-related
-	           :button (:toggle .
-		                   (and (boundp 'mu4e-headers-include-related)
-			                   mu4e-headers-include-related))))
-	      (define-key menumap [toggle-threading]
-	        '(menu-item "Toggle threading" mu4e-headers-toggle-threading
-	           :button (:toggle .
-		                   (and (boundp 'mu4e-headers-show-threads)
-			                   mu4e-headers-show-threads))))
+            (define-key menumap [toggle-include-related]
+              '(menu-item "Toggle related messages"
+                          mu4e-headers-toggle-include-related
+                          :button (:toggle .
+                                           (and (boundp 'mu4e-headers-include-related)
+                                                mu4e-headers-include-related))))
+            (define-key menumap [toggle-threading]
+              '(menu-item "Toggle threading" mu4e-headers-toggle-threading
+                          :button (:toggle .
+                                           (and (boundp 'mu4e-headers-show-threads)
+                                                mu4e-headers-show-threads))))
 
-	      (define-key menumap [sepa1] '("--"))
+            (define-key menumap [sepa1] '("--"))
 
-	      (define-key menumap [execute-marks]  '("Execute marks"
-						                                    . mu4e-mark-execute-all))
-	      (define-key menumap [unmark-all]  '("Unmark all" . mu4e-mark-unmark-all))
-	      (define-key menumap [unmark]
-	        '("Unmark" . mu4e-headers-mark-for-unmark))
+            (define-key menumap [execute-marks]  '("Execute marks"
+                                                   . mu4e-mark-execute-all))
+            (define-key menumap [unmark-all]  '("Unmark all" . mu4e-mark-unmark-all))
+            (define-key menumap [unmark]
+              '("Unmark" . mu4e-headers-mark-for-unmark))
 
-	      (define-key menumap [mark-pattern]  '("Mark pattern" .
-					                                     mu4e-headers-mark-pattern))
-	      (define-key menumap [mark-as-read]  '("Mark as read" .
-					                                     mu4e-headers-mark-for-read))
-	      (define-key menumap [mark-as-unread]
-	        '("Mark as unread" .  mu4e-headers-mark-for-unread))
+            (define-key menumap [mark-pattern]  '("Mark pattern" .
+                                                  mu4e-headers-mark-pattern))
+            (define-key menumap [mark-as-read]  '("Mark as read" .
+                                                  mu4e-headers-mark-for-read))
+            (define-key menumap [mark-as-unread]
+              '("Mark as unread" .  mu4e-headers-mark-for-unread))
 
-	      (define-key menumap [mark-delete]
-	        '("Mark for deletion" . mu4e-headers-mark-for-delete))
-	      (define-key menumap [mark-untrash]
-	        '("Mark for untrash" .  mu4e-headers-mark-for-untrash))
-	      (define-key menumap [mark-trash]
-	        '("Mark for trash" .  mu4e-headers-mark-for-trash))
-	      (define-key menumap [mark-move]
-	        '("Mark for move" . mu4e-headers-mark-for-move))
-	      (define-key menumap [sepa2] '("--"))
+            (define-key menumap [mark-delete]
+              '("Mark for deletion" . mu4e-headers-mark-for-delete))
+            (define-key menumap [mark-untrash]
+              '("Mark for untrash" .  mu4e-headers-mark-for-untrash))
+            (define-key menumap [mark-trash]
+              '("Mark for trash" .  mu4e-headers-mark-for-trash))
+            (define-key menumap [mark-move]
+              '("Mark for move" . mu4e-headers-mark-for-move))
+            (define-key menumap [sepa2] '("--"))
 
-	      (define-key menumap [resend]  '("Resend" . mu4e-compose-resend))
-	      (define-key menumap [forward]  '("Forward" . mu4e-compose-forward))
-	      (define-key menumap [reply]  '("Reply" . mu4e-compose-reply))
-	      (define-key menumap [compose-new]  '("Compose new" . mu4e-compose-new))
+            (define-key menumap [resend]  '("Resend" . mu4e-compose-resend))
+            (define-key menumap [forward]  '("Forward" . mu4e-compose-forward))
+            (define-key menumap [reply]  '("Reply" . mu4e-compose-reply))
+            (define-key menumap [compose-new]  '("Compose new" . mu4e-compose-new))
 
-	      (define-key menumap [sepa3] '("--"))
+            (define-key menumap [sepa3] '("--"))
 
-	      (define-key menumap [query-next]
-	        '("Next query" . mu4e-headers-query-next))
-	      (define-key menumap [query-prev]  '("Previous query" .
-					                                   mu4e-headers-query-prev))
-	      (define-key menumap [narrow-search] '("Narrow search" .
-					                                     mu4e-headers-search-narrow))
-	      (define-key menumap [bookmark]  '("Search bookmark" .
-					                                 mu4e-headers-search-bookmark))
-	      (define-key menumap [jump]  '("Jump to maildir" .
-				                               mu4e~headers-jump-to-maildir))
-	      (define-key menumap [refresh]  '("Refresh" . mu4e-headers-rerun-search))
-	      (define-key menumap [search]  '("Search" . mu4e-headers-search))
+            (define-key menumap [query-next]
+              '("Next query" . mu4e-headers-query-next))
+            (define-key menumap [query-prev]  '("Previous query" .
+                                                mu4e-headers-query-prev))
+            (define-key menumap [narrow-search] '("Narrow search" .
+                                                  mu4e-headers-search-narrow))
+            (define-key menumap [bookmark]  '("Search bookmark" .
+                                              mu4e-headers-search-bookmark))
+            (define-key menumap [jump]  '("Jump to maildir" .
+                                          mu4e~headers-jump-to-maildir))
+            (define-key menumap [refresh]  '("Refresh" . mu4e-headers-rerun-search))
+            (define-key menumap [search]  '("Search" . mu4e-headers-search))
 
-	      (define-key menumap [sepa4] '("--"))
+            (define-key menumap [sepa4] '("--"))
 
-	      (define-key menumap [view]  '("View" . mu4e-headers-view-message))
-	      (define-key menumap [next]  '("Next" . mu4e-headers-next))
-	      (define-key menumap [previous]  '("Previous" . mu4e-headers-prev))
-	      (define-key menumap [sepa5] '("--")))
-      map)))
+            (define-key menumap [view]  '("View" . mu4e-headers-view-message))
+            (define-key menumap [next]  '("Next" . mu4e-headers-next))
+            (define-key menumap [previous]  '("Previous" . mu4e-headers-prev))
+            (define-key menumap [sepa5] '("--")))
+          map)))
 (fset 'mu4e-headers-mode-map mu4e-headers-mode-map)
 
 (defun mu4e~header-line-format ()
   "Get the format for the header line."
   (let ((uparrow   (if mu4e-use-fancy-chars " ▲" " ^"))
-	       (downarrow (if mu4e-use-fancy-chars " ▼" " V")))
+        (downarrow (if mu4e-use-fancy-chars " ▼" " V")))
     (cons
-      (make-string
-	      (+ mu4e~mark-fringe-len (floor (fringe-columns 'left t))) ?\s)
-      (mapcar
-	      (lambda (item)
-	        (let* ((field (car item)) (width (cdr item))
-		              (info (cdr (assoc field
-			                         (append mu4e-header-info mu4e-header-info-custom))))
-		              (require-full (plist-get info :require-full))
-		              (sortable (plist-get info :sortable))
-		              ;; if sortable, it is either t (when field is sortable itself)
-		              ;; or a symbol (if another field is used for sorting)
-		              (sortfield (when sortable (if (booleanp sortable) field sortable)))
-		              (help (plist-get info :help))
-		              ;; triangle to mark the sorted-by column
-		              (arrow
-		                (when (and sortable (eq sortfield mu4e-headers-sort-field))
-		                  (if (eq mu4e-headers-sort-direction 'descending) downarrow uparrow)))
-		              (name (concat (plist-get info :shortname) arrow))
-		              (map (make-sparse-keymap)))
-	          (when require-full
-	            (mu4e-error "Field %S is not supported in mu4e-headers-mode" field))
-	          (when sortable
-	            (define-key map [header-line mouse-1]
-		            (lambda (&optional e)
-		              ;; getting the field, inspired by `tabulated-list-col-sort'
-		              (interactive "e")
-		              (let* ((obj (posn-object (event-start e)))
-			                    (field
-			                      (and obj (get-text-property 0 'field (car obj)))))
-		                ;; "t": if we're already sorted by field, the sort-order is
-		                ;; changed
-		                (mu4e-headers-change-sorting field t)))))
-	          (concat
-	            (propertize
-		            (if width
-		              (truncate-string-to-width name width 0 ?\s t)
-		              name)
-		            'face (when arrow 'bold)
-		            'help-echo help
-		            'mouse-face (when sortable 'highlight)
-		            'keymap (when sortable map)
-		            'field field) " ")))
-	      mu4e-headers-fields))))
+     (make-string
+      (+ mu4e~mark-fringe-len (floor (fringe-columns 'left t))) ?\s)
+     (mapcar
+      (lambda (item)
+        (let* ((field (car item)) (width (cdr item))
+               (info (cdr (assoc field
+                                 (append mu4e-header-info mu4e-header-info-custom))))
+               (require-full (plist-get info :require-full))
+               (sortable (plist-get info :sortable))
+               ;; if sortable, it is either t (when field is sortable itself)
+               ;; or a symbol (if another field is used for sorting)
+               (sortfield (when sortable (if (booleanp sortable) field sortable)))
+               (help (plist-get info :help))
+               ;; triangle to mark the sorted-by column
+               (arrow
+                (when (and sortable (eq sortfield mu4e-headers-sort-field))
+                  (if (eq mu4e-headers-sort-direction 'descending) downarrow uparrow)))
+               (name (concat (plist-get info :shortname) arrow))
+               (map (make-sparse-keymap)))
+          (when require-full
+            (mu4e-error "Field %S is not supported in mu4e-headers-mode" field))
+          (when sortable
+            (define-key map [header-line mouse-1]
+              (lambda (&optional e)
+                ;; getting the field, inspired by `tabulated-list-col-sort'
+                (interactive "e")
+                (let* ((obj (posn-object (event-start e)))
+                       (field
+                        (and obj (get-text-property 0 'field (car obj)))))
+                  ;; "t": if we're already sorted by field, the sort-order is
+                  ;; changed
+                  (mu4e-headers-change-sorting field t)))))
+          (concat
+           (propertize
+            (if width
+                (truncate-string-to-width name width 0 ?\s t)
+              name)
+            'face (when arrow 'bold)
+            'help-echo help
+            'mouse-face (when sortable 'highlight)
+            'keymap (when sortable map)
+            'field field) " ")))
+      mu4e-headers-fields))))
 
 
 (defvar mu4e-headers-mode-abbrev-table nil)
@@ -1080,12 +1080,12 @@ Also see `mu4e-view-mark-or-move-to-trash'."
 some changes, `mu4e-headers-auto-update' is non-nil and there is
 no user-interaction ongoing."
   (when (and mu4e-headers-auto-update       ;; must be set
-	        (zerop (mu4e-mark-marks-num))     ;; non active marks
-	        (not (active-minibuffer-window))) ;; no user input only
+             (zerop (mu4e-mark-marks-num))     ;; non active marks
+             (not (active-minibuffer-window))) ;; no user input only
     ;; rerun search if there's a live window with search results;
     ;; otherwise we'd trigger a headers view from out of nowhere.
     (when (and (buffer-live-p (mu4e-get-headers-buffer))
-	          (window-live-p (get-buffer-window (mu4e-get-headers-buffer) t)))
+               (window-live-p (get-buffer-window (mu4e-get-headers-buffer) t)))
       (mu4e-headers-rerun-search))))
 
 (define-derived-mode mu4e-headers-mode special-mode
@@ -1101,12 +1101,12 @@ no user-interaction ongoing."
   ;; maybe update the current headers upon indexing changes
   (add-hook 'mu4e-index-updated-hook 'mu4e~headers-maybe-auto-update)
   (add-hook 'mu4e-index-updated-hook
-    (lambda() (run-hooks 'mu4e-message-changed-hook)) t)
+            (lambda() (run-hooks 'mu4e-message-changed-hook)) t)
   (setq
-    truncate-lines t
-    buffer-undo-list t ;; don't record undo information
-    overwrite-mode nil
-    header-line-format (mu4e~header-line-format))
+   truncate-lines t
+   buffer-undo-list t ;; don't record undo information
+   overwrite-mode nil
+   header-line-format (mu4e~header-line-format))
 
   (mu4e~mark-initialize) ;; initialize the marking subsystem
   (hl-line-mode 1))
@@ -1123,11 +1123,11 @@ Also, unhighlight any previously highlighted headers."
     (save-excursion
       ;; first, unhighlight the previously highlighted docid, if any
       (when (and docid mu4e~highlighted-docid
-	            (mu4e~headers-goto-docid mu4e~highlighted-docid))
-	      (hl-line-unhighlight))
+                 (mu4e~headers-goto-docid mu4e~highlighted-docid))
+        (hl-line-unhighlight))
       ;; now, highlight the new one
       (when (mu4e~headers-goto-docid docid)
-	      (hl-line-highlight)))
+        (hl-line-highlight)))
     (setq mu4e~highlighted-docid docid)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1142,10 +1142,10 @@ adding a lot of new headers looks really choppy."
   "Go to the next message with message-id MSGID. Return the
 message plist, or nil if not found."
   (mu4e-headers-find-if
-    (lambda (msg)
-      (let ((this-msgid (mu4e-message-field msg :message-id)))
-	      (when (and this-msgid (string= msgid this-msgid))
-	        msg)))))
+   (lambda (msg)
+     (let ((this-msgid (mu4e-message-field msg :message-id)))
+       (when (and this-msgid (string= msgid this-msgid))
+         msg)))))
 
 ;;;; markers mark headers for
 (defun mu4e~headers-mark (docid mark)
@@ -1153,21 +1153,21 @@ message plist, or nil if not found."
   (with-current-buffer (mu4e-get-headers-buffer)
     (let ((inhibit-read-only t) (oldpoint (point)))
       (unless (mu4e~headers-goto-docid docid)
-	      (mu4e-error "Cannot find message with docid %S" docid))
+        (mu4e-error "Cannot find message with docid %S" docid))
       ;; now, we're at the beginning of the header, looking at
       ;; <docid>\004
       ;; (which is invisible). jump past that…
       (unless (re-search-forward mu4e~headers-docid-post nil t)
-	      (mu4e-error "Cannot find the `mu4e~headers-docid-post' separator"))
+        (mu4e-error "Cannot find the `mu4e~headers-docid-post' separator"))
 
       ;; clear old marks, and add the new ones.
       (let ((msg (get-text-property (point) 'msg)))
-	      (delete-char mu4e~mark-fringe-len)
-	      (insert (propertize
-		              (format mu4e~mark-fringe-format mark)
-		              'face 'mu4e-header-marks-face
-		              'docid docid
-		              'msg msg)))
+        (delete-char mu4e~mark-fringe-len)
+        (insert (propertize
+                 (format mu4e~mark-fringe-format mark)
+                 'face 'mu4e-header-marks-face
+                 'docid docid
+                 'msg msg)))
       (goto-char oldpoint))))
 
 (defun mu4e~headers-add-header (str docid point &optional msg)
@@ -1177,15 +1177,15 @@ text-property `msg'."
   (when (buffer-live-p (mu4e-get-headers-buffer))
     (with-current-buffer (mu4e-get-headers-buffer)
       (let ((inhibit-read-only t))
-	      (save-excursion
-	        (goto-char (if point point (point-max)))
-	        (insert
-	          (propertize
-	            (concat
-		            (mu4e~headers-docid-cookie docid)
-		            mu4e~mark-fringe
-		            str "\n")
-	            'docid docid 'msg msg)))))))
+        (save-excursion
+          (goto-char (if point point (point-max)))
+          (insert
+           (propertize
+            (concat
+             (mu4e~headers-docid-cookie docid)
+             mu4e~mark-fringe
+             str "\n")
+            'docid docid 'msg msg)))))))
 
 (defun mu4e~headers-remove-header (docid &optional ignore-missing)
   "Remove header with DOCID at point.
@@ -1193,10 +1193,10 @@ When IGNORE-MISSING is non-nill, don't raise an error when the
 docid is not found."
   (with-current-buffer (mu4e-get-headers-buffer)
     (if (mu4e~headers-goto-docid docid)
-      (let ((inhibit-read-only t))
-	      (delete-region (line-beginning-position) (line-beginning-position 2)))
+        (let ((inhibit-read-only t))
+          (delete-region (line-beginning-position) (line-beginning-position 2)))
       (unless ignore-missing
-	      (mu4e-error "Cannot find message with docid %S" docid)))))
+        (mu4e-error "Cannot find message with docid %S" docid)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defcustom mu4e-query-rewrite-function 'identity
@@ -1212,7 +1212,7 @@ For instance, we could change and of workmail into
 (setq mu4e-query-rewrite-function
   (lambda(expr)
      (replace-regexp-in-string \"workmail\"
-		   \"maildir:/long-path-to-work-related-emails\" expr)))
+                   \"maildir:/long-path-to-work-related-emails\" expr)))
 
 It is good to remember that the replacement does not understand
 anything about the query, it just does text replacement."
@@ -1227,32 +1227,32 @@ the query history stack."
   ;; `mu4e~headers-query-next' or `mu4e~headers-query-prev'.
   ;;(mu4e-hide-other-mu4e-buffers)
   (let* ((buf (get-buffer-create mu4e~headers-buffer-name))
-	        (inhibit-read-only t)
-	        (rewritten-expr (funcall mu4e-query-rewrite-function expr))
-	        (maxnum (unless mu4e-headers-full-search mu4e-headers-results-limit)))
+         (inhibit-read-only t)
+         (rewritten-expr (funcall mu4e-query-rewrite-function expr))
+         (maxnum (unless mu4e-headers-full-search mu4e-headers-results-limit)))
     (with-current-buffer buf
       (mu4e-headers-mode)
       (unless ignore-history
-	      ;; save the old present query to the history list
-	      (when mu4e~headers-last-query
-	        (mu4e~headers-push-query mu4e~headers-last-query 'past)))
+        ;; save the old present query to the history list
+        (when mu4e~headers-last-query
+          (mu4e~headers-push-query mu4e~headers-last-query 'past)))
       (setq
-	      mode-name "mu4e-headers"
-	      mu4e~headers-last-query rewritten-expr)
+       mode-name "mu4e-headers"
+       mu4e~headers-last-query rewritten-expr)
       (add-to-list 'global-mode-string
-		    '(:eval
-		       (concat
-		         (propertize
-		           (mu4e~quote-for-modeline mu4e~headers-last-query)
-		           'face 'mu4e-modeline-face)
-		         " "
-		         (mu4e-context-label)
-		         (if (and mu4e-display-update-status-in-modeline
-			             (buffer-live-p mu4e~update-buffer)
-			             (process-live-p (get-buffer-process
-					                           mu4e~update-buffer)))
-			         (propertize " (updating)" 'face 'mu4e-modeline-face)
-			         "")))))
+                   '(:eval
+                     (concat
+                      (propertize
+                       (mu4e~quote-for-modeline mu4e~headers-last-query)
+                       'face 'mu4e-modeline-face)
+                      " "
+                      (mu4e-context-label)
+                      (if (and mu4e-display-update-status-in-modeline
+                               (buffer-live-p mu4e~update-buffer)
+                               (process-live-p (get-buffer-process
+                                                mu4e~update-buffer)))
+                          (propertize " (updating)" 'face 'mu4e-modeline-face)
+                        "")))))
 
     ;; when the buffer is already visible, select it; otherwise,
     ;; switch to it.
@@ -1261,21 +1261,21 @@ the query history stack."
     (run-hook-with-args 'mu4e-headers-search-hook expr)
     (mu4e~headers-clear mu4e~searching)
     (mu4e~proc-find
-      rewritten-expr
-      mu4e-headers-show-threads
-      mu4e-headers-sort-field
-      mu4e-headers-sort-direction
-      maxnum
-      mu4e-headers-skip-duplicates
-      mu4e-headers-include-related)))
+     rewritten-expr
+     mu4e-headers-show-threads
+     mu4e-headers-sort-field
+     mu4e-headers-sort-direction
+     maxnum
+     mu4e-headers-skip-duplicates
+     mu4e-headers-include-related)))
 
 (defun mu4e~headers-redraw-get-view-window ()
   "Close all windows, redraw the headers buffer based on the value
 of `mu4e-split-view', and return a window for the message view."
   (if (eq mu4e-split-view 'single-window)
-    (or (and (buffer-live-p (mu4e-get-view-buffer))
-	        (get-buffer-window (mu4e-get-view-buffer)))
-	    (selected-window))
+      (or (and (buffer-live-p (mu4e-get-view-buffer))
+               (get-buffer-window (mu4e-get-view-buffer)))
+          (selected-window))
     (mu4e-hide-other-mu4e-buffers)
     (unless (buffer-live-p (mu4e-get-headers-buffer))
       (mu4e-error "No headers buffer available"))
@@ -1285,16 +1285,16 @@ of `mu4e-split-view', and return a window for the message view."
       (kill-buffer (mu4e-get-view-buffer)))
     ;; get a new view window
     (setq mu4e~headers-view-win
-      (let* ((new-win-func
-	             (cond
-	               ((eq mu4e-split-view 'horizontal) ;; split horizontally
-	                 '(split-window-vertically mu4e-headers-visible-lines))
-	               ((eq mu4e-split-view 'vertical) ;; split vertically
-	                 '(split-window-horizontally mu4e-headers-visible-columns)))))
-        (cond ((with-demoted-errors "Unable to split window: %S"
-		             (eval new-win-func)))
-	        (t ;; no splitting; just use the currently selected one
-	          (selected-window)))))))
+          (let* ((new-win-func
+                  (cond
+                   ((eq mu4e-split-view 'horizontal) ;; split horizontally
+                    '(split-window-vertically mu4e-headers-visible-lines))
+                   ((eq mu4e-split-view 'vertical) ;; split vertically
+                    '(split-window-horizontally mu4e-headers-visible-columns)))))
+            (cond ((with-demoted-errors "Unable to split window: %S"
+                     (eval new-win-func)))
+                  (t ;; no splitting; just use the currently selected one
+                   (selected-window)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; search-based marking
@@ -1309,8 +1309,8 @@ corresponding header."
       ;; not really sure why we need to jump to bol; we do need to, otherwise we
       ;; miss lines sometimes...
       (let ((msg (get-text-property (line-beginning-position) 'msg)))
-	      (when msg
-	        (funcall func msg))))))
+        (when msg
+          (funcall func msg))))))
 
 (defun mu4e-headers-find-if (func &optional backward)
   "Move to the next header for which FUNC returns non-`nil',
@@ -1320,15 +1320,15 @@ non-`nil', search backwards. Returns the new position, or `nil' if
 nothing was found. If you want to exclude matches for the current
 message, you can use `mu4e-headers-find-if-next'."
   (let ((pos)
-	       (search-func (if backward 'search-backward 'search-forward)))
+        (search-func (if backward 'search-backward 'search-forward)))
     (save-excursion
       (while (and (null pos)
-	             (funcall search-func mu4e~headers-docid-pre nil t))
-	      ;; not really sure why we need to jump to bol; we do need to, otherwise
-	      ;; we miss lines sometimes...
-	      (let ((msg (get-text-property (line-beginning-position) 'msg)))
-	        (when (and msg (funcall func msg))
-	          (setq pos (point))))))
+                  (funcall search-func mu4e~headers-docid-pre nil t))
+        ;; not really sure why we need to jump to bol; we do need to, otherwise
+        ;; we miss lines sometimes...
+        (let ((msg (get-text-property (line-beginning-position) 'msg)))
+          (when (and msg (funcall func msg))
+            (setq pos (point))))))
     (when pos
       (goto-char pos))))
 
@@ -1339,8 +1339,8 @@ returns non-`nil', starting from the current position."
   (let ((pos))
     (save-excursion
       (if backwards
-	      (beginning-of-line)
-	      (end-of-line))
+          (beginning-of-line)
+        (end-of-line))
       (setq pos (mu4e-headers-find-if func backwards)))
     (when pos (goto-char pos))))
 
@@ -1354,9 +1354,9 @@ arguments, MSG (the message at point) and PARAM (a user-specified
 parameter). MARKPAIR is a cell (MARK . TARGET); see
 `mu4e-mark-at-point' for details about marks."
   (mu4e-headers-for-each
-    (lambda (msg)
-      (when (funcall mark-pred msg param)
-	      (mu4e-mark-at-point (car markpair) (cdr markpair))))))
+   (lambda (msg)
+     (when (funcall mark-pred msg param)
+       (mu4e-mark-at-point (car markpair) (cdr markpair))))))
 
 (defun mu4e-headers-mark-pattern ()
   "Ask user for a kind of mark (move, delete etc.), a field to
@@ -1364,49 +1364,49 @@ match and a regular expression to match with. Then, mark all
 matching messages with that mark."
   (interactive)
   (let ((markpair (mu4e~mark-get-markpair "Mark matched messages with: " t))
-	       (field (mu4e-read-option "Field to match: "
-		              '( ("subject" . :subject)
-		                 ("from"    . :from)
-		                 ("to"      . :to)
-		                 ("cc"      . :cc)
-		                 ("bcc"     . :bcc)
-		                 ("list"    . :mailing-list))))
-	       (pattern (read-string
-		                (mu4e-format "Regexp:")
-		                nil 'mu4e~headers-regexp-hist)))
+        (field (mu4e-read-option "Field to match: "
+                                 '( ("subject" . :subject)
+                                    ("from"    . :from)
+                                    ("to"      . :to)
+                                    ("cc"      . :cc)
+                                    ("bcc"     . :bcc)
+                                    ("list"    . :mailing-list))))
+        (pattern (read-string
+                  (mu4e-format "Regexp:")
+                  nil 'mu4e~headers-regexp-hist)))
     (mu4e-headers-mark-for-each-if
-      markpair
-      (lambda (msg _param)
-	      (let* ((value (mu4e-msg-field msg field)))
-	        (if (member field '(:to :from :cc :bcc :reply-to))
-	          (cl-find-if (lambda (contact)
-			                    (let ((name (car contact)) (email (cdr contact)))
-			                      (or (and name (string-match pattern name))
-			                        (and email (string-match pattern email))))) value)
-	          (string-match pattern (or value ""))))))))
+     markpair
+     (lambda (msg _param)
+       (let* ((value (mu4e-msg-field msg field)))
+         (if (member field '(:to :from :cc :bcc :reply-to))
+             (cl-find-if (lambda (contact)
+                           (let ((name (car contact)) (email (cdr contact)))
+                             (or (and name (string-match pattern name))
+                                 (and email (string-match pattern email))))) value)
+           (string-match pattern (or value ""))))))))
 
 (defun mu4e-headers-mark-custom ()
   "Mark messages based on a user-provided predicate function."
   (interactive)
   (let* ((pred (mu4e-read-option "Match function: "
-		             mu4e-headers-custom-markers))
-	        (param (when (cdr pred) (eval (cdr pred))))
-	        (markpair (mu4e~mark-get-markpair "Mark matched messages with: " t)))
+                                 mu4e-headers-custom-markers))
+         (param (when (cdr pred) (eval (cdr pred))))
+         (markpair (mu4e~mark-get-markpair "Mark matched messages with: " t)))
     (mu4e-headers-mark-for-each-if markpair (car pred) param)))
 
 (defun mu4e~headers-get-thread-info (msg what)
   "Get WHAT (a symbol, either path or thread-id) for MSG."
   (let* ((thread (or (mu4e-message-field msg :thread)
-		               (mu4e-error "No thread info found")))
-	        (path  (or (plist-get thread :path)
-		               (mu4e-error "No threadpath found"))))
+                     (mu4e-error "No thread info found")))
+         (path  (or (plist-get thread :path)
+                    (mu4e-error "No threadpath found"))))
     (cl-case what
       (path path)
       (thread-id
-	      (save-match-data
-	        ;; the thread id is the first segment of the thread path
-	        (when (string-match "^\\([[:xdigit:]]+\\):?" path)
-	          (match-string 1 path))))
+       (save-match-data
+         ;; the thread id is the first segment of the thread path
+         (when (string-match "^\\([[:xdigit:]]+\\):?" path)
+           (match-string 1 path))))
       (otherwise (mu4e-error "Not supported")))))
 
 (defun mu4e-headers-mark-thread-using-markpair (markpair &optional subthread)
@@ -1414,29 +1414,29 @@ matching messages with that mark."
 non-nil, marking is limited to the message at point and its
 descendants."
   (let* ((mark (car markpair))
-	        (allowed-marks (mapcar 'car mu4e-marks)))
+         (allowed-marks (mapcar 'car mu4e-marks)))
     (unless (memq mark allowed-marks)
       (mu4e-error "The mark (%s) has to be one of: %s"
-		    mark allowed-marks)))
+                  mark allowed-marks)))
   ;; note: the tread id is shared by all messages in a thread
   (let* ((msg (mu4e-message-at-point))
-	        (thread-id (mu4e~headers-get-thread-info msg 'thread-id))
-	        (path	   (mu4e~headers-get-thread-info msg 'path))
-	        (last-marked-point))
+         (thread-id (mu4e~headers-get-thread-info msg 'thread-id))
+         (path      (mu4e~headers-get-thread-info msg 'path))
+         (last-marked-point))
     (mu4e-headers-for-each
-      (lambda (mymsg)
-	      (let ((my-thread-id (mu4e~headers-get-thread-info mymsg 'thread-id)))
-	        (if subthread
-	          ;; subthread matching; mymsg's thread path should have path as its
-	          ;; prefix
-	          (when (string-match (concat "^" path)
-		                (mu4e~headers-get-thread-info mymsg 'path))
-	            (mu4e-mark-at-point (car markpair) (cdr markpair))
-	            (setq last-marked-point (point)))
-	          ;; nope; not looking for the subthread; looking for the whole thread
-	          (when (string= thread-id my-thread-id)
-	            (mu4e-mark-at-point (car markpair) (cdr markpair))
-	            (setq last-marked-point (point)))))))
+     (lambda (mymsg)
+       (let ((my-thread-id (mu4e~headers-get-thread-info mymsg 'thread-id)))
+         (if subthread
+             ;; subthread matching; mymsg's thread path should have path as its
+             ;; prefix
+             (when (string-match (concat "^" path)
+                                 (mu4e~headers-get-thread-info mymsg 'path))
+               (mu4e-mark-at-point (car markpair) (cdr markpair))
+               (setq last-marked-point (point)))
+           ;; nope; not looking for the subthread; looking for the whole thread
+           (when (string= thread-id my-thread-id)
+             (mu4e-mark-at-point (car markpair) (cdr markpair))
+             (setq last-marked-point (point)))))))
     (when last-marked-point
       (goto-char last-marked-point)
       (mu4e-headers-next))))
@@ -1444,13 +1444,13 @@ descendants."
 (defun mu4e-headers-mark-thread (&optional subthread markpair)
   "Like `mu4e-headers-mark-thread-using-markpair' but prompt for the markpair."
   (interactive
-    (let* ((subthread current-prefix-arg))
-      (list current-prefix-arg
-	      ;; FIXME: e.g., for refiling we should evaluate this
-	      ;; for each line separately
-	      (mu4e~mark-get-markpair
-	        (if subthread "Mark subthread with: " "Mark whole thread with: ")
-	        t))))
+   (let* ((subthread current-prefix-arg))
+     (list current-prefix-arg
+           ;; FIXME: e.g., for refiling we should evaluate this
+           ;; for each line separately
+           (mu4e~mark-get-markpair
+            (if subthread "Mark subthread with: " "Mark whole thread with: ")
+            t))))
   (mu4e-headers-mark-thread-using-markpair markpair subthread))
 
 (defun mu4e-headers-mark-subthread (&optional markpair)
@@ -1476,21 +1476,21 @@ WHERE is a symbol telling us where to push; it's a symbol, either
 'future or 'past. Functional also removes duplicates, limits the
 stack size."
   (let ((stack
-	        (cl-case where
-	          (past   mu4e~headers-query-past)
-	          (future mu4e~headers-query-future))))
+         (cl-case where
+           (past   mu4e~headers-query-past)
+           (future mu4e~headers-query-future))))
     ;; only add if not the same item
     (unless (and stack (string= (car stack) query))
       (push query stack)
       ;; limit the stack to `mu4e~headers-query-stack-size' elements
       (when (> (length stack) mu4e~headers-query-stack-size)
-	      (setq stack (cl-subseq stack 0 mu4e~headers-query-stack-size)))
+        (setq stack (cl-subseq stack 0 mu4e~headers-query-stack-size)))
       ;; remove all duplicates of the new element
       (cl-remove-if (lambda (elm) (string= elm (car stack))) (cdr stack))
       ;; update the stacks
       (cl-case where
-	      (past   (setq mu4e~headers-query-past   stack))
-	      (future (setq mu4e~headers-query-future stack))))))
+        (past   (setq mu4e~headers-query-past   stack))
+        (future (setq mu4e~headers-query-future stack))))))
 
 (defun mu4e~headers-pop-query (whence)
   "Pop a query from the stack.
@@ -1498,13 +1498,13 @@ WHENCE is a symbol telling us where to get it from, either `future'
 or `past'."
   (cl-case whence
     (past
-      (unless mu4e~headers-query-past
-	      (mu4e-warn "No more previous queries"))
-      (pop mu4e~headers-query-past))
+     (unless mu4e~headers-query-past
+       (mu4e-warn "No more previous queries"))
+     (pop mu4e~headers-query-past))
     (future
-      (unless mu4e~headers-query-future
-	      (mu4e-warn "No more next queries"))
-      (pop mu4e~headers-query-future))))
+     (unless mu4e~headers-query-future
+       (mu4e-warn "No more next queries"))
+     (pop mu4e~headers-query-future))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
@@ -1513,7 +1513,7 @@ or `past'."
   "History list of searches.")
 
 (defun mu4e-headers-search (&optional expr prompt edit
-			                       ignore-history msgid show)
+                                      ignore-history msgid show)
   "Search in the mu database for EXPR, and switch to the output
 buffer for the results. This is an interactive function which ask
 user for EXPR. PROMPT, if non-nil, is the prompt used by this
@@ -1527,15 +1527,15 @@ searching. If SHOW is non-nil, show the message with MSGID."
   ;; `mu4e~headers-query-next' or `mu4e~headers-query-prev'."
   (interactive)
   (let* ((prompt (mu4e-format (or prompt "Search for: ")))
-	        (expr
-	          (if edit
-	            (read-string prompt expr)
-	            (or expr
-		            (read-string prompt nil 'mu4e~headers-search-hist)))))
+         (expr
+          (if edit
+              (read-string prompt expr)
+            (or expr
+                (read-string prompt nil 'mu4e~headers-search-hist)))))
     (mu4e-mark-handle-when-leaving)
     (mu4e~headers-search-execute expr ignore-history)
     (setq mu4e~headers-msgid-target msgid
-      mu4e~headers-view-target show)))
+          mu4e~headers-view-target show)))
 
 (defun mu4e-headers-search-edit ()
   "Edit the last search expression."
@@ -1548,8 +1548,8 @@ If EDIT is non-nil, let the user edit the bookmark before starting
 the search."
   (interactive)
   (let ((expr
-	        (or expr
-	          (mu4e-ask-bookmark (if edit "Select bookmark: " "Bookmark: ")))))
+         (or expr
+             (mu4e-ask-bookmark (if edit "Select bookmark: " "Bookmark: ")))))
     (run-hook-with-args 'mu4e-headers-search-bookmark-hook expr)
     (mu4e-headers-search expr (when edit "Edit bookmark: ") edit)))
 
@@ -1563,14 +1563,14 @@ the search."
 the last search expression. Note that you can go back to previous
 query (effectively, 'widen' it), with `mu4e-headers-query-prev'."
   (interactive
-    (let ((filter
-	          (read-string (mu4e-format "Narrow down to: ")
-	            nil 'mu4e~headers-search-hist nil t)))
-      (list filter)))
+   (let ((filter
+          (read-string (mu4e-format "Narrow down to: ")
+                       nil 'mu4e~headers-search-hist nil t)))
+     (list filter)))
   (unless mu4e~headers-last-query
     (mu4e-warn "There's nothing to filter"))
   (mu4e-headers-search
-    (format "(%s) AND (%s)" mu4e~headers-last-query filter)))
+   (format "(%s) AND (%s)" mu4e~headers-last-query filter)))
 
 (defun mu4e-headers-change-sorting (&optional field dir)
   "Change the sorting/threading parameters.
@@ -1579,34 +1579,34 @@ FIELD is the field to sort by; DIR is a symbol: either 'ascending,
 sortfield, change the sort-order) or nil (ask the user)."
   (interactive)
   (let* ((field
-	         (or field
-	           (mu4e-read-option "Sortfield: " mu4e~headers-sort-field-choices)))
-	        ;; note: 'sortable' is either a boolean (meaning: if non-nil, this is
-	        ;; sortable field), _or_ another field (meaning: sort by this other field).
-	        (sortable (plist-get (cdr (assoc field mu4e-header-info)) :sortable))
-	        ;; error check
-	        (sortable
-	          (if sortable
-	            sortable
-	            (mu4e-error "Not a sortable field")))
-	        (sortfield (if (booleanp sortable) field sortable))
-	        (dir
-	          (cl-case dir
-	            ((ascending descending) dir)
-	            ;; change the sort order if field = curfield
-	            (t
-		            (if (eq sortfield mu4e-headers-sort-field)
-		              (if (eq mu4e-headers-sort-direction 'ascending)
-		                'descending 'ascending)
-		              'descending))
-	            (mu4e-read-option "Direction: "
-		            '(("ascending" . 'ascending) ("descending" . 'descending))))))
+          (or field
+              (mu4e-read-option "Sortfield: " mu4e~headers-sort-field-choices)))
+         ;; note: 'sortable' is either a boolean (meaning: if non-nil, this is
+         ;; sortable field), _or_ another field (meaning: sort by this other field).
+         (sortable (plist-get (cdr (assoc field mu4e-header-info)) :sortable))
+         ;; error check
+         (sortable
+          (if sortable
+              sortable
+            (mu4e-error "Not a sortable field")))
+         (sortfield (if (booleanp sortable) field sortable))
+         (dir
+          (cl-case dir
+            ((ascending descending) dir)
+            ;; change the sort order if field = curfield
+            (t
+             (if (eq sortfield mu4e-headers-sort-field)
+                 (if (eq mu4e-headers-sort-direction 'ascending)
+                     'descending 'ascending)
+               'descending))
+            (mu4e-read-option "Direction: "
+                              '(("ascending" . 'ascending) ("descending" . 'descending))))))
     (setq
-      mu4e-headers-sort-field sortfield
-      mu4e-headers-sort-direction dir)
+     mu4e-headers-sort-field sortfield
+     mu4e-headers-sort-direction dir)
     (mu4e-message "Sorting by %s (%s)"
-      (symbol-name sortfield)
-      (symbol-name mu4e-headers-sort-direction))
+                  (symbol-name sortfield)
+                  (symbol-name mu4e-headers-sort-direction))
     (mu4e-headers-rerun-search)))
 
 (defun mu4e~headers-toggle (name togglevar dont-refresh)
@@ -1614,10 +1614,10 @@ sortfield, change the sort-order) or nil (ask the user)."
 re-run the last search."
   (set togglevar (not (symbol-value togglevar)))
   (mu4e-message "%s turned %s%s"
-    name
-    (if (symbol-value togglevar) "on" "off")
-    (if dont-refresh
-      " (press 'g' to refresh)" ""))
+                name
+                (if (symbol-value togglevar) "on" "off")
+                (if dont-refresh
+                    " (press 'g' to refresh)" ""))
   (unless dont-refresh
     (mu4e-headers-rerun-search)))
 
@@ -1632,21 +1632,21 @@ _not_ refresh the last search with the new setting for threading."
 _not_ refresh the last search with the new setting for threading."
   (interactive "P")
   (mu4e~headers-toggle "Full-search"
-    'mu4e-headers-full-search dont-refresh))
+                       'mu4e-headers-full-search dont-refresh))
 
 (defun mu4e-headers-toggle-include-related (&optional dont-refresh)
   "Toggle `mu4e-headers-include-related'. With prefix-argument, do
 _not_ refresh the last search with the new setting for threading."
   (interactive "P")
   (mu4e~headers-toggle "Include-related"
-    'mu4e-headers-include-related dont-refresh))
+                       'mu4e-headers-include-related dont-refresh))
 
 (defun mu4e-headers-toggle-skip-duplicates (&optional dont-refresh)
   "Toggle `mu4e-headers-skip-duplicates'. With prefix-argument, do
 _not_ refresh the last search with the new setting for threading."
   (interactive "P")
   (mu4e~headers-toggle "Skip-duplicates"
-    'mu4e-headers-skip-duplicates dont-refresh))
+                       'mu4e-headers-skip-duplicates dont-refresh))
 
 (defvar mu4e~headers-loading-buf nil
   "A buffer for loading a message view.")
@@ -1655,25 +1655,25 @@ _not_ refresh the last search with the new setting for threading."
   "Get a buffer to give feedback while loading a message view."
   (unless (buffer-live-p mu4e~headers-loading-buf)
     (setq mu4e~headers-loading-buf
-      (get-buffer-create " *mu4e-loading*")))
+          (get-buffer-create " *mu4e-loading*")))
   (with-current-buffer mu4e~headers-loading-buf
     (read-only-mode)
     (let ((inhibit-read-only t))
       (erase-buffer)
       (local-set-key (kbd "q")
-	      (if (eq mu4e-split-view 'single-window)
-	        'kill-buffer
-	        'kill-buffer-and-window))
+                     (if (eq mu4e-split-view 'single-window)
+                         'kill-buffer
+                       'kill-buffer-and-window))
       (insert (propertize "Waiting for message..."
-		            'face 'mu4e-system-face 'intangible t))))
+                          'face 'mu4e-system-face 'intangible t))))
   mu4e~headers-loading-buf)
 
 (defun mu4e~decrypt-p (msg)
   "Should we decrypt this message?"
   (and (member 'encrypted (mu4e-message-field msg :flags))
-    (if (eq mu4e-decryption-policy 'ask)
-      (yes-or-no-p (mu4e-format "Decrypt message?"))
-      mu4e-decryption-policy)))
+       (if (eq mu4e-decryption-policy 'ask)
+           (yes-or-no-p (mu4e-format "Decrypt message?"))
+         mu4e-decryption-policy)))
 
 (defun mu4e-headers-view-message ()
   "View message at point.
@@ -1686,10 +1686,10 @@ window. "
   (unless (eq major-mode 'mu4e-headers-mode)
     (mu4e-error "Must be in mu4e-headers-mode (%S)" major-mode))
   (let* ((msg (mu4e-message-at-point))
-	        (docid (or (mu4e-message-field msg :docid)
-		               (mu4e-warn "No message at point")))
-	        (decrypt (mu4e~decrypt-p msg))
-	        (viewwin (mu4e~headers-redraw-get-view-window)))
+         (docid (or (mu4e-message-field msg :docid)
+                    (mu4e-warn "No message at point")))
+         (decrypt (mu4e~decrypt-p msg))
+         (viewwin (mu4e~headers-redraw-get-view-window)))
     (unless (window-live-p viewwin)
       (mu4e-error "Cannot get a message view"))
     (select-window viewwin)
@@ -1697,7 +1697,7 @@ window. "
     ;; note, in the 'gnus' case, we don't need to call the server to get the
     ;; body etc., we only need the path which we already have.
     (if mu4e-view-use-gnus
-      (mu4e-view msg)
+        (mu4e-view msg)
       (mu4e~proc-view docid mu4e-view-show-images decrypt))))
 
 (defun mu4e-headers-rerun-search ()
@@ -1705,7 +1705,7 @@ window. "
   (interactive)
   ;; if possible, try to return to the same message
   (let* ((msg (mu4e-message-at-point t))
-	        (msgid (and msg (mu4e-message-field msg :message-id))))
+         (msgid (and msg (mu4e-message-field msg :message-id))))
     (mu4e-headers-search mu4e~headers-last-query nil nil t msgid)))
 
 (defun mu4e~headers-query-navigate (whence)
@@ -1713,7 +1713,7 @@ window. "
 WHENCE determines where the query is taken from and is a symbol,
 either `future' or `past'."
   (let ((query (mu4e~headers-pop-query whence))
-	       (where (if (eq whence 'future) 'past 'future)))
+        (where (if (eq whence 'future) 'past 'future)))
     (when query
       (mu4e~headers-push-query mu4e~headers-last-query where)
       (mu4e-headers-search query nil nil t))))
@@ -1733,8 +1733,8 @@ either `future' or `past'."
   "Forget all the complete query history."
   (interactive)
   (setq ;; note: don't forget the present one
-    mu4e~headers-query-past nil
-    mu4e~headers-query-future nil)
+   mu4e~headers-query-past nil
+   mu4e~headers-query-future nil)
   (mu4e-message "Query history cleared"))
 
 (defun mu4e~headers-move (lines)
@@ -1744,22 +1744,22 @@ docid. Otherwise, return nil."
   (unless (eq major-mode 'mu4e-headers-mode)
     (mu4e-error "Must be in mu4e-headers-mode (%S)" major-mode))
   (let* ((_succeeded (zerop (forward-line lines)))
-	       (docid (mu4e~headers-docid-at-point)))
+         (docid (mu4e~headers-docid-at-point)))
     ;; move point, even if this function is called when this window is not
     ;; visible
     (when docid
       ;; update all windows showing the headers buffer
       (walk-windows
-        (lambda (win)
-	        (when (eq (window-buffer win) (mu4e-get-headers-buffer))
-	          (set-window-point win (point))))
-        nil t)
+       (lambda (win)
+         (when (eq (window-buffer win) (mu4e-get-headers-buffer))
+           (set-window-point win (point))))
+       nil t)
       (if (eq mu4e-split-view 'single-window)
-	      (when (eq (window-buffer) (mu4e-get-view-buffer))
-	        (mu4e-headers-view-message))
-	      ;; update message view if it was already showing
-	      (when (and mu4e-split-view (window-live-p mu4e~headers-view-win))
-	        (mu4e-headers-view-message)))
+          (when (eq (window-buffer) (mu4e-get-view-buffer))
+            (mu4e-headers-view-message))
+        ;; update message view if it was already showing
+        (when (and mu4e-split-view (window-live-p mu4e~headers-view-win))
+          (mu4e-headers-view-message)))
       ;; attempt to highlight the new line, display the message
       (mu4e~headers-highlight docid)
       docid)))
@@ -1785,12 +1785,12 @@ previous header."
 untrashed). If BACKWARDS is non-`nil', move backwards."
   (interactive)
   (or (mu4e-headers-find-if-next
-	      (lambda (msg)
-	        (let ((flags (mu4e-message-field msg :flags)))
-	          (and (member 'unread flags) (not (member 'trashed flags)))))
-	      backwards)
-    (mu4e-message (format "No %s unread message found"
-		                (if backwards "previous" "next")))))
+       (lambda (msg)
+         (let ((flags (mu4e-message-field msg :flags)))
+           (and (member 'unread flags) (not (member 'trashed flags)))))
+       backwards)
+      (mu4e-message (format "No %s unread message found"
+                            (if backwards "previous" "next")))))
 
 (defun mu4e-headers-prev-unread ()
   "Move point to the previous message that is unread (and
@@ -1808,8 +1808,8 @@ untrashed)."
   "Show the messages in maildir (user is prompted to ask what
 maildir)."
   (interactive
-    (let ((maildir (mu4e-ask-maildir "Jump to maildir: ")))
-      (list maildir)))
+   (let ((maildir (mu4e-ask-maildir "Jump to maildir: ")))
+     (list maildir)))
   (when maildir
     (mu4e-mark-handle-when-leaving)
     (mu4e-headers-search (format "maildir:\"%s\"" maildir))))
@@ -1822,17 +1822,17 @@ If N is negative shrink the headers window.  When not in split-view
 do nothing."
   (interactive "P")
   (let ((n (or n 1))
-	       (hwin (get-buffer-window (mu4e-get-headers-buffer))))
+        (hwin (get-buffer-window (mu4e-get-headers-buffer))))
     (when (and (buffer-live-p (mu4e-get-view-buffer)) (window-live-p hwin))
       (let ((n (or n 1)))
         (cl-case mu4e-split-view
-	        ;; emacs has weird ideas about what horizontal, vertical means...
-	        (horizontal
-	          (window-resize hwin n nil)
-	          (cl-incf mu4e-headers-visible-lines n))
-	        (vertical
-	          (window-resize hwin n t)
-	          (cl-incf mu4e-headers-visible-columns n)))))))
+          ;; emacs has weird ideas about what horizontal, vertical means...
+          (horizontal
+           (window-resize hwin n nil)
+           (cl-incf mu4e-headers-visible-lines n))
+          (vertical
+           (window-resize hwin n t)
+           (cl-incf mu4e-headers-visible-columns n)))))))
 
 (defun mu4e-headers-split-view-shrink (&optional n)
   "In split-view, shrink the headers window.
@@ -1850,7 +1850,7 @@ pass ACTIONFUNC, which is a function that takes a msg-plist
 argument."
   (interactive)
   (let ((msg (mu4e-message-at-point))
-	       (afunc (or actionfunc (mu4e-read-option "Action: " mu4e-headers-actions))))
+        (afunc (or actionfunc (mu4e-read-option "Action: " mu4e-headers-actions))))
     (funcall afunc msg)))
 
 (defun mu4e-headers-mark-and-next (mark)
@@ -1866,27 +1866,27 @@ This is a rather complex function, to ensure we don't disturb
 other windows."
   (interactive)
   (if (eq mu4e-split-view 'single-window)
-    (progn (mu4e-mark-handle-when-leaving)
-	    (kill-buffer))
+      (progn (mu4e-mark-handle-when-leaving)
+             (kill-buffer))
     (unless (eq major-mode 'mu4e-headers-mode)
       (mu4e-error "Must be in mu4e-headers-mode (%S)" major-mode))
     (mu4e-mark-handle-when-leaving)
     (let ((curbuf (current-buffer))
-	         (curwin (selected-window)))
+          (curwin (selected-window)))
       (walk-windows
-	      (lambda (win)
-	        (with-selected-window win
-	          ;; if we the view window connected to this one, kill it
-	          (when (and (not (one-window-p win)) (eq mu4e~headers-view-win win))
-	            (delete-window win)
-	            (setq mu4e~headers-view-win nil)))
-	        ;; and kill any _other_ (non-selected) window that shows the current
-	        ;; buffer
-	        (when (and
-		              (eq curbuf (window-buffer win)) ;; does win show curbuf?
-		              (not (eq curwin win))	        ;; it's not the curwin?
-		              (not (one-window-p)))           ;; and not the last one?
-	          (delete-window win))))  ;; delete it!
+       (lambda (win)
+         (with-selected-window win
+           ;; if we the view window connected to this one, kill it
+           (when (and (not (one-window-p win)) (eq mu4e~headers-view-win win))
+             (delete-window win)
+             (setq mu4e~headers-view-win nil)))
+         ;; and kill any _other_ (non-selected) window that shows the current
+         ;; buffer
+         (when (and
+                (eq curbuf (window-buffer win)) ;; does win show curbuf?
+                (not (eq curwin win))             ;; it's not the curwin?
+                (not (one-window-p)))           ;; and not the last one?
+           (delete-window win))))  ;; delete it!
       ;; now, all *other* windows should be gone. kill ourselves, and return
       ;; to the main view
       (kill-buffer)

--- a/mu4e/mu4e-icalendar.el
+++ b/mu4e/mu4e-icalendar.el
@@ -52,34 +52,34 @@
   (cl-defmethod gnus-icalendar-event:inline-reply-buttons :around
     ((event gnus-icalendar-event) handle)
     (if (and (boundp 'mu4e~view-rendering)
-          (gnus-icalendar-event:rsvp event))
-      (let ((method (gnus-icalendar-event:method event)))
-        (when (or (string= method "REQUEST") (string= method "PUBLISH"))
-          `(("Accept" mu4e-icalendar-reply (,handle accepted ,event))
-             ("Tentative" mu4e-icalendar-reply (,handle tentative ,event))
-             ("Decline" mu4e-icalendar-reply (,handle declined ,event)))))
+             (gnus-icalendar-event:rsvp event))
+        (let ((method (gnus-icalendar-event:method event)))
+          (when (or (string= method "REQUEST") (string= method "PUBLISH"))
+            `(("Accept" mu4e-icalendar-reply (,handle accepted ,event))
+              ("Tentative" mu4e-icalendar-reply (,handle tentative ,event))
+              ("Decline" mu4e-icalendar-reply (,handle declined ,event)))))
       (cl-call-next-method event handle))))
 
 (defun mu4e-icalendar-reply (data)
   "Reply to the text/calendar event present in DATA."
   ;; Based on `gnus-icalendar-reply'.
   (let* ((handle (car data))
-          (status (cadr data))
-          (event (caddr data))
-          (gnus-icalendar-additional-identities (mu4e-personal-addresses))
-          (reply (gnus-icalendar-with-decoded-handle handle
-                   (gnus-icalendar-event-reply-from-buffer
-                     (current-buffer) status (gnus-icalendar-identities))))
-          (msg (mu4e-message-at-point 'noerror))
-          (charset (cdr (assoc 'charset (mm-handle-type handle)))))
+         (status (cadr data))
+         (event (caddr data))
+         (gnus-icalendar-additional-identities (mu4e-personal-addresses))
+         (reply (gnus-icalendar-with-decoded-handle handle
+                                                    (gnus-icalendar-event-reply-from-buffer
+                                                     (current-buffer) status (gnus-icalendar-identities))))
+         (msg (mu4e-message-at-point 'noerror))
+         (charset (cdr (assoc 'charset (mm-handle-type handle)))))
     (when reply
       (cl-labels
-	      ((fold-icalendar-buffer
-	         ()
-	         (goto-char (point-min))
-	         (while (re-search-forward "^\\(.\\{72\\}\\)\\(.+\\)$" nil t)
-	           (replace-match "\\1\n \\2")
-	           (goto-char (line-beginning-position)))))
+          ((fold-icalendar-buffer
+            ()
+            (goto-char (point-min))
+            (while (re-search-forward "^\\(.\\{72\\}\\)\\(.+\\)$" nil t)
+              (replace-match "\\1\n \\2")
+              (goto-char (line-beginning-position)))))
 
         (with-current-buffer (get-buffer-create gnus-icalendar-reply-bufname)
           (delete-region (point-min) (point-max))
@@ -95,7 +95,7 @@
           (gnus-icalendar--update-org-event event status))
         (when mu4e-icalendar-diary-file
           (mu4e~icalendar-insert-diary event status
-            mu4e-icalendar-diary-file))))))
+                                       mu4e-icalendar-diary-file))))))
 
 (defun mu4e~icalendar-delete-citation ()
   "Function passed to `mu4e-compose-cite-function' to remove the citation."
@@ -107,17 +107,17 @@
     "See `mu4e-sent-handler' for DOCID and PATH."
     (mu4e-sent-handler docid path)
     (let* ((docid (mu4e-message-field original-msg :docid))
-            (markdescr (assq 'trash mu4e-marks))
-            (action (plist-get (cdr markdescr) :action))
-            (target (mu4e-get-trash-folder original-msg)))
+           (markdescr (assq 'trash mu4e-marks))
+           (action (plist-get (cdr markdescr) :action))
+           (target (mu4e-get-trash-folder original-msg)))
       (with-current-buffer (mu4e-get-headers-buffer)
         (run-hook-with-args 'mu4e-mark-execute-pre-hook 'trash original-msg)
         (funcall action docid original-msg target))
       (when (and (mu4e~headers-view-this-message-p docid)
-              (buffer-live-p (mu4e-get-view-buffer)))
+                 (buffer-live-p (mu4e-get-view-buffer)))
         (switch-to-buffer (mu4e-get-view-buffer))
         (or (mu4e-view-headers-next)
-          (kill-buffer-and-window))))))
+            (kill-buffer-and-window))))))
 
 (defun mu4e-icalendar-reply-ical (original-msg event status buffer-name)
   "Reply to ORIGINAL-MSG containing invitation EVENT with STATUS.
@@ -126,8 +126,8 @@ STATUS values.  BUFFER-NAME is the name of the buffer holding the
 response in icalendar format."
   (let ((message-signature nil))
     (let ((mu4e-compose-cite-function #'mu4e~icalendar-delete-citation)
-           (mu4e-sent-messages-behavior 'delete)
-           (mu4e-compose-reply-recipients 'sender))
+          (mu4e-sent-messages-behavior 'delete)
+          (mu4e-compose-reply-recipients 'sender))
       (mu4e~compose-handler 'reply original-msg))
     ;; Make sure the recipient is the organizer
     (let ((organizer (gnus-icalendar-event:organizer event)))
@@ -141,23 +141,23 @@ response in icalendar format."
     (mml-insert-multipart "alternative")
     (mml-insert-part "text/plain")
     (let ((reply-event (gnus-icalendar-event-from-buffer
-                         buffer-name (mu4e-personal-addresses))))
+                        buffer-name (mu4e-personal-addresses))))
       (insert (gnus-icalendar-event->gnus-calendar reply-event status)))
     (forward-line 1); move past closing tag
     (mml-attach-buffer buffer-name "text/calendar; method=REPLY; charset=utf-8")
     (message-remove-header "Subject")
     (message-goto-subject)
     (insert (capitalize (symbol-name status))
-      ": " (gnus-icalendar-event:summary event))
+            ": " (gnus-icalendar-event:summary event))
     (set-buffer-modified-p nil); not yet modified by user
     (when mu4e-icalendar-trash-after-reply
       ;; Override `mu4e-sent-handler' set by `mu4e-compose-mode' to
       ;; also trash the message (thus must be appended to hooks).
       (add-hook
-        'message-sent-hook
-        (lambda () (setq mu4e-sent-func
-                     (mu4e~icalendar-trash-message original-msg)))
-        t t))))
+       'message-sent-hook
+       (lambda () (setq mu4e-sent-func
+                   (mu4e~icalendar-trash-message original-msg)))
+       t t))))
 
 
 (defun mu4e~icalendar-insert-diary (event reply-status filename)
@@ -166,20 +166,20 @@ REPLY-STATUS is the status of the reply.  The possible values are
 given in the doc of `gnus-icalendar-event-reply-from-buffer'."
   ;; FIXME: handle recurring events
   (let* ((beg (gnus-icalendar-event:start-time event))
-          (beg-date (format-time-string "%d/%m/%Y" beg))
-          (beg-time (format-time-string "%H:%M" beg))
-          (end (gnus-icalendar-event:end-time event))
-          (end-date (format-time-string "%d/%m/%Y" end))
-          (end-time (format-time-string "%H:%M" end))
-          (summary (gnus-icalendar-event:summary event))
-          (location (gnus-icalendar-event:location event))
-          (status (capitalize (symbol-name reply-status)))
-          (txt (if location
-                 (format "%s (%s)\n %s " summary status location)
-                 (format "%s (%s)" summary status))))
+         (beg-date (format-time-string "%d/%m/%Y" beg))
+         (beg-time (format-time-string "%H:%M" beg))
+         (end (gnus-icalendar-event:end-time event))
+         (end-date (format-time-string "%d/%m/%Y" end))
+         (end-time (format-time-string "%H:%M" end))
+         (summary (gnus-icalendar-event:summary event))
+         (location (gnus-icalendar-event:location event))
+         (status (capitalize (symbol-name reply-status)))
+         (txt (if location
+                  (format "%s (%s)\n %s " summary status location)
+                (format "%s (%s)" summary status))))
     (with-temp-buffer
       (if (string= beg-date end-date)
-        (insert beg-date " " beg-time "-" end-time " " txt "\n")
+          (insert beg-date " " beg-time "-" end-time " " txt "\n")
         (insert beg-date " " beg-time " Start of: " txt "\n")
         (insert beg-date " " end-time " End of: " txt "\n"))
       (write-region (point-min) (point-max) filename t))))

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -71,9 +71,8 @@
   "Major mode for the mu4e main screen.
 \\{mu4e-main-mode-map}."
   (use-local-map mu4e-main-mode-map)
-  (setq
-    truncate-lines t
-    overwrite-mode 'overwrite-mode-binary)
+  (setq truncate-lines t)
+  (setq overwrite-mode 'overwrite-mode-binary)
 
   ;; show context in mode-string
   (make-local-variable 'global-mode-string)
@@ -88,23 +87,23 @@ when STR is clicked (using RET or mouse-2); if FUNC-OR-SHORTCUT is
 a string, execute the corresponding keyboard action when it is
 clicked."
   (let ((newstr
-	        (replace-regexp-in-string
-	          "\\[\\(..?\\)\\]"
-	          (lambda(m)
-	            (format "[%s]"
-		            (propertize (match-string 1 m) 'face 'mu4e-highlight-face)))
-	          str))
-	       (map (make-sparse-keymap))
-	       (func (if (functionp func-or-shortcut)
-		             func-or-shortcut
-		             (if (stringp func-or-shortcut)
-                   (lambda()(interactive)
-			               (execute-kbd-macro func-or-shortcut))))))
+         (replace-regexp-in-string
+          "\\[\\(..?\\)\\]"
+          (lambda(m)
+            (format "[%s]"
+                    (propertize (match-string 1 m) 'face 'mu4e-highlight-face)))
+          str))
+        (map (make-sparse-keymap))
+        (func (if (functionp func-or-shortcut)
+                  func-or-shortcut
+                (if (stringp func-or-shortcut)
+                    (lambda()(interactive)
+                      (execute-kbd-macro func-or-shortcut))))))
     (define-key map [mouse-2] func)
     (define-key map (kbd "RET") func)
     (put-text-property 0 (length newstr) 'keymap map newstr)
     (put-text-property (string-match "\\[.+$" newstr)
-      (- (length newstr) 1) 'mouse-face 'highlight newstr)
+                       (- (length newstr) 1) 'mouse-face 'highlight newstr)
     newstr))
 
 
@@ -125,8 +124,8 @@ clicked."
            concat (concat
                    ;; menu entry
                    (mu4e~main-action-str
-	            (concat "\t* [b" key "] " name)
-	            (concat "b" key))
+                    (concat "\t* [b" key "] " name)
+                    (concat "b" key))
                    ;; append all/unread numbers, if available.
                    (if qcounts
                        (let ((unread (plist-get (car qcounts) :unread))
@@ -144,99 +143,99 @@ clicked."
 (defun mu4e~key-val (key val &optional unit)
   "Return a key / value pair."
   (concat
-    "        * "
-    (propertize (format "%-20s" key) 'face 'mu4e-header-title-face)
-    ": "
-    (propertize val 'face 'mu4e-header-key-face)
-    (if unit
-      (propertize (concat " " unit) 'face 'mu4e-header-title-face)
-      "")
-    "\n"))
+   "        * "
+   (propertize (format "%-20s" key) 'face 'mu4e-header-title-face)
+   ": "
+   (propertize val 'face 'mu4e-header-key-face)
+   (if unit
+       (propertize (concat " " unit) 'face 'mu4e-header-title-face)
+     "")
+   "\n"))
 
 ;; NEW
 ;; This is the old `mu4e~main-view' function but without
 ;; buffer switching at the end.
 (defun mu4e~main-view-real (_ignore-auto _noconfirm)
   (let ((buf (get-buffer-create mu4e~main-buffer-name))
-	       (inhibit-read-only t))
+        (inhibit-read-only t))
     (with-current-buffer buf
       (erase-buffer)
       (insert
-        "* "
-        (propertize "mu4e" 'face 'mu4e-header-key-face)
-	      (propertize " - mu for emacs version " 'face 'mu4e-title-face)
-	      (propertize  mu4e-mu-version 'face 'mu4e-header-key-face)
-        "\n\n"
-        (propertize "  Basics\n\n" 'face 'mu4e-title-face)
-	      (mu4e~main-action-str
-	        "\t* [j]ump to some maildir\n" 'mu4e-jump-to-maildir)
-	      (mu4e~main-action-str
-	        "\t* enter a [s]earch query\n" 'mu4e-search)
-	      (mu4e~main-action-str
-	        "\t* [C]ompose a new message\n" 'mu4e-compose-new)
-        "\n"
-        (propertize "  Bookmarks\n\n" 'face 'mu4e-title-face)
-        (mu4e~main-bookmarks)
-        "\n"
-        (propertize "  Misc\n\n" 'face 'mu4e-title-face)
+       "* "
+       (propertize "mu4e" 'face 'mu4e-header-key-face)
+       (propertize " - mu for emacs version " 'face 'mu4e-title-face)
+       (propertize  mu4e-mu-version 'face 'mu4e-header-key-face)
+       "\n\n"
+       (propertize "  Basics\n\n" 'face 'mu4e-title-face)
+       (mu4e~main-action-str
+        "\t* [j]ump to some maildir\n" 'mu4e-jump-to-maildir)
+       (mu4e~main-action-str
+        "\t* enter a [s]earch query\n" 'mu4e-search)
+       (mu4e~main-action-str
+        "\t* [C]ompose a new message\n" 'mu4e-compose-new)
+       "\n"
+       (propertize "  Bookmarks\n\n" 'face 'mu4e-title-face)
+       (mu4e~main-bookmarks)
+       "\n"
+       (propertize "  Misc\n\n" 'face 'mu4e-title-face)
 
-	      (mu4e~main-action-str "\t* [;]Switch context\n" 'mu4e-context-switch)
+       (mu4e~main-action-str "\t* [;]Switch context\n" 'mu4e-context-switch)
 
-	      (mu4e~main-action-str "\t* [U]pdate email & database\n"
-	        'mu4e-update-mail-and-index)
+       (mu4e~main-action-str "\t* [U]pdate email & database\n"
+                             'mu4e-update-mail-and-index)
 
-	      ;; show the queue functions if `smtpmail-queue-dir' is defined
-	      (if (file-directory-p smtpmail-queue-dir)
-	        (mu4e~main-view-queue)
-	        "")
-	      "\n"
-	      (mu4e~main-action-str "\t* [N]ews\n" 'mu4e-news)
-	      (mu4e~main-action-str "\t* [A]bout mu4e\n" 'mu4e-about)
-	      (mu4e~main-action-str "\t* [H]elp\n" 'mu4e-display-manual)
-	      (mu4e~main-action-str "\t* [q]uit\n" 'mu4e-quit)
+       ;; show the queue functions if `smtpmail-queue-dir' is defined
+       (if (file-directory-p smtpmail-queue-dir)
+           (mu4e~main-view-queue)
+         "")
+       "\n"
+       (mu4e~main-action-str "\t* [N]ews\n" 'mu4e-news)
+       (mu4e~main-action-str "\t* [A]bout mu4e\n" 'mu4e-about)
+       (mu4e~main-action-str "\t* [H]elp\n" 'mu4e-display-manual)
+       (mu4e~main-action-str "\t* [q]uit\n" 'mu4e-quit)
 
-        "\n"
-        (propertize "  Info\n\n" 'face 'mu4e-title-face)
-        (mu4e~key-val "database-path" (mu4e-database-path))
-        (mu4e~key-val "maildir" (mu4e-root-maildir))
-        (mu4e~key-val "in store"
-          (format "%d" (plist-get mu4e~server-props :doccount)) "messages"))
+       "\n"
+       (propertize "  Info\n\n" 'face 'mu4e-title-face)
+       (mu4e~key-val "database-path" (mu4e-database-path))
+       (mu4e~key-val "maildir" (mu4e-root-maildir))
+       (mu4e~key-val "in store"
+                     (format "%d" (plist-get mu4e~server-props :doccount)) "messages"))
       (mu4e-main-mode))))
 
 (defun mu4e~main-view-queue ()
   "Display queue-related actions in the main view."
   (concat
-    (mu4e~main-action-str "\t* toggle [m]ail sending mode "
-			'mu4e~main-toggle-mail-sending-mode)
-    "(currently "
-    (propertize (if smtpmail-queue-mail "queued" "direct")
-	    'face 'mu4e-header-key-face)
-    ")\n"
-    (let ((queue-size (mu4e~main-queue-size)))
-      (if (zerop queue-size)
-	      ""
-        (mu4e~main-action-str
-	        (format "\t* [f]lush %s queued %s\n"
-		        (propertize (int-to-string queue-size)
-			        'face 'mu4e-header-key-face)
-		        (if (> queue-size 1) "mails" "mail"))
-	        'smtpmail-send-queued-mail)))))
+   (mu4e~main-action-str "\t* toggle [m]ail sending mode "
+                         'mu4e~main-toggle-mail-sending-mode)
+   "(currently "
+   (propertize (if smtpmail-queue-mail "queued" "direct")
+               'face 'mu4e-header-key-face)
+   ")\n"
+   (let ((queue-size (mu4e~main-queue-size)))
+     (if (zerop queue-size)
+         ""
+       (mu4e~main-action-str
+        (format "\t* [f]lush %s queued %s\n"
+                (propertize (int-to-string queue-size)
+                            'face 'mu4e-header-key-face)
+                (if (> queue-size 1) "mails" "mail"))
+        'smtpmail-send-queued-mail)))))
 
 (defun mu4e~main-queue-size ()
   "Return, as an int, the number of emails in the queue."
   (condition-case nil
-    (with-temp-buffer
-	    (insert-file-contents (expand-file-name smtpmail-queue-index-file
-						                  smtpmail-queue-dir))
-	    (count-lines (point-min) (point-max)))
+      (with-temp-buffer
+        (insert-file-contents (expand-file-name smtpmail-queue-index-file
+                                                smtpmail-queue-dir))
+        (count-lines (point-min) (point-max)))
     (error 0)))
 
 (defun mu4e~main-view ()
   "Create the mu4e main-view, and switch to it."
   (if (eq mu4e-split-view 'single-window)
-    (if (buffer-live-p (mu4e-get-headers-buffer))
-	    (switch-to-buffer (mu4e-get-headers-buffer))
-	    (mu4e~main-menu))
+      (if (buffer-live-p (mu4e-get-headers-buffer))
+          (switch-to-buffer (mu4e-get-headers-buffer))
+        (mu4e~main-menu))
     (mu4e~main-view-real nil nil)
     (switch-to-buffer mu4e~main-buffer-name)
     (goto-char (point-min)))
@@ -253,7 +252,7 @@ clicked."
     (mu4e-error "`smtpmail-queue-dir' does not exist"))
   (setq smtpmail-queue-mail (not smtpmail-queue-mail))
   (message (concat "Outgoing mail will now be "
-		         (if smtpmail-queue-mail "queued" "sent directly")))
+                   (if smtpmail-queue-mail "queued" "sent directly")))
   (unless (eq mu4e-split-view 'single-window)
     (let ((curpos (point)))
       (mu4e~main-view-real nil nil)
@@ -263,29 +262,29 @@ clicked."
   "mu4e main view in the minibuffer."
   (interactive)
   (let ((key
-	        (read-key
-	          (mu4e-format
-	            "%s"
-	            (concat
-	              (mu4e~main-action-str "[j]ump " 'mu4e-jump-to-maildir)
-	              (mu4e~main-action-str "[s]earch " 'mu4e-search)
-	              (mu4e~main-action-str "[C]ompose " 'mu4e-compose-new)
-	              (mu4e~main-action-str "[b]ookmarks " 'mu4e-headers-search-bookmark)
-	              (mu4e~main-action-str "[;]Switch context " 'mu4e-context-switch)
-	              (mu4e~main-action-str "[U]pdate " 'mu4e-update-mail-and-index)
-	              (mu4e~main-action-str "[N]ews " 'mu4e-news)
-	              (mu4e~main-action-str "[A]bout " 'mu4e-about)
-	              (mu4e~main-action-str "[H]elp " 'mu4e-display-manual))))))
+         (read-key
+          (mu4e-format
+           "%s"
+           (concat
+            (mu4e~main-action-str "[j]ump " 'mu4e-jump-to-maildir)
+            (mu4e~main-action-str "[s]earch " 'mu4e-search)
+            (mu4e~main-action-str "[C]ompose " 'mu4e-compose-new)
+            (mu4e~main-action-str "[b]ookmarks " 'mu4e-headers-search-bookmark)
+            (mu4e~main-action-str "[;]Switch context " 'mu4e-context-switch)
+            (mu4e~main-action-str "[U]pdate " 'mu4e-update-mail-and-index)
+            (mu4e~main-action-str "[N]ews " 'mu4e-news)
+            (mu4e~main-action-str "[A]bout " 'mu4e-about)
+            (mu4e~main-action-str "[H]elp " 'mu4e-display-manual))))))
     (unless (member key '(?\C-g ?\C-\[))
       (let ((mu4e-command (lookup-key mu4e-main-mode-map (string key) t)))
-	      (if mu4e-command
-	        (condition-case err
-		        (let ((mu4e-hide-index-messages t))
-		          (call-interactively mu4e-command))
-	          (error (when (cadr err) (message (cadr err)))))
-	        (message (mu4e-format "key %s not bound to a command" (string key))))
-	      (when (or (not mu4e-command) (eq mu4e-command 'mu4e-context-switch))
-	        (sit-for 1)
-	        (mu4e~main-menu))))))
+        (if mu4e-command
+            (condition-case err
+                (let ((mu4e-hide-index-messages t))
+                  (call-interactively mu4e-command))
+              (error (when (cadr err) (message (cadr err)))))
+          (message (mu4e-format "key %s not bound to a command" (string key))))
+        (when (or (not mu4e-command) (eq mu4e-command 'mu4e-context-switch))
+          (sit-for 1)
+          (mu4e~main-menu))))))
 
 (provide 'mu4e-main)

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -1,4 +1,4 @@
-;; mu4e-mark.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
+;;; mu4e-mark.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2011-2020 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -44,8 +44,8 @@ Value is one of the following symbols:
 - `apply'   automatically apply the marks before doing anything else
 - `ignore'  automatically ignore the marks without asking"
   :type '(choice (const ask    :tag "ask user whether to ignore marks")
-	   (const apply  :tag "apply marks without asking")
-	   (const ignore :tag "ignore marks without asking"))
+                 (const apply  :tag "apply marks without asking")
+                 (const ignore :tag "ignore marks without asking"))
   :group 'mu4e-headers)
 
 (defcustom mu4e-mark-execute-pre-hook nil
@@ -96,98 +96,98 @@ TARGET (optional) is the target directory (for 'move')")
 (defun mu4e~mark-find-headers-buffer ()
   "Find the headers buffer, if any."
   (cl-find-if
-    (lambda (b)
-      (with-current-buffer b
-	(eq major-mode 'mu4e-headers-mode)))
-    (buffer-list)))
+   (lambda (b)
+     (with-current-buffer b
+       (eq major-mode 'mu4e-headers-mode)))
+   (buffer-list)))
 
 (defmacro mu4e~mark-in-context (&rest body)
   "Evaluate BODY in the context of the headers buffer.
 The current buffer must be either a headers or view buffer."
   `(cond
-     ((eq major-mode 'mu4e-headers-mode) ,@body)
-     ((eq major-mode 'mu4e-view-mode)
-       (when (buffer-live-p (mu4e-get-headers-buffer))
-	 (let* ((msg (mu4e-message-at-point))
-		 (docid (mu4e-message-field msg :docid)))
-	   (with-current-buffer (mu4e-get-headers-buffer)
-	     (if (mu4e~headers-goto-docid docid)
-	       ,@body
-	       (mu4e-error "Cannot find message in headers buffer"))))))
-     (t
-       ;; even in other modes (e.g. mu4e-main-mode we try to find
-       ;; the headers buffer
-       (let ((hbuf (mu4e~mark-find-headers-buffer)))
-	 (if (buffer-live-p hbuf)
-	   (with-current-buffer hbuf ,@body)
-	   ,@body)))))
+    ((eq major-mode 'mu4e-headers-mode) ,@body)
+    ((eq major-mode 'mu4e-view-mode)
+     (when (buffer-live-p (mu4e-get-headers-buffer))
+       (let* ((msg (mu4e-message-at-point))
+              (docid (mu4e-message-field msg :docid)))
+         (with-current-buffer (mu4e-get-headers-buffer)
+           (if (mu4e~headers-goto-docid docid)
+               ,@body
+             (mu4e-error "Cannot find message in headers buffer"))))))
+    (t
+     ;; even in other modes (e.g. mu4e-main-mode we try to find
+     ;; the headers buffer
+     (let ((hbuf (mu4e~mark-find-headers-buffer)))
+       (if (buffer-live-p hbuf)
+           (with-current-buffer hbuf ,@body)
+         ,@body)))))
 
 (defconst mu4e-marks
-    '((refile
-	:char ("r" . "▶")
-	:prompt "refile"
-	:dyn-target (lambda (target msg) (mu4e-get-refile-folder msg))
-	:action (lambda (docid msg target)
-		  (mu4e~proc-move docid (mu4e~mark-check-target target) "-N")))
-       (delete
-	 :char ("D" . "x")
-	 :prompt "Delete"
-	 :show-target (lambda (target) "delete")
-	 :action (lambda (docid msg target) (mu4e~proc-remove docid)))
-       (flag
-	 :char ("+" . "✚")
-	 :prompt "+flag"
-	 :show-target (lambda (target) "flag")
-	 :action (lambda (docid msg target)
-		   (mu4e~proc-move docid nil "+F-u-N")))
-       (move
-	 :char ("m" . "▷")
-	 :prompt "move"
-	 :ask-target  mu4e~mark-get-move-target
-	 :action (lambda (docid msg target)
-		   (mu4e~proc-move docid (mu4e~mark-check-target target) "-N")))
-       (read
-	 :char    ("!" . "◼")
-	 :prompt "!read"
-	 :show-target (lambda (target) "read")
-	 :action (lambda (docid msg target) (mu4e~proc-move docid nil "+S-u-N")))
-       (trash
-	 :char ("d" . "▼")
-	 :prompt "dtrash"
-	 :dyn-target (lambda (target msg) (mu4e-get-trash-folder msg))
-	 :action (lambda (docid msg target) (mu4e~proc-move docid
-					      (mu4e~mark-check-target target) "+T-N")))
-       (unflag
-	 :char    ("-" . "➖")
-	 :prompt "-unflag"
-	 :show-target (lambda (target) "unflag")
-	 :action (lambda (docid msg target) (mu4e~proc-move docid nil "-F-N")))
-       (untrash
-	 :char   ("=" . "▲")
-	 :prompt "=untrash"
-	 :show-target (lambda (target) "untrash")
-	 :action (lambda (docid msg target) (mu4e~proc-move docid nil "-T")))
-       (unread
-	 :char    ("?" . "◻")
-	 :prompt "?unread"
-	 :show-target (lambda (target) "unread")
-	 :action (lambda (docid msg target) (mu4e~proc-move docid nil "-S+u-N")))
-       (unmark
-	 :char  " "
-	 :prompt "unmark"
-	 :action (mu4e-error "No action for unmarking"))
-       (action
-	 :char ( "a" . "◯")
-	 :prompt "action"
-	 :ask-target  (lambda () (mu4e-read-option "Action: " mu4e-headers-actions))
-	 :action  (lambda (docid msg actionfunc)
-		    (save-excursion
-		      (when (mu4e~headers-goto-docid docid)
-			(mu4e-headers-action actionfunc)))))
-       (something
-	 :char  ("*" . "✱")
-	 :prompt "*something"
-	 :action (mu4e-error "No action for deferred mark")))
+  '((refile
+     :char ("r" . "▶")
+     :prompt "refile"
+     :dyn-target (lambda (target msg) (mu4e-get-refile-folder msg))
+     :action (lambda (docid msg target)
+               (mu4e~proc-move docid (mu4e~mark-check-target target) "-N")))
+    (delete
+     :char ("D" . "x")
+     :prompt "Delete"
+     :show-target (lambda (target) "delete")
+     :action (lambda (docid msg target) (mu4e~proc-remove docid)))
+    (flag
+     :char ("+" . "✚")
+     :prompt "+flag"
+     :show-target (lambda (target) "flag")
+     :action (lambda (docid msg target)
+               (mu4e~proc-move docid nil "+F-u-N")))
+    (move
+     :char ("m" . "▷")
+     :prompt "move"
+     :ask-target  mu4e~mark-get-move-target
+     :action (lambda (docid msg target)
+               (mu4e~proc-move docid (mu4e~mark-check-target target) "-N")))
+    (read
+     :char    ("!" . "◼")
+     :prompt "!read"
+     :show-target (lambda (target) "read")
+     :action (lambda (docid msg target) (mu4e~proc-move docid nil "+S-u-N")))
+    (trash
+     :char ("d" . "▼")
+     :prompt "dtrash"
+     :dyn-target (lambda (target msg) (mu4e-get-trash-folder msg))
+     :action (lambda (docid msg target) (mu4e~proc-move docid
+                                                        (mu4e~mark-check-target target) "+T-N")))
+    (unflag
+     :char    ("-" . "➖")
+     :prompt "-unflag"
+     :show-target (lambda (target) "unflag")
+     :action (lambda (docid msg target) (mu4e~proc-move docid nil "-F-N")))
+    (untrash
+     :char   ("=" . "▲")
+     :prompt "=untrash"
+     :show-target (lambda (target) "untrash")
+     :action (lambda (docid msg target) (mu4e~proc-move docid nil "-T")))
+    (unread
+     :char    ("?" . "◻")
+     :prompt "?unread"
+     :show-target (lambda (target) "unread")
+     :action (lambda (docid msg target) (mu4e~proc-move docid nil "-S+u-N")))
+    (unmark
+     :char  " "
+     :prompt "unmark"
+     :action (mu4e-error "No action for unmarking"))
+    (action
+     :char ( "a" . "◯")
+     :prompt "action"
+     :ask-target  (lambda () (mu4e-read-option "Action: " mu4e-headers-actions))
+     :action  (lambda (docid msg actionfunc)
+                (save-excursion
+                  (when (mu4e~headers-goto-docid docid)
+                    (mu4e-headers-action actionfunc)))))
+    (something
+     :char  ("*" . "✱")
+     :prompt "*something"
+     :action (mu4e-error "No action for deferred mark")))
 
   "The list of all the possible marks.
 This is an alist mapping mark symbols to their properties.  The
@@ -223,76 +223,76 @@ The following marks are available, and the corresponding props:
 
    MARK       TARGET    description
    ----------------------------------------------------------
-   `refile'    y	mark this message for archiving
-   `something' n	mark this message for *something* (decided later)
-   `delete'    n	remove the message
-   `flag'      n	mark this message for flagging
-   `move'      y	move the message to some folder
-   `read'      n	mark the message as read
-   `trash'     y	trash the message to some folder
-   `unflag'    n	mark this message for unflagging
-   `untrash'   n	remove the 'trashed' flag from a message
-   `unmark'    n	unmark this message
-   `unread'    n	mark the message as unread
+   `refile'    y        mark this message for archiving
+   `something' n        mark this message for *something* (decided later)
+   `delete'    n        remove the message
+   `flag'      n        mark this message for flagging
+   `move'      y        move the message to some folder
+   `read'      n        mark the message as read
+   `trash'     y        trash the message to some folder
+   `unflag'    n        mark this message for unflagging
+   `untrash'   n        remove the 'trashed' flag from a message
+   `unmark'    n        unmark this message
+   `unread'    n        mark the message as unread
    `action'    y        mark the message for some action."
   (interactive)
   (let* ((msg (mu4e-message-at-point))
-	  (docid (mu4e-message-field msg :docid))
-	  ;; get a cell with the mark char and the 'target' 'move' already has a
-	  ;; target (the target folder) the other ones get a pseudo "target", as
-	  ;; info for the user.
-	  (markdesc (cdr (or (assq mark mu4e-marks)
-			   (mu4e-error "Invalid mark %S" mark))))
-	  (get-markkar
-	   (lambda (char)
-	     (if (listp char)
-	       (if mu4e-use-fancy-chars (cdr char) (car char))
-	       char)))
-	  (markkar (funcall get-markkar (plist-get markdesc :char)))
-	  (target (mu4e~mark-get-dyn-target mark target))
-	  (show-fct (plist-get markdesc :show-target))
-	  (shown-target (if show-fct
-			  (funcall show-fct target)
-			  (if target (format "%S" target)))))
+         (docid (mu4e-message-field msg :docid))
+         ;; get a cell with the mark char and the 'target' 'move' already has a
+         ;; target (the target folder) the other ones get a pseudo "target", as
+         ;; info for the user.
+         (markdesc (cdr (or (assq mark mu4e-marks)
+                            (mu4e-error "Invalid mark %S" mark))))
+         (get-markkar
+          (lambda (char)
+            (if (listp char)
+                (if mu4e-use-fancy-chars (cdr char) (car char))
+              char)))
+         (markkar (funcall get-markkar (plist-get markdesc :char)))
+         (target (mu4e~mark-get-dyn-target mark target))
+         (show-fct (plist-get markdesc :show-target))
+         (shown-target (if show-fct
+                           (funcall show-fct target)
+                         (if target (format "%S" target)))))
     (unless docid (mu4e-warn "No message on this line"))
     (unless (eq major-mode 'mu4e-headers-mode)
       (mu4e-error "Not in headers-mode"))
     (save-excursion
       (when (mu4e~headers-mark docid markkar)
-	;; update the hash -- remove everything current, and if add the new
-	;; stuff, unless we're unmarking
-	(remhash docid mu4e~mark-map)
-	;; remove possible overlays
-	(remove-overlays (line-beginning-position) (line-end-position))
-	;; now, let's set a mark (unless we were unmarking)
-	(unless (eql mark 'unmark)
-	  (puthash docid (cons mark target) mu4e~mark-map)
-	  ;; when we have a target (ie., when moving), show the target folder in
-	  ;; an overlay
-	  (when (and shown-target mu4e-headers-show-target)
-	    (let* ((targetstr (propertize (concat "-> " shown-target " ")
-				'face 'mu4e-system-face))
-		    ;; mu4e~headers-goto-docid docid t \will take us just after
-		    ;; the docid cookie and then we skip the mu4e~mark-fringe
-		    (start (+ (length mu4e~mark-fringe)
-			     (mu4e~headers-goto-docid docid t)))
-		    (overlay (make-overlay start (+ start (length targetstr)))))
-	      (overlay-put overlay 'display targetstr)
-	      docid)))))))
+        ;; update the hash -- remove everything current, and if add the new
+        ;; stuff, unless we're unmarking
+        (remhash docid mu4e~mark-map)
+        ;; remove possible overlays
+        (remove-overlays (line-beginning-position) (line-end-position))
+        ;; now, let's set a mark (unless we were unmarking)
+        (unless (eql mark 'unmark)
+          (puthash docid (cons mark target) mu4e~mark-map)
+          ;; when we have a target (ie., when moving), show the target folder in
+          ;; an overlay
+          (when (and shown-target mu4e-headers-show-target)
+            (let* ((targetstr (propertize (concat "-> " shown-target " ")
+                                          'face 'mu4e-system-face))
+                   ;; mu4e~headers-goto-docid docid t \will take us just after
+                   ;; the docid cookie and then we skip the mu4e~mark-fringe
+                   (start (+ (length mu4e~mark-fringe)
+                             (mu4e~headers-goto-docid docid t)))
+                   (overlay (make-overlay start (+ start (length targetstr)))))
+              (overlay-put overlay 'display targetstr)
+              docid)))))))
 
 (defun mu4e~mark-get-move-target ()
   "Ask for a move target, and propose to create it if it does not exist."
   (interactive)
   ;;  (mu4e-message-at-point) ;; raises error if there is none
   (let* ((target (mu4e-ask-maildir "Move message to: "))
-	  (target (if (string= (substring target 0 1) "/")
-		    target
-		    (concat "/" target)))
-	  (fulltarget (concat (mu4e-root-maildir) target)))
+         (target (if (string= (substring target 0 1) "/")
+                     target
+                   (concat "/" target)))
+         (fulltarget (concat (mu4e-root-maildir) target)))
     (when (or (file-directory-p fulltarget)
-	    (and (yes-or-no-p
-		   (format "%s does not exist.  Create now?" fulltarget))
-	      (mu4e~proc-mkdir fulltarget)))
+              (and (yes-or-no-p
+                    (format "%s does not exist.  Create now?" fulltarget))
+                   (mu4e~proc-mkdir fulltarget)))
       target)))
 
 (defun mu4e~mark-ask-target (mark)
@@ -305,7 +305,7 @@ The following marks are available, and the corresponding props:
 The result may depend on the message at point."
   (let ((getter (plist-get (cdr (assq mark mu4e-marks)) :dyn-target)))
     (if getter
-      (funcall getter target (mu4e-message-at-point))
+        (funcall getter target (mu4e-message-at-point))
       target)))
 
 (defun mu4e-mark-set (mark &optional target)
@@ -314,37 +314,37 @@ Optionally, provide TARGET (for moves)."
   (unless target
     (setq target (mu4e~mark-ask-target mark)))
   (if (not (use-region-p))
-    ;; single message
-    (mu4e-mark-at-point mark target)
+      ;; single message
+      (mu4e-mark-at-point mark target)
     ;; mark all messages in the region.
     (save-excursion
       (let ((cant-go-further) (eor (region-end)))
-	(goto-char (region-beginning))
-	(while (and (< (point) eor) (not cant-go-further))
-	  (mu4e-mark-at-point mark target)
-	  (setq cant-go-further (not (mu4e-headers-next))))))))
+        (goto-char (region-beginning))
+        (while (and (< (point) eor) (not cant-go-further))
+          (mu4e-mark-at-point mark target)
+          (setq cant-go-further (not (mu4e-headers-next))))))))
 
 (defun mu4e-mark-restore (docid)
   "Restore the visual mark for the message with DOCID."
   (let ((markcell (gethash docid mu4e~mark-map)))
     (when markcell
       (save-excursion
-	(when (mu4e~headers-goto-docid docid)
-	  (mu4e-mark-at-point (car markcell) (cdr markcell)))))))
+        (when (mu4e~headers-goto-docid docid)
+          (mu4e-mark-at-point (car markcell) (cdr markcell)))))))
 
 (defun mu4e~mark-get-markpair (prompt &optional allow-something)
   "Ask user with PROMPT for a mark and return (MARK . TARGET).
 If ALLOW-SOMETHING is non-nil, allow the 'something' pseudo mark
 as well."
   (let* ((marks (mapcar (lambda (markdescr)
-			  (cons (plist-get (cdr markdescr) :prompt)
-			    (car markdescr)))
-		  mu4e-marks))
-	  (marks
-	    (if allow-something
-	      marks (cl-remove-if (lambda (m) (eq 'something (cdr m))) marks)))
-	  (mark (mu4e-read-option prompt marks))
-	  (target (mu4e~mark-ask-target mark)))
+                          (cons (plist-get (cdr markdescr) :prompt)
+                                (car markdescr)))
+                        mu4e-marks))
+         (marks
+          (if allow-something
+              marks (cl-remove-if (lambda (m) (eq 'something (cdr m))) marks)))
+         (mark (mu4e-read-option prompt marks))
+         (target (mu4e~mark-ask-target mark)))
     (cons mark target)))
 
 (defun mu4e-mark-resolve-deferred-marks ()
@@ -353,24 +353,24 @@ If there are such marks, replace them with a _real_ mark (ask the
 user which one)."
   (interactive)
   (mu4e~mark-in-context
-    (let ((markpair))
-      (maphash
-	(lambda (docid val)
-	  (let ((mark (car val)))
-	    (when (eql mark 'something)
-	      (unless markpair
-		(setq markpair
-		  (mu4e~mark-get-markpair "Set deferred mark(s) to: " nil)))
-	      (save-excursion
-		(when (mu4e~headers-goto-docid docid)
-		  (mu4e-mark-set (car markpair) (cdr markpair)))))))
-	mu4e~mark-map))))
+   (let ((markpair))
+     (maphash
+      (lambda (docid val)
+        (let ((mark (car val)))
+          (when (eql mark 'something)
+            (unless markpair
+              (setq markpair
+                    (mu4e~mark-get-markpair "Set deferred mark(s) to: " nil)))
+            (save-excursion
+              (when (mu4e~headers-goto-docid docid)
+                (mu4e-mark-set (car markpair) (cdr markpair)))))))
+      mu4e~mark-map))))
 
 (defun mu4e~mark-check-target (target)
   "Check if TARGET exists; if not, offer to create it."
   (let ((fulltarget (concat (mu4e-root-maildir) target)))
     (if (not (mu4e-create-maildir-maybe fulltarget))
-      (mu4e-error "Target dir %s does not exist " fulltarget)
+        (mu4e-error "Target dir %s does not exist " fulltarget)
       target)))
 
 (defun mu4e-mark-execute-all (&optional no-confirmation)
@@ -387,30 +387,30 @@ work well.
 If NO-CONFIRMATION is non-nil, don't ask user for confirmation."
   (interactive)
   (mu4e~mark-in-context
-    (let* ((marknum (hash-table-count mu4e~mark-map))
-	   (prompt (format "Are you sure you want to execute %d mark%s?"
-		     marknum (if (> marknum 1) "s" ""))))
+   (let* ((marknum (hash-table-count mu4e~mark-map))
+          (prompt (format "Are you sure you want to execute %d mark%s?"
+                          marknum (if (> marknum 1) "s" ""))))
      (if (zerop marknum)
-	 (mu4e-warn "Nothing is marked")
+         (mu4e-warn "Nothing is marked")
        (mu4e-mark-resolve-deferred-marks)
        (when (or no-confirmation (y-or-n-p prompt))
-	 (maphash
-	  (lambda (docid val)
-	    (let* ((mark (car val)) (target (cdr val))
-		   (markdescr (assq mark mu4e-marks))
-		   (msg (save-excursion
-			  (mu4e~headers-goto-docid docid)
-			  (mu4e-message-at-point))))
-	      ;; note: whenever you do something with the message,
-	      ;; it looses its N (new) flag
-	      (if markdescr
-		  (progn
-		    (run-hook-with-args
-		    'mu4e-mark-execute-pre-hook mark msg)
-		    (funcall (plist-get (cdr markdescr) :action)
-		      docid msg target))
-		(mu4e-error "Unrecognized mark %S" mark))))
-	  mu4e~mark-map))
+         (maphash
+          (lambda (docid val)
+            (let* ((mark (car val)) (target (cdr val))
+                   (markdescr (assq mark mu4e-marks))
+                   (msg (save-excursion
+                          (mu4e~headers-goto-docid docid)
+                          (mu4e-message-at-point))))
+              ;; note: whenever you do something with the message,
+              ;; it looses its N (new) flag
+              (if markdescr
+                  (progn
+                    (run-hook-with-args
+                     'mu4e-mark-execute-pre-hook mark msg)
+                    (funcall (plist-get (cdr markdescr) :action)
+                             docid msg target))
+                (mu4e-error "Unrecognized mark %S" mark))))
+          mu4e~mark-map))
        (mu4e-mark-unmark-all)
        (message nil)))))
 
@@ -418,16 +418,16 @@ If NO-CONFIRMATION is non-nil, don't ask user for confirmation."
   "Unmark all marked messages."
   (interactive)
   (mu4e~mark-in-context
-    (when (or (null mu4e~mark-map) (zerop (hash-table-count mu4e~mark-map)))
-      (mu4e-warn "Nothing is marked"))
-    (maphash
-      (lambda (docid _val)
-	(save-excursion
-	  (when (mu4e~headers-goto-docid docid)
-	    (mu4e-mark-set 'unmark))))
-      mu4e~mark-map)
-    ;; in any case, clear the marks map
-    (mu4e~mark-clear)))
+   (when (or (null mu4e~mark-map) (zerop (hash-table-count mu4e~mark-map)))
+     (mu4e-warn "Nothing is marked"))
+   (maphash
+    (lambda (docid _val)
+      (save-excursion
+        (when (mu4e~headers-goto-docid docid)
+          (mu4e-mark-set 'unmark))))
+    mu4e~mark-map)
+   ;; in any case, clear the marks map
+   (mu4e~mark-clear)))
 
 (defun mu4e-mark-docid-marked-p (docid)
   "Is the given DOCID marked?"
@@ -437,7 +437,7 @@ If NO-CONFIRMATION is non-nil, don't ask user for confirmation."
 (defun mu4e-mark-marks-num ()
   "Return the number of mark-instances in the current buffer."
   (mu4e~mark-in-context
-    (if mu4e~mark-map (hash-table-count mu4e~mark-map) 0)))
+   (if mu4e~mark-map (hash-table-count mu4e~mark-map) 0)))
 
 (defun mu4e-mark-handle-when-leaving ()
   "Handle any mark-instances in the current buffer when leaving.
@@ -446,18 +446,18 @@ function is to be called before any further action (like searching,
 quitting the buffer) is taken; returning t means 'take the following
 action', return nil means 'don't do anything'."
   (mu4e~mark-in-context
-    (let ((marknum (mu4e-mark-marks-num))
-	   (what mu4e-headers-leave-behavior))
-      (unless (zerop marknum) ;; nothing to do?
-	(when (eq what 'ask)
-	  (setq what (mu4e-read-option
-		       (format  "There are %d existing mark(s); should we: "
-			 marknum)
-		       '( ("apply marks"   . apply)
-			  ("ignore marks?" . ignore)))))
-	;; we determined what to do... now do it
-	(when (eq what 'apply)
-	  (mu4e-mark-execute-all t))))))
+   (let ((marknum (mu4e-mark-marks-num))
+         (what mu4e-headers-leave-behavior))
+     (unless (zerop marknum) ;; nothing to do?
+       (when (eq what 'ask)
+         (setq what (mu4e-read-option
+                     (format  "There are %d existing mark(s); should we: "
+                              marknum)
+                     '( ("apply marks"   . apply)
+                        ("ignore marks?" . ignore)))))
+       ;; we determined what to do... now do it
+       (when (eq what 'apply)
+         (mu4e-mark-execute-all t))))))
 
 (provide 'mu4e-mark)
 ;;; mu4e-mark.el ends here

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -35,7 +35,7 @@
 
 (defcustom mu4e-html2text-command
   (if (fboundp 'shr-insert-document)
-    'mu4e-shr2text
+      'mu4e-shr2text
     (progn (require 'html2text) 'html2text))
   "Either a shell command or a function that converts from html to plain text.
 
@@ -124,7 +124,7 @@ Some notes on the format:
   Message view use the actual message file, and do include these fields."
   ;; after all this documentation, the spectacular implementation
   (if msg
-    (plist-get msg field)
+      (plist-get msg field)
     (mu4e-error "Message must be non-nil")))
 
 (defsubst mu4e-message-field (msg field)
@@ -136,16 +136,16 @@ Like `mu4e-message-field-nil', but will sanitize nil values:
 Thus, function will return nil for empty lists, non-existing body-txt or body-html."
   (let ((val (mu4e-message-field-raw msg field)))
     (cond
-      (val
-	val)   ;; non-nil -> just return it
-      ((member field '(:subject :message-id :path :maildir :in-reply-to))
-	"")    ;; string fields except body-txt, body-html: nil -> ""
-      ((member field '(:body-html :body-txt))
-	val)
-      ((member field '(:docid :size))
-	0)     ;; numeric type: nil -> 0
-      (t
-	val)))) ;; otherwise, just return nil
+     (val
+      val)   ;; non-nil -> just return it
+     ((member field '(:subject :message-id :path :maildir :in-reply-to))
+      "")    ;; string fields except body-txt, body-html: nil -> ""
+     ((member field '(:body-html :body-txt))
+      val)
+     ((member field '(:docid :size))
+      0)     ;; numeric type: nil -> 0
+     (t
+      val)))) ;; otherwise, just return nil
 
 (defsubst mu4e-message-has-field (msg field)
   "If MSG has a FIELD return t, nil otherwise."
@@ -158,7 +158,7 @@ no such message. If optional NOERROR is non-nil, do not raise an
 error when there is no message at point."
   (let ((msg (or (get-text-property (point) 'msg) mu4e~view-message)))
     (if msg
-      msg
+        msg
       (unless noerror (mu4e-warn "No message at point")))))
 
 (defsubst mu4e-message-field-at-point (field)
@@ -176,19 +176,19 @@ Determine whether we want
 to use html or text. The decision is based on PREFER-HTML and
 whether the message supports the given representation."
   (let* ((txt (mu4e-message-field msg :body-txt))
-	  (html (mu4e-message-field msg :body-html))
-	  (txt-len (length txt))
-	  (html-len (length html))
-	  (txt-limit (* mu4e-view-html-plaintext-ratio-heuristic txt-len))
-	  (txt-limit (if (>= txt-limit 0) txt-limit most-positive-fixnum)))
+         (html (mu4e-message-field msg :body-html))
+         (txt-len (length txt))
+         (html-len (length html))
+         (txt-limit (* mu4e-view-html-plaintext-ratio-heuristic txt-len))
+         (txt-limit (if (>= txt-limit 0) txt-limit most-positive-fixnum)))
     (cond
-      ; user prefers html --> use html if there is
-      (prefer-html (> html-len 0))
-      ;; otherwise (user prefers text) still use html if there is not enough
-      ;; text
-      ((< txt-limit html-len) t)
-      ;; otherwise, use text
-      (t nil))))
+                                        ; user prefers html --> use html if there is
+     (prefer-html (> html-len 0))
+     ;; otherwise (user prefers text) still use html if there is not enough
+     ;; text
+     ((< txt-limit html-len) t)
+     ;; otherwise, use text
+     (t nil))))
 
 (defun mu4e~message-body-has-content-type-param (msg param)
   "Does the MSG have a content-type parameter PARAM?"
@@ -207,29 +207,29 @@ will use that. Normally, this function prefers the text part,
 unless PREFER-HTML is non-nil."
   (setq mu4e~message-body-html (mu4e~message-use-html-p msg prefer-html))
   (let ((body
-	  (if mu4e~message-body-html
-	    ;; use an htmml body
-	    (cond
-	      ((stringp mu4e-html2text-command)
-		(mu4e~html2text-shell msg mu4e-html2text-command))
-	      ((functionp mu4e-html2text-command)
-		(if (help-function-arglist mu4e-html2text-command)
-		  (funcall mu4e-html2text-command msg)
-		  ;; oldskool parameterless mu4e-html2text-command
-		  (mu4e~html2text-wrapper mu4e-html2text-command msg)))
-	      (t (mu4e-error "Invalid `mu4e-html2text-command'")))
-	    ;; use a text body
-	    (or (with-temp-buffer
-		  (insert (or (mu4e-message-field msg :body-txt) ""))
-		  (if (mu4e~safe-iequal "flowed"
-			(mu4e~message-body-has-content-type-param
-			  msg "format"))
-		    (fill-flowed nil
-		      (mu4e~safe-iequal
-			"yes"
-			(mu4e~message-body-has-content-type-param
-			  msg "delsp"))))
-		 (buffer-string)) ""))))
+         (if mu4e~message-body-html
+             ;; use an htmml body
+             (cond
+              ((stringp mu4e-html2text-command)
+               (mu4e~html2text-shell msg mu4e-html2text-command))
+              ((functionp mu4e-html2text-command)
+               (if (help-function-arglist mu4e-html2text-command)
+                   (funcall mu4e-html2text-command msg)
+                 ;; oldskool parameterless mu4e-html2text-command
+                 (mu4e~html2text-wrapper mu4e-html2text-command msg)))
+              (t (mu4e-error "Invalid `mu4e-html2text-command'")))
+           ;; use a text body
+           (or (with-temp-buffer
+                 (insert (or (mu4e-message-field msg :body-txt) ""))
+                 (if (mu4e~safe-iequal "flowed"
+                                       (mu4e~message-body-has-content-type-param
+                                        msg "format"))
+                     (fill-flowed nil
+                                  (mu4e~safe-iequal
+                                   "yes"
+                                   (mu4e~message-body-has-content-type-param
+                                    msg "delsp"))))
+                 (buffer-string)) ""))))
     (dolist (func mu4e-message-body-rewrite-functions)
       (setq body (funcall func msg body)))
     body))
@@ -245,10 +245,10 @@ replace with."
     (goto-char (point-min))
     (while (re-search-forward "[ ]" nil t)
       (replace-match
-	(cond
-	  ((string= (match-string 0) "") "'")
-	  ((string= (match-string 0) " ") " ")
-	  (t ""))))
+       (cond
+        ((string= (match-string 0) "") "'")
+        ((string= (match-string 0) " ") " ")
+        (t ""))))
     (buffer-string)))
 
 (defun mu4e-message-contact-field-matches (msg cfield rx)
@@ -260,22 +260,22 @@ address) regular expressions RX. If there is a match, return
 non-nil; otherwise return nil. RX can also be a list of regular
 expressions, in which case any of those are tried for a match."
   (if (and cfield (listp cfield))
-    (or (mu4e-message-contact-field-matches msg (car cfield) rx)
-      (mu4e-message-contact-field-matches msg (cdr cfield) rx))
+      (or (mu4e-message-contact-field-matches msg (car cfield) rx)
+          (mu4e-message-contact-field-matches msg (cdr cfield) rx))
     (when cfield
       (if (listp rx)
-	;; if rx is a list, try each one of them for a match
-	(cl-find-if
-	  (lambda (a-rx) (mu4e-message-contact-field-matches msg cfield a-rx))
-	  rx)
-	;; not a list, check the rx
-	(cl-find-if
-	  (lambda (ct)
-	    (let ((name (car ct)) (email (cdr ct)))
-	      (or
-		(and name  (string-match rx name))
-		(and email (string-match rx email)))))
-	  (mu4e-message-field msg cfield))))))
+          ;; if rx is a list, try each one of them for a match
+          (cl-find-if
+           (lambda (a-rx) (mu4e-message-contact-field-matches msg cfield a-rx))
+           rx)
+        ;; not a list, check the rx
+        (cl-find-if
+         (lambda (ct)
+           (let ((name (car ct)) (email (cdr ct)))
+             (or
+              (and name  (string-match rx name))
+              (and email (string-match rx email)))))
+         (mu4e-message-field msg cfield))))))
 
 (defun mu4e-message-contact-field-matches-me (msg cfield)
   "Does contact-field CFIELD in MSG match me?
@@ -285,12 +285,12 @@ that is, any of the e-mail address in
 `(mu4e-personal-addresses)'. Returns the contact cell that
 matched, or nil."
   (cl-find-if
-    (lambda (cc-cell)
-      (cl-member-if
-	(lambda (addr)
-	  (string= (downcase addr) (downcase (cdr cc-cell))))
-	(mu4e-personal-addresses)))
-    (mu4e-message-field msg cfield)))
+   (lambda (cc-cell)
+     (cl-member-if
+      (lambda (addr)
+        (string= (downcase addr) (downcase (cdr cc-cell))))
+      (mu4e-personal-addresses)))
+   (mu4e-message-field msg cfield)))
 
 (defsubst mu4e-message-part-field  (msgpart field)
   "Get some FIELD from MSGPART.
@@ -322,27 +322,27 @@ Return the buffer contents."
 This can be used in `mu4e-html2text-command' in a new enough
 Emacs. Based on code by Titus von der Malsburg."
   (mu4e~html2text-wrapper
-    (lambda ()
-	(let (
-	 ;; When HTML emails contain references to remote images,
-	 ;; retrieving these images leaks information. For example,
-	 ;; the sender can see when I openend the email and from which
-	 ;; computer (IP address). For this reason, it is preferrable
-	 ;; to not retrieve images.
-	 ;; See this discussion on mu-discuss:
-	 ;; https://groups.google.com/forum/#!topic/mu-discuss/gr1cwNNZnXo
-	 (shr-inhibit-images t))
-	  (shr-render-region (point-min) (point-max)))) msg))
+   (lambda ()
+     (let (
+           ;; When HTML emails contain references to remote images,
+           ;; retrieving these images leaks information. For example,
+           ;; the sender can see when I openend the email and from which
+           ;; computer (IP address). For this reason, it is preferrable
+           ;; to not retrieve images.
+           ;; See this discussion on mu-discuss:
+           ;; https://groups.google.com/forum/#!topic/mu-discuss/gr1cwNNZnXo
+           (shr-inhibit-images t))
+       (shr-render-region (point-min) (point-max)))) msg))
 
 (defun mu4e~html2text-shell (msg _cmd)
   "Convert html2 text in MSG using a shell function CMD."
   (mu4e~html2text-wrapper
-    (lambda ()
-      (let* ((tmp-file (mu4e-make-temp-file "html")))
-	(write-region (point-min) (point-max) tmp-file)
-	(erase-buffer)
-	(call-process-shell-command mu4e-html2text-command tmp-file t t)
-	(delete-file tmp-file))) msg))
+   (lambda ()
+     (let* ((tmp-file (mu4e-make-temp-file "html")))
+       (write-region (point-min) (point-max) tmp-file)
+       (erase-buffer)
+       (call-process-shell-command mu4e-html2text-command tmp-file t t)
+       (delete-file tmp-file))) msg))
 
 (provide 'mu4e-message)
 ;;; mu4e-message ends here

--- a/mu4e/mu4e-org.el
+++ b/mu4e/mu4e-org.el
@@ -1,4 +1,5 @@
 ;;; mu4e-org -- Org-links to mu4e messages/queries -*- lexical-binding: t -*-
+;;
 ;; Copyright (C) 2012-2020 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>

--- a/mu4e/mu4e-org.el
+++ b/mu4e/mu4e-org.el
@@ -64,46 +64,46 @@ Example usage:
 (defun mu4e~org-store-link-query ()
   "Store a link to a mu4e query."
   (let* ((query  (mu4e-last-query))
-          (date (format-time-string (org-time-stamp-format)))
-          ;; seems we get an error when there's no date...
-          (link (concat "mu4e:query:" query)))
+         (date (format-time-string (org-time-stamp-format)))
+         ;; seems we get an error when there's no date...
+         (link (concat "mu4e:query:" query)))
     (org-store-link-props
-      :type "mu4e"
-      :query query
-      :date date)
+     :type "mu4e"
+     :query query
+     :date date)
     (org-add-link-props
-      :link link
-      :description (format "mu4e-query: '%s'" query))
+     :link link
+     :description (format "mu4e-query: '%s'" query))
     link))
 
 (defun mu4e~org-first-address (msg field)
   "Get address field FIELD from MSG as a string or nil."
   (let* ((val (plist-get msg field))
-          (name (when val (car (car val))))
-          (addr (when val (cdr (car val)))))
+         (name (when val (car (car val))))
+         (addr (when val (cdr (car val)))))
     (when val
       (if name
-        (format "%s <%s>" name addr)
+          (format "%s <%s>" name addr)
         (format "%s" addr)))))
 
 (defun mu4e~org-store-link-message ()
   "Store a link to a mu4e message."
   (let* ((msg      (mu4e-message-at-point))
-          (msgid   (or (plist-get msg :message-id) "<none>"))
-          (date    (plist-get msg :date))
-          (date    (format-time-string (org-time-stamp-format) date))
-          ;; seems we get an error when there's no date...
-          (link    (concat "mu4e:msgid:" msgid)))
+         (msgid   (or (plist-get msg :message-id) "<none>"))
+         (date    (plist-get msg :date))
+         (date    (format-time-string (org-time-stamp-format) date))
+         ;; seems we get an error when there's no date...
+         (link    (concat "mu4e:msgid:" msgid)))
     (org-store-link-props
-      :type        "mu4e"
-      :message-id  msgid
-      :to          (mu4e~org-first-address msg :to)
-      :from        (mu4e~org-first-address msg :from)
-      :date        date
-      :subject     (plist-get msg :subject))
+     :type        "mu4e"
+     :message-id  msgid
+     :to          (mu4e~org-first-address msg :to)
+     :from        (mu4e~org-first-address msg :from)
+     :date        date
+     :subject     (plist-get msg :subject))
     (org-add-link-props
-      :link link
-      :description (funcall mu4e-org-link-desc-func msg))
+     :link link
+     :description (funcall mu4e-org-link-desc-func msg))
     link))
 
 (defun mu4e-org-store-link ()
@@ -113,8 +113,8 @@ It links to the last known query when in `mu4e-headers-mode' with
 a specific message, based on its message-id, so that links stay
 valid even after moving the message around."
   (if (and (eq major-mode 'mu4e-headers-mode)
-  mu4e-org-link-query-in-headers-mode)
-    (mu4e~org-store-link-query)
+           mu4e-org-link-query-in-headers-mode)
+      (mu4e~org-store-link-query)
     (when (mu4e-message-at-point t)
       (mu4e~org-store-link-message))))
 
@@ -122,8 +122,8 @@ valid even after moving the message around."
 ;; org-link-set-parameters method
 (if (fboundp 'org-link-set-parameters)
     (org-link-set-parameters "mu4e"
-           :follow #'mu4e-org-open
-           :store  #'mu4e-org-store-link)
+                             :follow #'mu4e-org-open
+                             :store  #'mu4e-org-store-link)
   (org-add-link-type "mu4e" 'mu4e-org-open)
   (add-hook 'org-store-link-functions 'mu4e-org-store-link))
 
@@ -133,11 +133,11 @@ Open the mu4e message (for links starting with 'msgid:') or run
 the query (for links starting with 'query:')."
   (require 'mu4e)
   (cond
-    ((string-match "^msgid:\\(.+\\)" link)
-      (mu4e-view-message-with-message-id (match-string 1 link)))
-    ((string-match "^query:\\(.+\\)" link)
-      (mu4e-headers-search (match-string 1 link) current-prefix-arg))
-    (t (mu4e-error "Unrecognized link type '%s'" link))))
+   ((string-match "^msgid:\\(.+\\)" link)
+    (mu4e-view-message-with-message-id (match-string 1 link)))
+   ((string-match "^query:\\(.+\\)" link)
+    (mu4e-headers-search (match-string 1 link) current-prefix-arg))
+   (t (mu4e-error "Unrecognized link type '%s'" link))))
 
 (make-obsolete 'org-mu4e-open 'mu4e-org-open "1.3.6")
 

--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -30,7 +30,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; internal vars
 
-(defconst mu4e~proc-name "*mu4e-proc*"
+(defvar mu4e~proc-buf nil
+  "Buffer (string) for data received from the backend.")
+(defconst mu4e~proc-name " *mu4e-proc*"
   "Name of the server process, buffer.")
 (defvar mu4e~proc-process nil
   "The mu-server process.")
@@ -46,13 +48,6 @@
   (concat mu4e~cookie-pre "\\([[:xdigit:]]+\\)" mu4e~cookie-post)
   "Regular expression matching the length cookie.
 Match 1 will be the length (in hex).")
-
-(defvar mu4e~proc-buf nil
-  "Buffer (string) for data received from the backend.")
-(defconst mu4e~proc-name " *mu4e-proc*"
-  "Name of the server process, buffer.")
-(defvar mu4e~proc-process nil
-  "The mu-server process.")
 
 (defun mu4e~proc-running-p  ()
   "Whether the mu process is running."

--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -1,4 +1,4 @@
-;; mu4e-proc.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
+;;; mu4e-proc.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2011-2019 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -40,7 +40,7 @@
   "Each expression starts with a length cookie:
 <`mu4e~cookie-pre'><length-in-hex><`mu4e~cookie-post'>.")
 (defconst mu4e~cookie-post "\377"
-    "Each expression starts with a length cookie:
+  "Each expression starts with a length cookie:
 <`mu4e~cookie-pre'><length-in-hex><`mu4e~cookie-post'>.")
 (defconst mu4e~cookie-matcher-rx
   (concat mu4e~cookie-pre "\\([[:xdigit:]]+\\)" mu4e~cookie-post)
@@ -57,8 +57,8 @@ Match 1 will be the length (in hex).")
 (defun mu4e~proc-running-p  ()
   "Whether the mu process is running."
   (when (and mu4e~proc-process
-    (memq (process-status mu4e~proc-process)
-      '(run open listen connect stop)))
+             (memq (process-status mu4e~proc-process)
+                   '(run open listen connect stop)))
     t))
 
 (defsubst mu4e~proc-eat-sexp-from-buf ()
@@ -73,23 +73,23 @@ removed."
     ;; mu4e~cookie-matcher-rx:
     ;;  (concat mu4e~cookie-pre "\\([[:xdigit:]]+\\)]" mu4e~cookie-post)
     (let ((b (string-match mu4e~cookie-matcher-rx mu4e~proc-buf))
-     (sexp-len) (objcons))
+          (sexp-len) (objcons))
       (when b
-  (setq sexp-len (string-to-number (match-string 1 mu4e~proc-buf) 16))
-  ;; does mu4e~proc-buf contain the full sexp?
-  (when (>= (length mu4e~proc-buf) (+ sexp-len (match-end 0)))
-    ;; clear-up start
-    (setq mu4e~proc-buf (substring mu4e~proc-buf (match-end 0)))
-    ;; note: we read the input in binary mode -- here, we take the part
-    ;; that is the sexp, and convert that to utf-8, before we interpret
-    ;; it.
-    (setq objcons (read-from-string
-        (decode-coding-string
-          (substring mu4e~proc-buf 0 sexp-len)
-          'utf-8 t)))
-    (when objcons
-      (setq mu4e~proc-buf (substring mu4e~proc-buf sexp-len))
-      (car objcons)))))))
+        (setq sexp-len (string-to-number (match-string 1 mu4e~proc-buf) 16))
+        ;; does mu4e~proc-buf contain the full sexp?
+        (when (>= (length mu4e~proc-buf) (+ sexp-len (match-end 0)))
+          ;; clear-up start
+          (setq mu4e~proc-buf (substring mu4e~proc-buf (match-end 0)))
+          ;; note: we read the input in binary mode -- here, we take the part
+          ;; that is the sexp, and convert that to utf-8, before we interpret
+          ;; it.
+          (setq objcons (read-from-string
+                         (decode-coding-string
+                          (substring mu4e~proc-buf 0 sexp-len)
+                          'utf-8 t)))
+          (when objcons
+            (setq mu4e~proc-buf (substring mu4e~proc-buf sexp-len))
+            (car objcons)))))))
 
 
 (defun mu4e~proc-filter (_proc str)
@@ -154,81 +154,81 @@ The server output is as follows:
   (let ((sexp (mu4e~proc-eat-sexp-from-buf)))
     (with-local-quit
       (while sexp
-  (mu4e-log 'from-server "%S" sexp)
-  (cond
-    ;; a header plist can be recognized by the existence of a :date field
-    ((plist-get sexp :date)
-      (funcall mu4e-header-func sexp))
+        (mu4e-log 'from-server "%S" sexp)
+        (cond
+         ;; a header plist can be recognized by the existence of a :date field
+         ((plist-get sexp :date)
+          (funcall mu4e-header-func sexp))
 
-    ;; the found sexp, we receive after getting all the headers
-    ((plist-get sexp :found)
-      (funcall mu4e-found-func (plist-get sexp :found)))
+         ;; the found sexp, we receive after getting all the headers
+         ((plist-get sexp :found)
+          (funcall mu4e-found-func (plist-get sexp :found)))
 
-    ;; viewing a specific message
-    ((plist-get sexp :view)
-      (funcall mu4e-view-func (plist-get sexp :view)))
+         ;; viewing a specific message
+         ((plist-get sexp :view)
+          (funcall mu4e-view-func (plist-get sexp :view)))
 
-    ;; receive an erase message
-    ((plist-get sexp :erase)
-      (funcall mu4e-erase-func))
+         ;; receive an erase message
+         ((plist-get sexp :erase)
+          (funcall mu4e-erase-func))
 
-    ;; receive a :sent message
-    ((plist-get sexp :sent)
-      (funcall mu4e-sent-func
-        (plist-get sexp :docid)
-        (plist-get sexp :path)))
+         ;; receive a :sent message
+         ((plist-get sexp :sent)
+          (funcall mu4e-sent-func
+                   (plist-get sexp :docid)
+                   (plist-get sexp :path)))
 
-    ;; received a pong message
-    ((plist-get sexp :pong)
-      (funcall mu4e-pong-func sexp))
+         ;; received a pong message
+         ((plist-get sexp :pong)
+          (funcall mu4e-pong-func sexp))
 
-    ;; received a contacts message
-    ;; note: we use 'member', to match (:contacts nil)
-    ((plist-member sexp :contacts)
-      (funcall mu4e-contacts-func
-        (plist-get sexp :contacts)
-        (plist-get sexp :tstamp)))
+         ;; received a contacts message
+         ;; note: we use 'member', to match (:contacts nil)
+         ((plist-member sexp :contacts)
+          (funcall mu4e-contacts-func
+                   (plist-get sexp :contacts)
+                   (plist-get sexp :tstamp)))
 
-    ;; something got moved/flags changed
-    ((plist-get sexp :update)
-            (funcall mu4e-update-func
-        (plist-get sexp :update)
-        (plist-get sexp :move)
-        (plist-get sexp :maybe-view)))
+         ;; something got moved/flags changed
+         ((plist-get sexp :update)
+          (funcall mu4e-update-func
+                   (plist-get sexp :update)
+                   (plist-get sexp :move)
+                   (plist-get sexp :maybe-view)))
 
-    ;; a message got removed
-    ((plist-get sexp :remove)
-      (funcall mu4e-remove-func (plist-get sexp :remove)))
+         ;; a message got removed
+         ((plist-get sexp :remove)
+          (funcall mu4e-remove-func (plist-get sexp :remove)))
 
-    ;; start composing a new message
-    ((plist-get sexp :compose)
-      (funcall mu4e-compose-func
-        (plist-get sexp :compose)
-        (plist-get sexp :original)
-        (plist-get sexp :include)))
+         ;; start composing a new message
+         ((plist-get sexp :compose)
+          (funcall mu4e-compose-func
+                   (plist-get sexp :compose)
+                   (plist-get sexp :original)
+                   (plist-get sexp :include)))
 
-    ;; do something with a temporary file
-    ((plist-get sexp :temp)
-      (funcall mu4e-temp-func
-        (plist-get sexp :temp)   ;; name of the temp file
-        (plist-get sexp :what)   ;; what to do with it
-               ;; (pipe|emacs|open-with...)
-        (plist-get sexp :docid)  ;; docid of the message
-        (plist-get sexp :param)));; parameter for the action
+         ;; do something with a temporary file
+         ((plist-get sexp :temp)
+          (funcall mu4e-temp-func
+                   (plist-get sexp :temp)   ;; name of the temp file
+                   (plist-get sexp :what)   ;; what to do with it
+                   ;; (pipe|emacs|open-with...)
+                   (plist-get sexp :docid)  ;; docid of the message
+                   (plist-get sexp :param)));; parameter for the action
 
-    ;; get some info
-    ((plist-get sexp :info)
-      (funcall mu4e-info-func sexp))
+         ;; get some info
+         ((plist-get sexp :info)
+          (funcall mu4e-info-func sexp))
 
-    ;; receive an error
-    ((plist-get sexp :error)
-      (funcall mu4e-error-func
-        (plist-get sexp :error)
-        (plist-get sexp :message)))
+         ;; receive an error
+         ((plist-get sexp :error)
+          (funcall mu4e-error-func
+                   (plist-get sexp :error)
+                   (plist-get sexp :message)))
 
-    (t (mu4e-message "Unexpected data from server [%S]" sexp)))
+         (t (mu4e-message "Unexpected data from server [%S]" sexp)))
 
-  (setq sexp (mu4e~proc-eat-sexp-from-buf))))))
+        (setq sexp (mu4e~proc-eat-sexp-from-buf))))))
 
 (defun mu4e~escape (str)
   "Escape string STR for transport.
@@ -252,12 +252,12 @@ Start the process if needed."
   (unless (file-executable-p mu4e-mu-binary)
     (mu4e-error (format "`mu4e-mu-binary' (%S) not found" mu4e-mu-binary)))
   (let* ((process-connection-type nil) ;; use a pipe
-          (args (when mu4e-mu-home `(,(format"--muhome=%s" mu4e-mu-home))))
-          (args (cons "server" args)))
+         (args (when mu4e-mu-home `(,(format"--muhome=%s" mu4e-mu-home))))
+         (args (cons "server" args)))
     (setq mu4e~proc-buf "")
     (setq mu4e~proc-process (apply 'start-process
-            mu4e~proc-name mu4e~proc-name
-                              mu4e-mu-binary args))
+                                   mu4e~proc-name mu4e~proc-name
+                                   mu4e-mu-binary args))
     ;; register a function for (:info ...) sexps
     (unless mu4e~proc-process
       (mu4e-error "Failed to start the mu4e backend"))
@@ -269,7 +269,7 @@ Start the process if needed."
 (defun mu4e~proc-kill ()
   "Kill the mu server process."
   (let* ((buf (get-buffer mu4e~proc-name))
-    (proc (and (buffer-live-p buf) (get-buffer-process buf))))
+         (proc (and (buffer-live-p buf) (get-buffer-process buf))))
     (when proc
       (let ((delete-exited-processes t))
         (mu4e~call-mu '(quit)))
@@ -277,8 +277,8 @@ Start the process if needed."
       (ignore-errors
         (signal-process proc 'SIGINT))))
   (setq
-    mu4e~proc-process nil
-    mu4e~proc-buf nil))
+   mu4e~proc-process nil
+   mu4e~proc-buf nil))
 
 ;; error codes are defined in src/mu-util
 ;;(defconst mu4e-xapian-empty 19 "Error code: xapian is empty/non-existent")
@@ -289,20 +289,20 @@ Start the process if needed."
     (setq mu4e~proc-process nil)
     (setq mu4e~proc-buf "") ;; clear any half-received sexps
     (cond
-      ((eq status 'signal)
-        (cond
-          ((or(eq code 9) (eq code 2)) (message nil))
-          ;;(message "the mu server process has been stopped"))
-          (t (error (format "mu server process received signal %d" code)))))
-      ((eq status 'exit)
-        (cond
-          ((eq code 0)
-            (message nil)) ;; don't do anything
-          ((eq code 19)
-            (error "Database is locked by another process"))
-          (t (error "Mu server process ended with exit code %d" code))))
-      (t
-        (error "Something bad happened to the mu server process")))))
+     ((eq status 'signal)
+      (cond
+       ((or(eq code 9) (eq code 2)) (message nil))
+       ;;(message "the mu server process has been stopped"))
+       (t (error (format "mu server process received signal %d" code)))))
+     ((eq status 'exit)
+      (cond
+       ((eq code 0)
+        (message nil)) ;; don't do anything
+       ((eq code 19)
+        (error "Database is locked by another process"))
+       (t (error "Mu server process ended with exit code %d" code))))
+     (t
+      (error "Something bad happened to the mu server process")))))
 
 (defun mu4e~call-mu (form)
   "Call 'mu' with some command."
@@ -314,7 +314,7 @@ Start the process if needed."
 (defun mu4e~docid-msgid-param (docid-or-msgid)
   "Construct a backend parameter based on DOCID-OR-MSGID."
   (if (stringp docid-or-msgid)
-    `(:msgid ,(mu4e~escape docid-or-msgid))
+      `(:msgid ,(mu4e~escape docid-or-msgid))
     `(:docid ,docid-or-msgid)))
 
 (defun mu4e~proc-add (path)
@@ -332,9 +332,9 @@ editing, resending) with DOCID or nil for type `new'.
 The result is delivered to the function registered as
 `mu4e-compose-func'."
   (mu4e~call-mu `(compose
-                   :type ,type
-                   :extract-encrypted ,decrypt
-                   :docid ,docid)))
+                  :type ,type
+                  :extract-encrypted ,decrypt
+                  :docid ,docid)))
 
 (defun mu4e~proc-contacts (personal after tstamp)
   "Ask for contacts with PERSONAL AFTER TSTAMP.
@@ -343,12 +343,12 @@ response. If PERSONAL is non-nil, only get personal contacts, if
 AFTER is non-nil, get only contacts seen AFTER (the time_t
 value)."
   (mu4e~call-mu `(contacts
-                   :personal ,personal
-                   :after  ,(or after nil)
-                   :tstamp ,(or tstamp nil))))
+                  :personal ,personal
+                  :after  ,(or after nil)
+                  :tstamp ,(or tstamp nil))))
 
 (defun mu4e~proc-extract (action docid index decrypt
-         &optional path what param)
+                                 &optional path what param)
   "Perform ACTION  on part with DOCID INDEX DECRYPT PATH WHAT PARAM.
 Use a message with DOCID and perform ACTION on it (as symbol,
 either `save', `open', `temp') which mean: * save: save the part
@@ -357,16 +357,16 @@ with the default application registered for doing so * temp: save
 to a temporary file, then respond with
        (:temp <path> :what <what> :param <param>)."
   (mu4e~call-mu `(extract
-                   :action ,action
-                   :docid ,docid
-                   :index ,index
-                   :decrypt ,decrypt
-                   :path ,path
-                   :what ,what
-                   :param ,param)))
+                  :action ,action
+                  :docid ,docid
+                  :index ,index
+                  :decrypt ,decrypt
+                  :path ,path
+                  :what ,what
+                  :param ,param)))
 
 (defun mu4e~proc-find (query threads sortfield sortdir maxnum skip-dups
-      include-related)
+                             include-related)
   "Run QUERY with THREADS SORTFIELD SORTDIR MAXNUM SKIP-DUPS INCLUDE-RELATED.
 If THREADS is non-nil, show results in threaded fashion, SORTFIELD
 is a symbol describing the field to sort by (or nil); see
@@ -383,13 +383,13 @@ kind of result. The variables `mu4e-error-func' contain the
 function that will be called for, resp., a message (header row)
 or an error."
   (mu4e~call-mu `(find
-                   :query ,query
-                   :threads ,threads
-                   :sortfield ,sortfield
-                   :reverse ,(if (eq sortdir 'descending) t nil)
-                   :maxnum ,maxnum
-                   :skip-dups ,skip-dups
-                   :include-related ,include-related)))
+                  :query ,query
+                  :threads ,threads
+                  :sortfield ,sortfield
+                  :reverse ,(if (eq sortdir 'descending) t nil)
+                  :maxnum ,maxnum
+                  :skip-dups ,skip-dups
+                  :include-related ,include-related)))
 
 (defun mu4e~proc-index (&optional cleanup lazy-check)
   "Index messages with possible CLEANUP and LAZY-CHECK.
@@ -440,15 +440,15 @@ Returns either (:update ... ) or (:error ) sexp, which are handled my
   (unless (or maildir flags)
     (mu4e-error "At least one of maildir and flags must be specified"))
   (unless (or (not maildir)
-      (file-exists-p (concat (mu4e-root-maildir) "/" maildir "/")))
+              (file-exists-p (concat (mu4e-root-maildir) "/" maildir "/")))
     (mu4e-error "Target dir does not exist"))
   (mu4e~call-mu `(move
-                   :docid ,(if (stringp docid-or-msgid) nil docid-or-msgid)
-                   :msgid ,(if (stringp docid-or-msgid) docid-or-msgid nil)
-                   :flags ,(or flags nil)
-                   :maildir ,(or maildir nil)
-                   :rename ,(and maildir mu4e-change-filenames-when-moving)
-                   :noview ,no-view)))
+                  :docid ,(if (stringp docid-or-msgid) nil docid-or-msgid)
+                  :msgid ,(if (stringp docid-or-msgid) docid-or-msgid nil)
+                  :flags ,(or flags nil)
+                  :maildir ,(or maildir nil)
+                  :rename ,(and maildir mu4e-change-filenames-when-moving)
+                  :noview ,no-view)))
 
 (defun mu4e~proc-ping (&optional queries)
   "Sends a ping to the mu server, expecting a (:pong ...) in response.
@@ -477,10 +477,10 @@ attached to the message, and return them as temp files. DECRYPT
 if necessary. The result will be delivered to the function
 registered as `mu4e-view-func'."
   (mu4e~call-mu `(view
-                   :docid ,(if (stringp docid-or-msgid) nil docid-or-msgid)
-                   :msgid ,(if (stringp docid-or-msgid) docid-or-msgid nil)
-                   :extract-images ,images
-                   :extract-encrypted ,decrypt)))
+                  :docid ,(if (stringp docid-or-msgid) nil docid-or-msgid)
+                  :msgid ,(if (stringp docid-or-msgid) docid-or-msgid nil)
+                  :extract-images ,images
+                  :extract-encrypted ,decrypt)))
 
 (defun mu4e~proc-view-path (path &optional images decrypt)
   "View message at PATH..
@@ -489,9 +489,9 @@ attached to the message, and return them as temp files. The
 result will be delivered to the function registered as
 `mu4e-view-func'. Optionally DECRYPT."
   (mu4e~call-mu `(view
-                   :path ,path
-                   :extract-images ,images
-                   :extract-encrypted ,decrypt)))
+                  :path ,path
+                  :extract-images ,images
+                  :extract-encrypted ,decrypt)))
 
 (provide 'mu4e-proc)
 ;;; mu4e-proc.el ends here

--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -89,7 +89,7 @@ removed."
 
 (defun mu4e~proc-filter (_proc str)
   "Filter string STR from PROC.
-This process the the 'mu server' output. It accumulates the
+This processes the 'mu server' output. It accumulates the
 strings into valid sexps by checking of the ';;eox' `end-of-sexp'
 marker, and then evaluating them.
 

--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -51,10 +51,10 @@ Match 1 will be the length (in hex).")
 
 (defun mu4e~proc-running-p  ()
   "Whether the mu process is running."
-  (when (and mu4e~proc-process
-             (memq (process-status mu4e~proc-process)
-                   '(run open listen connect stop)))
-    t))
+  (and mu4e~proc-process
+       (memq (process-status mu4e~proc-process)
+             '(run open listen connect stop))
+       t))
 
 (defsubst mu4e~proc-eat-sexp-from-buf ()
   "'Eat' the next s-expression from `mu4e~proc-buf'.

--- a/mu4e/mu4e-speedbar.el
+++ b/mu4e/mu4e-speedbar.el
@@ -1,23 +1,23 @@
 ;;; mu4e-speedbar --- Speedbar support for mu4e -*- lexical-binding: t -*-
-
-;; Copyright (C) 2012-2020 Antono Vasiljev, Dirk-Jan C. Binnema
 ;;
+;; Copyright (C) 2012-2020 Antono Vasiljev, Dirk-Jan C. Binnema
+
 ;; Author: Antono Vasiljev <self@antono.info>
 ;; Version: 0.1
 ;; Keywords: file, tags, tools
-;;
+
 ;; This file is not part of GNU Emacs.
 ;;
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation; either version 3, or (at your option)
 ;; any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/mu4e/mu4e-speedbar.el
+++ b/mu4e/mu4e-speedbar.el
@@ -55,15 +55,15 @@
 (defun mu4e-speedbar-install-variables ()
   "Install those variables used by speedbar to enhance mu4e."
   (add-hook 'mu4e-context-changed-hook
-    (lambda()
-      (when (buffer-live-p speedbar-buffer)
-        (with-current-buffer speedbar-buffer
-          (let ((inhibit-read-only t))
-            (mu4e-speedbar-buttons))))))
+            (lambda()
+              (when (buffer-live-p speedbar-buffer)
+                (with-current-buffer speedbar-buffer
+                  (let ((inhibit-read-only t))
+                    (mu4e-speedbar-buttons))))))
   (dolist (keymap
-            '( mu4e-main-speedbar-key-map
-               mu4e-headers-speedbar-key-map
-               mu4e-view-speedbar-key-map))
+           '( mu4e-main-speedbar-key-map
+              mu4e-headers-speedbar-key-map
+              mu4e-view-speedbar-key-map))
     (unless keymap
       (setq keymap (speedbar-make-specialized-keymap))
       (define-key keymap "RET" 'speedbar-edit-line)
@@ -71,7 +71,7 @@
 
 ;; Make sure our special speedbar major mode is loaded
 (if (featurep 'speedbar)
-  (mu4e-speedbar-install-variables)
+    (mu4e-speedbar-install-variables)
   (add-hook 'speedbar-load-hook 'mu4e-speedbar-install-variables))
 
 (defun mu4e~speedbar-render-maildir-list ()
@@ -80,19 +80,19 @@
   (when (buffer-live-p speedbar-buffer)
     (with-current-buffer speedbar-buffer
       (mapcar (lambda (maildir-name)
-		            (speedbar-insert-button
-		              (concat "  " maildir-name)
-		              'mu4e-highlight-face
-		              'highlight
-		              'mu4e~speedbar-maildir
-		              maildir-name))
-	      (mu4e-get-maildirs)))))
+                (speedbar-insert-button
+                 (concat "  " maildir-name)
+                 'mu4e-highlight-face
+                 'highlight
+                 'mu4e~speedbar-maildir
+                 maildir-name))
+              (mu4e-get-maildirs)))))
 
 (defun mu4e~speedbar-maildir (&optional _text token _ident)
   "Jump to maildir TOKEN. TEXT and INDENT are not used."
   (dframe-with-attached-buffer
-    (mu4e-headers-search (concat "\"maildir:" token "\"")
-      current-prefix-arg)))
+   (mu4e-headers-search (concat "\"maildir:" token "\"")
+                        current-prefix-arg)))
 
 (defun mu4e~speedbar-render-bookmark-list ()
   "Insert the list of bookmarks in the speedbar"
@@ -100,17 +100,17 @@
   (mapcar (lambda (bookmark)
             (unless (plist-get bookmark :hide)
               (speedbar-insert-button
-	              (concat "  " (plist-get bookmark :name))
-	              'mu4e-highlight-face
-	              'highlight
-	              'mu4e~speedbar-bookmark
-	              (plist-get bookmark :query))))
-    (mu4e-bookmarks)))
+               (concat "  " (plist-get bookmark :name))
+               'mu4e-highlight-face
+               'highlight
+               'mu4e~speedbar-bookmark
+               (plist-get bookmark :query))))
+          (mu4e-bookmarks)))
 
 (defun mu4e~speedbar-bookmark (&optional _text token _ident)
   "Run bookmarked query TOKEN. TEXT and INDENT are not used."
   (dframe-with-attached-buffer
-    (mu4e-headers-search token current-prefix-arg)))
+   (mu4e-headers-search token current-prefix-arg)))
 
 ;;;###autoload
 (defun mu4e-speedbar-buttons (&optional _buffer)

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -56,9 +56,9 @@
 ;; cleaner solution....
 (defconst mu4e~ts-regexp0
   (concat
-    "\\(\\([0-9]\\{4\\}\\)-\\([0-9]\\{2\\}\\)-\\([0-9]\\{2\\}\\)"
-    "\\( +[^]+0-9>\r\n -]+\\)?\\( +\\([0-9]\\{1,2\\}\\):"
-    "\\([0-9]\\{2\\}\\)\\)?\\)")
+   "\\(\\([0-9]\\{4\\}\\)-\\([0-9]\\{2\\}\\)-\\([0-9]\\{2\\}\\)"
+   "\\( +[^]+0-9>\r\n -]+\\)?\\( +\\([0-9]\\{1,2\\}\\):"
+   "\\([0-9]\\{2\\}\\)\\)?\\)")
   "Regular expression matching time strings for analysis.
 This one does not require the space after the date, so it can be
 used on a string that terminates immediately after the date.")
@@ -69,15 +69,15 @@ This should be a lot faster than the normal `parse-time-string'.
 If time is not given, defaults to 0:00.  However, with optional
 NODEFAULT, hour and minute fields will be nil if not given."
   (if (string-match mu4e~ts-regexp0 s)
-    (list 0
-	    (if (or (match-beginning 8) (not nodefault))
-		    (string-to-number (or (match-string 8 s) "0")))
-	    (if (or (match-beginning 7) (not nodefault))
-		    (string-to-number (or (match-string 7 s) "0")))
-	    (string-to-number (match-string 4 s))
-	    (string-to-number (match-string 3 s))
-	    (string-to-number (match-string 2 s))
-	    nil nil nil)
+      (list 0
+            (if (or (match-beginning 8) (not nodefault))
+                (string-to-number (or (match-string 8 s) "0")))
+            (if (or (match-beginning 7) (not nodefault))
+                (string-to-number (or (match-string 7 s) "0")))
+            (string-to-number (match-string 4 s))
+            (string-to-number (match-string 3 s))
+            (string-to-number (match-string 2 s))
+            nil nil nil)
     (mu4e-error "Not a standard mu4e time string: %s" s)))
 
 
@@ -86,9 +86,9 @@ NODEFAULT, hour and minute fields will be nil if not given."
 User's addresses are set in `(mu4e-personal-addresses)'.  Case
 insensitive comparison is used."
   (when (and addr (mu4e-personal-addresses)
-	        (cl-find addr (mu4e-personal-addresses)
-		        :test (lambda (s1 s2)
-			              (eq t (compare-strings s1 nil nil s2 nil nil t)))))
+             (cl-find addr (mu4e-personal-addresses)
+                      :test (lambda (s1 s2)
+                              (eq t (compare-strings s1 nil nil s2 nil nil t)))))
     t))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -98,8 +98,8 @@ insensitive comparison is used."
   (declare (indent 2))
   `(let* ((vars (and ,context (mu4e-context-vars ,context))))
      (cl-progv ;; XXX: perhaps use eval's lexical environment instead of progv?
-       (mapcar (lambda(cell) (car cell)) vars)
-       (mapcar (lambda(cell) (cdr cell)) vars)
+         (mapcar (lambda(cell) (car cell)) vars)
+         (mapcar (lambda(cell) (cdr cell)) vars)
        (eval ,@body))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -110,18 +110,18 @@ If FOLDER is a string, return it, if it is a function, evaluate
 this function with MSG as parameter (which may be `nil'), and
 return the result."
   (unless (member foldervar
-	          '(mu4e-sent-folder mu4e-drafts-folder
-	             mu4e-trash-folder mu4e-refile-folder))
+                  '(mu4e-sent-folder mu4e-drafts-folder
+                                     mu4e-trash-folder mu4e-refile-folder))
     (mu4e-error "Folder must be one of mu4e-(sent|drafts|trash|refile)-folder"))
   ;; get the value with the vars for the relevants context let-bound
   (with~mu4e-context-vars (mu4e-context-determine msg nil)
-    (let* ((folder (symbol-value foldervar))
-	          (val
-	            (cond
-		            ((stringp   folder) folder)
-		            ((functionp folder) (funcall folder msg))
-		            (t (mu4e-error "unsupported type for %S" folder)))))
-      (or val (mu4e-error "%S evaluates to nil" foldervar)))))
+      (let* ((folder (symbol-value foldervar))
+             (val
+              (cond
+               ((stringp   folder) folder)
+               ((functionp folder) (funcall folder msg))
+               (t (mu4e-error "unsupported type for %S" folder)))))
+        (or val (mu4e-error "%S evaluates to nil" foldervar)))))
 
 (defun mu4e-get-drafts-folder (&optional msg)
   "Get the sent folder. See `mu4e-drafts-folder'."
@@ -144,7 +144,7 @@ return the result."
 (defun mu4e-remove-file-later (filename)
   "Remove FILENAME in a few seconds."
   (run-at-time "30 sec" nil
-    (lambda () (ignore-errors (delete-file filename)))))
+               (lambda () (ignore-errors (delete-file filename)))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -166,16 +166,16 @@ program."
 `mu4e-attachment-dir' (which can be either a string or a function,
 see its docstring)."
   (let
-    ((dir
-       (cond
-	       ((stringp mu4e-attachment-dir)
-	         mu4e-attachment-dir)
-	       ((functionp mu4e-attachment-dir)
-	         (funcall mu4e-attachment-dir fname mimetype))
-	       (t
-	         (mu4e-error "unsupported type for mu4e-attachment-dir" )))))
+      ((dir
+        (cond
+         ((stringp mu4e-attachment-dir)
+          mu4e-attachment-dir)
+         ((functionp mu4e-attachment-dir)
+          (funcall mu4e-attachment-dir fname mimetype))
+         (t
+          (mu4e-error "unsupported type for mu4e-attachment-dir" )))))
     (if dir
-      (expand-file-name dir)
+        (expand-file-name dir)
       (mu4e-error (mu4e-error "mu4e-attachment-dir evaluates to nil")))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -185,10 +185,10 @@ see its docstring)."
   (let ((idx (string-match (mu4e-root-maildir) path)))
     (when (and idx (zerop idx))
       (replace-regexp-in-string
-	      (mu4e-root-maildir)
-	      ""
-	      (expand-file-name
-	        (concat path "/../.."))))))
+       (mu4e-root-maildir)
+       ""
+       (expand-file-name
+        (concat path "/../.."))))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
@@ -200,18 +200,18 @@ create it -- we cannot be sure creation succeeded here, since this
 is done asynchronously. Otherwise, return nil. NOte, DIR has to be
 an absolute path."
   (if (and (file-exists-p dir) (not (file-directory-p dir)))
-    (mu4e-error "%s exists, but is not a directory." dir))
+      (mu4e-error "%s exists, but is not a directory." dir))
   (cond
-    ((file-directory-p dir) t)
-    ((yes-or-no-p (mu4e-format "%s does not exist yet. Create now?" dir))
-      (mu4e~proc-mkdir dir) t)
-    (t nil)))
+   ((file-directory-p dir) t)
+   ((yes-or-no-p (mu4e-format "%s does not exist yet. Create now?" dir))
+    (mu4e~proc-mkdir dir) t)
+   (t nil)))
 
 (defun mu4e-format (frm &rest args)
   "Create [mu4e]-prefixed string based on format FRM and ARGS."
   (concat
-    "[" (propertize "mu4e" 'face 'mu4e-title-face) "] "
-    (apply 'format frm args)))
+   "[" (propertize "mu4e" 'face 'mu4e-title-face) "] "
+   (apply 'format frm args)))
 
 (defun mu4e-message (frm &rest args)
   "Like `message', but prefixed with mu4e.
@@ -256,8 +256,8 @@ trying an exact match."
       (setq choice (read-char-exclusive prompt))
       (if (eq choice 27) (keyboard-quit)) ;; quit if ESC is pressed
       (setq chosen (or (member choice choices)
-		                 (member (downcase choice) choices)
-		                 (member (upcase choice) choices))))
+                       (member (downcase choice) choices)
+                       (member (upcase choice) choices))))
     (car chosen)))
 
 (defun mu4e-read-option (prompt options)
@@ -276,57 +276,57 @@ can prefix the string with an uniquifying character.
 The options are provided as a list for the user to choose from;
 user can then choose by typing CHAR.  Example:
   (mu4e-read-option \"Choose an animal: \"
-	      '((\"Monkey\" . monkey) (\"Gnu\" . gnu) (\"xMoose\" . moose)))
+              '((\"Monkey\" . monkey) (\"Gnu\" . gnu) (\"xMoose\" . moose)))
 
 User now will be presented with a list: \"Choose an animal:
    [M]onkey, [G]nu, [x]Moose\".
 
 Function will return the cdr of the list element."
   (let* ((prompt (mu4e-format "%s" prompt))
-	        (optionsstr
-	          (mapconcat
-	            (lambda (option)
-		            ;; try to detect old-style options, and warn
-		            (when (characterp (car-safe (cdr-safe option)))
-		              (mu4e-error
-		                (concat "Please use the new format for options/actions; "
-				              "see the manual")))
-		            (let ((kar (substring (car option) 0 1)))
-		              (concat
-		                "[" (propertize kar 'face 'mu4e-highlight-face) "]"
-		                (substring (car option) 1))))
-	            options ", "))
-	        (response
-	          (mu4e~read-char-choice
-	            (concat prompt optionsstr
-		            " [" (propertize "C-g" 'face 'mu4e-highlight-face)
-		            " to cancel]")
-	            ;; the allowable chars
-	            (cl-map 'list (lambda(elm) (string-to-char (car elm))) options)))
-	        (chosen
-	          (cl-find-if
-	            (lambda (option) (eq response (string-to-char (car option))))
-	            options)))
+         (optionsstr
+          (mapconcat
+           (lambda (option)
+             ;; try to detect old-style options, and warn
+             (when (characterp (car-safe (cdr-safe option)))
+               (mu4e-error
+                (concat "Please use the new format for options/actions; "
+                        "see the manual")))
+             (let ((kar (substring (car option) 0 1)))
+               (concat
+                "[" (propertize kar 'face 'mu4e-highlight-face) "]"
+                (substring (car option) 1))))
+           options ", "))
+         (response
+          (mu4e~read-char-choice
+           (concat prompt optionsstr
+                   " [" (propertize "C-g" 'face 'mu4e-highlight-face)
+                   " to cancel]")
+           ;; the allowable chars
+           (cl-map 'list (lambda(elm) (string-to-char (car elm))) options)))
+         (chosen
+          (cl-find-if
+           (lambda (option) (eq response (string-to-char (car option))))
+           options)))
     (if chosen
-      (cdr chosen)
+        (cdr chosen)
       (mu4e-warn "Unknown shortcut '%c'" response))))
 
 (defun mu4e~get-maildirs-1 (path mdir)
   "Get maildirs under path, recursively, as a list of relative paths."
   (let ((dirs)
-	       (dentries
-	         (ignore-errors
-	           (directory-files-and-attributes
-	             (concat path mdir) nil
-	             "^[^.]\\|\\.[^.][^.]" t))))
+        (dentries
+         (ignore-errors
+           (directory-files-and-attributes
+            (concat path mdir) nil
+            "^[^.]\\|\\.[^.][^.]" t))))
     (dolist (dentry dentries)
       (when (and (booleanp (cadr dentry)) (cadr dentry))
-	      (if (file-accessible-directory-p
-	            (concat (mu4e-root-maildir) "/" mdir "/" (car dentry) "/cur"))
-	        (setq dirs (cons (concat mdir (car dentry)) dirs)))
-	      (unless (member (car dentry) '("cur" "new" "tmp"))
-	        (setq dirs (append dirs (mu4e~get-maildirs-1 path
-				                            (concat mdir (car dentry) "/")))))))
+        (if (file-accessible-directory-p
+             (concat (mu4e-root-maildir) "/" mdir "/" (car dentry) "/cur"))
+            (setq dirs (cons (concat mdir (car dentry)) dirs)))
+        (unless (member (car dentry) '("cur" "new" "tmp"))
+          (setq dirs (append dirs (mu4e~get-maildirs-1 path
+                                                       (concat mdir (car dentry) "/")))))))
     dirs))
 
 (defvar mu4e-cache-maildir-list nil
@@ -346,12 +346,12 @@ if `mu4e-cache-maildir-list' is customized to non-nil. In that case,
 the list of maildirs will not change until you restart mu4e."
   (unless (and mu4e-maildir-list mu4e-cache-maildir-list)
     (setq mu4e-maildir-list
-      (sort
-	      (append
-	        (when (file-accessible-directory-p
-		              (concat (mu4e-root-maildir) "/cur")) '("/"))
-	        (mu4e~get-maildirs-1 (mu4e-root-maildir) "/"))
-	      (lambda (s1 s2) (string< (downcase s1) (downcase s2))))))
+          (sort
+           (append
+            (when (file-accessible-directory-p
+                   (concat (mu4e-root-maildir) "/cur")) '("/"))
+            (mu4e~get-maildirs-1 (mu4e-root-maildir) "/"))
+           (lambda (s1 s2) (string< (downcase s1) (downcase s2))))))
   mu4e-maildir-list)
 
 (defun mu4e-ask-maildir (prompt)
@@ -362,82 +362,82 @@ name. If the special shortcut 'o' (for _o_ther) is used, or if
 maildirs under `mu4e-maildir'."
   (let ((prompt (mu4e-format "%s" prompt)))
     (if (not mu4e-maildir-shortcuts)
-      (funcall mu4e-completing-read-function prompt (mu4e-get-maildirs))
+        (funcall mu4e-completing-read-function prompt (mu4e-get-maildirs))
       (let* ((mlist (append mu4e-maildir-shortcuts '(("ther" . ?o))))
-	            (fnames
-		            (mapconcat
-		              (lambda (item)
-		                (concat
-		                  "["
-		                  (propertize (make-string 1 (cdr item))
-			                  'face 'mu4e-highlight-face)
-		                  "]"
-		                  (car item)))
-		              mlist ", "))
-	            (kar (read-char (concat prompt fnames))))
-	      (if (member kar '(?/ ?o)) ;; user chose 'other'?
-	        (funcall mu4e-completing-read-function prompt
-	          (mu4e-get-maildirs) nil nil "/")
-	        (or (car-safe
-		            (cl-find-if (lambda (item) (= kar (cdr item)))
-		              mu4e-maildir-shortcuts))
-	          (mu4e-warn "Unknown shortcut '%c'" kar)))))))
+             (fnames
+              (mapconcat
+               (lambda (item)
+                 (concat
+                  "["
+                  (propertize (make-string 1 (cdr item))
+                              'face 'mu4e-highlight-face)
+                  "]"
+                  (car item)))
+               mlist ", "))
+             (kar (read-char (concat prompt fnames))))
+        (if (member kar '(?/ ?o)) ;; user chose 'other'?
+            (funcall mu4e-completing-read-function prompt
+                     (mu4e-get-maildirs) nil nil "/")
+          (or (car-safe
+               (cl-find-if (lambda (item) (= kar (cdr item)))
+                           mu4e-maildir-shortcuts))
+              (mu4e-warn "Unknown shortcut '%c'" kar)))))))
 
 
 (defun mu4e-ask-maildir-check-exists (prompt)
   "Like `mu4e-ask-maildir', but check for existence of the maildir,
 and offer to create it if it does not exist yet."
   (let* ((mdir (mu4e-ask-maildir prompt))
-	        (fullpath (concat (mu4e-root-maildir) mdir)))
+         (fullpath (concat (mu4e-root-maildir) mdir)))
     (unless (file-directory-p fullpath)
       (and (yes-or-no-p
-	           (mu4e-format "%s does not exist. Create now?" fullpath))
-	      (mu4e~proc-mkdir fullpath)))
+            (mu4e-format "%s does not exist. Create now?" fullpath))
+           (mu4e~proc-mkdir fullpath)))
     mdir))
 
 (defun mu4e-bookmarks ()
   "Get `mu4e-bookmarks' in the (new) format, converting from the
 old format if needed."
   (cl-map 'list
-    (lambda (item)
-      (if (and (listp item) (= (length item) 3))
-	      `(:name  ,(nth 1 item)
-	         :query ,(nth 0 item)
-	         :key   ,(nth 2 item))
-        item))
-    mu4e-bookmarks))
+          (lambda (item)
+            (if (and (listp item) (= (length item) 3))
+                `(:name  ,(nth 1 item)
+                         :query ,(nth 0 item)
+                         :key   ,(nth 2 item))
+              item))
+          mu4e-bookmarks))
 
 (defun mu4e-ask-bookmark (prompt)
   "Ask the user for a bookmark (using PROMPT) as defined in
 `mu4e-bookmarks', then return the corresponding query."
   (unless (mu4e-bookmarks) (mu4e-error "No bookmarks defined"))
   (let* ((prompt (mu4e-format "%s" prompt))
-	        (bmarks
-	          (mapconcat
-	            (lambda (bm)
-	              (concat
-		              "[" (propertize (make-string 1 (plist-get bm :key))
-		                    'face 'mu4e-highlight-face)
-		              "]"
-		              (plist-get bm :name))) (mu4e-bookmarks) ", "))
-	        (kar (read-char (concat prompt bmarks))))
+         (bmarks
+          (mapconcat
+           (lambda (bm)
+             (concat
+              "[" (propertize (make-string 1 (plist-get bm :key))
+                              'face 'mu4e-highlight-face)
+              "]"
+              (plist-get bm :name))) (mu4e-bookmarks) ", "))
+         (kar (read-char (concat prompt bmarks))))
     (mu4e-get-bookmark-query kar)))
 
 (defun mu4e-get-bookmark-query (kar)
   "Get the corresponding bookmarked query for shortcut character
 KAR, or raise an error if none is found."
   (let* ((chosen-bm
-	         (or (cl-find-if
-		             (lambda (bm)
-		               (= kar (plist-get bm :key)))
-		             (mu4e-bookmarks))
-	           (mu4e-warn "Unknown shortcut '%c'" kar)))
-	        (expr (plist-get chosen-bm :query))
-          (expr (if (not (functionp expr)) expr
-                  (funcall expr)))
-          (query (eval expr)))
+          (or (cl-find-if
+               (lambda (bm)
+                 (= kar (plist-get bm :key)))
+               (mu4e-bookmarks))
+              (mu4e-warn "Unknown shortcut '%c'" kar)))
+         (expr (plist-get chosen-bm :query))
+         (expr (if (not (functionp expr)) expr
+                 (funcall expr)))
+         (query (eval expr)))
     (if (stringp query)
-      query
+        query
       (mu4e-warn "Expression must evaluate to query string ('%S')" expr))))
 
 
@@ -446,14 +446,14 @@ KAR, or raise an error if none is found."
 shortcut-character KEY in the list of `mu4e-bookmarks'. This
 replaces any existing bookmark with KEY."
   (setq mu4e-bookmarks
-    (cl-remove-if
-      (lambda (bm)
-	      (= (plist-get bm :key) key))
-      (mu4e-bookmarks)))
+        (cl-remove-if
+         (lambda (bm)
+           (= (plist-get bm :key) key))
+         (mu4e-bookmarks)))
   (cl-pushnew `(:name  ,name
-                 :query ,query
-                 :key   ,key)
-    mu4e-bookmarks :test 'equal))
+                       :query ,query
+                       :key   ,key)
+              mu4e-bookmarks :test 'equal))
 
 
 ;;; converting flags->string and vice-versa ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -467,25 +467,25 @@ Also see `mu4e-flags-to-string'.
 \[1\]: http://cr.yp.to/proto/maildir.html"
   (when flags
     (let ((kar (cl-case (car flags)
-		             ('draft     ?D)
-		             ('flagged   ?F)
-		             ('new       ?N)
-		             ('passed    ?P)
-		             ('replied   ?R)
-		             ('seen      ?S)
-		             ('trashed   ?T)
-		             ('attach    ?a)
-		             ('encrypted ?x)
-		             ('signed    ?s)
-		             ('unread    ?u))))
+                 ('draft     ?D)
+                 ('flagged   ?F)
+                 ('new       ?N)
+                 ('passed    ?P)
+                 ('replied   ?R)
+                 ('seen      ?S)
+                 ('trashed   ?T)
+                 ('attach    ?a)
+                 ('encrypted ?x)
+                 ('signed    ?s)
+                 ('unread    ?u))))
       (concat (and kar (string kar))
-	      (mu4e~flags-to-string-raw (cdr flags))))))
+              (mu4e~flags-to-string-raw (cdr flags))))))
 
 (defun mu4e-flags-to-string (flags)
   "Remove duplicates and sort the output of `mu4e~flags-to-string-raw'."
   (concat
-    (sort (cl-remove-duplicates
-	          (append (mu4e~flags-to-string-raw flags) nil)) '>)))
+   (sort (cl-remove-duplicates
+          (append (mu4e~flags-to-string-raw flags) nil)) '>)))
 
 (defun mu4e~string-to-flags-1 (str)
   "Convert a string with message flags as seen in Maildir
@@ -497,15 +497,15 @@ Also see `mu4e-flags-to-string'.
 \[1\]: http://cr.yp.to/proto/maildir.html."
   (when (/= 0 (length str))
     (let ((flag
-	          (cl-case (string-to-char str)
-	            (?D   'draft)
-	            (?F   'flagged)
-	            (?P   'passed)
-	            (?R   'replied)
-	            (?S   'seen)
-	            (?T   'trashed))))
+           (cl-case (string-to-char str)
+             (?D   'draft)
+             (?F   'flagged)
+             (?P   'passed)
+             (?R   'replied)
+             (?S   'seen)
+             (?T   'trashed))))
       (append (when flag (list flag))
-	      (mu4e~string-to-flags-1 (substring str 1))))))
+              (mu4e~string-to-flags-1 (substring str 1))))))
 
 (defun mu4e-string-to-flags (str)
   "Convert a string with message flags as seen in Maildir messages
@@ -523,11 +523,11 @@ http://cr.yp.to/proto/maildir.html "
 (defun mu4e-display-size (size)
   "Get a string representation of SIZE (in bytes)."
   (cond
-    ((>= size 1000000) (format "%2.1fM" (/ size 1000000.0)))
-    ((and (>= size 1000) (< size 1000000))
-      (format "%2.1fK" (/ size 1000.0)))
-    ((< size 1000) (format "%d" size))
-    (t (propertize "?" 'face 'mu4e-system-face))))
+   ((>= size 1000000) (format "%2.1fM" (/ size 1000000.0)))
+   ((and (>= size 1000) (< size 1000000))
+    (format "%2.1fK" (/ size 1000.0)))
+   ((< size 1000) (format "%d" size))
+   (t (propertize "?" 'face 'mu4e-system-face))))
 
 
 (defun mu4e-display-manual ()
@@ -535,10 +535,10 @@ http://cr.yp.to/proto/maildir.html "
 Or go to the top level if there is none."
   (interactive)
   (info (cl-case major-mode
-	        ('mu4e-main-mode "(mu4e)Main view")
-	        ('mu4e-headers-mode "(mu4e)Headers view")
-	        ('mu4e-view-mode "(mu4e)Message view")
-	        (t               "mu4e"))))
+          ('mu4e-main-mode "(mu4e)Main view")
+          ('mu4e-headers-mode "(mu4e)Headers view")
+          ('mu4e-view-mode "(mu4e)Message view")
+          (t               "mu4e"))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun mu4e-last-query ()
@@ -558,14 +558,14 @@ Or go to the top level if there is none."
 that has a live window), and vice versa."
   (interactive)
   (let* ((other-buf
-	         (cond
-	           ((eq major-mode 'mu4e-headers-mode)
-	             (mu4e-get-view-buffer))
-	           ((eq major-mode 'mu4e-view-mode)
-	             (mu4e-get-headers-buffer))))
-	        (other-win (and other-buf (get-buffer-window other-buf))))
+          (cond
+           ((eq major-mode 'mu4e-headers-mode)
+            (mu4e-get-view-buffer))
+           ((eq major-mode 'mu4e-view-mode)
+            (mu4e-get-headers-buffer))))
+         (other-win (and other-buf (get-buffer-window other-buf))))
     (if (window-live-p other-win)
-      (select-window other-win)
+        (select-window other-win)
       (mu4e-message "No window to switch to"))))
 
 
@@ -577,9 +577,9 @@ that has a live window), and vice versa."
   (let ((buf (get-buffer-create mu4e-output-buffer-name)))
     (with-current-buffer buf
       (let ((inhibit-read-only t))
-	      (erase-buffer)
-	      (call-process-shell-command pipecmd path t t)
-	      (view-mode)))
+        (erase-buffer)
+        (call-process-shell-command pipecmd path t t)
+        (view-mode)))
     (switch-to-buffer buf)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -598,18 +598,18 @@ on `mu4e~mailing-lists', `mu4e-user-mailing-lists', and
     (dolist (cell mu4e-user-mailing-lists)
       (puthash (car cell) (cdr cell) mu4e~lists-hash)))
   (or
-    (gethash list-id mu4e~lists-hash)
-    (and (boundp 'mu4e-mailing-list-patterns)
-	    (cl-member-if
-	      (lambda (pattern)
-	        (string-match pattern list-id))
-	      mu4e-mailing-list-patterns)
-	    (match-string 1 list-id))
-    ;; if it's not in the db, take the part until the first dot if there is one;
-    ;; otherwise just return the whole thing
-    (if (string-match "\\([^.]*\\)\\." list-id)
-      (match-string 1 list-id)
-      list-id)))
+   (gethash list-id mu4e~lists-hash)
+   (and (boundp 'mu4e-mailing-list-patterns)
+        (cl-member-if
+         (lambda (pattern)
+           (string-match pattern list-id))
+         mu4e-mailing-list-patterns)
+        (match-string 1 list-id))
+   ;; if it's not in the db, take the part until the first dot if there is one;
+   ;; otherwise just return the whole thing
+   (if (string-match "\\([^.]*\\)\\." list-id)
+       (match-string 1 list-id)
+     list-id)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -626,7 +626,7 @@ used as a simple way to invoke some action when a message
 changed.")
 
 (make-obsolete-variable 'mu4e-msg-changed-hook
-  'mu4e-message-changed-hook "0.9.19")
+                        'mu4e-message-changed-hook "0.9.19")
 
 (defvar mu4e~contacts-tstamp "0"
   "Timestamp for the most recent contacts update." )
@@ -637,27 +637,27 @@ changed.")
   "Handler function for (:info ...) sexps received from the server
 process."
   (let* ((type (plist-get info :info))
-          (processed (plist-get info :processed))
-          (updated (plist-get info :updated))
-          (cleaned-up (plist-get info :cleaned-up)))
+         (processed (plist-get info :processed))
+         (updated (plist-get info :updated))
+         (cleaned-up (plist-get info :cleaned-up)))
     (cond
-      ((eq type 'add) t) ;; do nothing
-      ((eq type 'index)
-	      (if (eq (plist-get info :status) 'running)
-	        (mu4e-index-message
-            "Indexing... processed %d, updated %d" processed updated)
-	        (progn
-	          (mu4e-index-message
-	            "Indexing completed; processed %d, updated %d, cleaned-up %d"
-              processed updated cleaned-up)
-            ;; call the updated hook if anything changed.
-            (unless (zerop (+ updated cleaned-up))
-              (run-hooks 'mu4e-index-updated-hook))
-	          (unless (and (not (string= mu4e~contacts-tstamp "0"))
-                      (zerop (plist-get info :updated)))
-	            (mu4e~request-contacts-maybe)))))
-      ((plist-get info :message)
-	      (mu4e-index-message "%s" (plist-get info :message))))))
+     ((eq type 'add) t) ;; do nothing
+     ((eq type 'index)
+      (if (eq (plist-get info :status) 'running)
+          (mu4e-index-message
+           "Indexing... processed %d, updated %d" processed updated)
+        (progn
+          (mu4e-index-message
+           "Indexing completed; processed %d, updated %d, cleaned-up %d"
+           processed updated cleaned-up)
+          ;; call the updated hook if anything changed.
+          (unless (zerop (+ updated cleaned-up))
+            (run-hooks 'mu4e-index-updated-hook))
+          (unless (and (not (string= mu4e~contacts-tstamp "0"))
+                       (zerop (plist-get info :updated)))
+            (mu4e~request-contacts-maybe)))))
+     ((plist-get info :message)
+      (mu4e-index-message "%s" (plist-get info :message))))))
 
 (defun mu4e-error-handler (errcode errmsg)
   "Handler function for showing an error."
@@ -685,13 +685,13 @@ This is used by the completion function in mu4e-compose."
   (let ((n 0))
     (unless mu4e~contacts
       (setq mu4e~contacts (make-hash-table :test 'equal :weakness nil
-		                        :size (length contacts))))
+                                           :size (length contacts))))
     (dolist (contact contacts)
       (cl-incf n)
       (let ((address
-              (if (functionp mu4e-contact-process-function)
-                (funcall mu4e-contact-process-function (car contact))
-                (car contact))))
+             (if (functionp mu4e-contact-process-function)
+                 (funcall mu4e-contact-process-function (car contact))
+               (car contact))))
         (when address
           (puthash address (cdr contact) mu4e~contacts))))
 
@@ -699,7 +699,7 @@ This is used by the completion function in mu4e-compose."
 
     (unless (zerop n)
       (mu4e-index-message "Contacts updated: %d; total %d"
-        n (hash-table-count mu4e~contacts)))))
+                          n (hash-table-count mu4e~contacts)))))
 
 (defun mu4e-contacts-info ()
   "Display information about the cache used for contacts
@@ -708,15 +708,15 @@ completion; for testing/debugging."
   (with-current-buffer (get-buffer-create "*mu4e-contacts-info*")
     (erase-buffer)
     (insert (format "complete addresses:        %s\n"
-              (if mu4e-compose-complete-addresses "yes" "no")))
+                    (if mu4e-compose-complete-addresses "yes" "no")))
     (insert (format "only personal addresses:   %s\n"
-              (if mu4e-compose-complete-only-personal "yes" "no")))
+                    (if mu4e-compose-complete-only-personal "yes" "no")))
     (insert (format "only addresses seen after: %s\n"
-              (or mu4e-compose-complete-only-after "no restrictions")))
+                    (or mu4e-compose-complete-only-after "no restrictions")))
 
     (when mu4e~contacts
       (insert (format "number of contacts cached: %d\n\n"
-                (hash-table-count mu4e~contacts)))
+                      (hash-table-count mu4e~contacts)))
       (maphash (lambda(key _val)
                  (insert (format "%S\n" key))) mu4e~contacts)))
   (pop-to-buffer "*mu4e-contacts-info*"))
@@ -727,22 +727,22 @@ completion; for testing/debugging."
     (mu4e-error "Emacs >= 25.x is required for mu4e"))
   (when mu4e~server-props
     (unless (string= (mu4e-server-version) mu4e-mu-version)
-	    (mu4e-error "mu server has version %s, but we need %s"
-	      (mu4e-server-version) mu4e-mu-version)))
+      (mu4e-error "mu server has version %s, but we need %s"
+                  (mu4e-server-version) mu4e-mu-version)))
   (unless (and mu4e-mu-binary (file-executable-p mu4e-mu-binary))
     (mu4e-error "Please set `mu4e-mu-binary' to the full path to the mu
     binary."))
   (dolist (var '(mu4e-sent-folder mu4e-drafts-folder
-		              mu4e-trash-folder))
+                                  mu4e-trash-folder))
     (unless (and (boundp var) (symbol-value var))
       (mu4e-error "Please set %S" var))
     (unless (functionp (symbol-value var)) ;; functions are okay, too
       (let* ((dir (symbol-value var))
-	            (path (concat (mu4e-root-maildir) dir)))
-	      (unless (string= (substring dir 0 1) "/")
-	        (mu4e-error "%S must start with a '/'" dir))
-	      (unless (mu4e-create-maildir-maybe path)
-	        (mu4e-error "%s (%S) does not exist" path var))))))
+             (path (concat (mu4e-root-maildir) dir)))
+        (unless (string= (substring dir 0 1) "/")
+          (mu4e-error "%S must start with a '/'" dir))
+        (unless (mu4e-create-maildir-maybe path)
+          (mu4e-error "%s (%S) does not exist" path var))))))
 
 (defun mu4e-running-p ()
   "Whether mu4e is running.
@@ -772,25 +772,25 @@ nothing."
   (when mu4e-compose-complete-addresses
     (setq mu4e-contacts-func 'mu4e~update-contacts)
     (mu4e~proc-contacts
-      mu4e-compose-complete-only-personal
-      mu4e-compose-complete-only-after
-	    mu4e~contacts-tstamp)))
+     mu4e-compose-complete-only-personal
+     mu4e-compose-complete-only-after
+     mu4e~contacts-tstamp)))
 
 (defun mu4e~pong-handler (data func)
   "Handle 'pong' responses from the mu server."
-	(setq mu4e~server-props (plist-get data :props)) ;; save info from the server
-	(let ((doccount (plist-get mu4e~server-props :doccount)))
+  (setq mu4e~server-props (plist-get data :props)) ;; save info from the server
+  (let ((doccount (plist-get mu4e~server-props :doccount)))
     (mu4e~context-autoswitch nil mu4e-context-policy)
-	  (mu4e~check-requirements)
-	  (when func (funcall func))
+    (mu4e~check-requirements)
+    (when func (funcall func))
     (when (zerop doccount)
       (mu4e-message "Store is empty; (re)indexing. This may take a while.") ;
       (mu4e-update-index))
-	  (when (and mu4e-update-interval (null mu4e~update-timer))
-		  (setq mu4e~update-timer
-        (run-at-time 0 mu4e-update-interval
-		      (lambda () (mu4e-update-mail-and-index
-				               mu4e-index-update-in-background)))))))
+    (when (and mu4e-update-interval (null mu4e~update-timer))
+      (setq mu4e~update-timer
+            (run-at-time 0 mu4e-update-interval
+                         (lambda () (mu4e-update-mail-and-index
+                                     mu4e-index-update-in-background)))))))
 
 
 (defun mu4e~start (&optional func)
@@ -803,21 +803,21 @@ When successful, call FUNC (if non-nil) afterwards."
   (unless (mu4e-running-p) ;; already running?
     ;; when it's visible, re-draw the main view when there are changes.
     (add-hook 'mu4e-index-updated-hook
-      (lambda()
-        (let ((mainbuf (get-buffer mu4e~main-buffer-name)))
-          (when (and (buffer-live-p mainbuf) (get-buffer-window mainbuf))
-            (mu4e~start 'mu4e~main-view))))))
+              (lambda()
+                (let ((mainbuf (get-buffer mu4e~main-buffer-name)))
+                  (when (and (buffer-live-p mainbuf) (get-buffer-window mainbuf))
+                    (mu4e~start 'mu4e~main-view))))))
 
   (setq mu4e-pong-func (lambda (info) (mu4e~pong-handler info func)))
   (mu4e~proc-ping
-    (mapcar ;; send it a list of queries we'd like to see read/unread info
-      ;; for.
-      (lambda(bm) (plist-get bm :query))
-      (seq-filter (lambda (bm) ;; exclude bookmarks that are not strings,
-                    ;; and with these flags.
-                    (and (stringp (plist-get bm :query))
-                      (not (or (plist-get bm :hide) (plist-get bm :hide-unread)))))
-        (mu4e-bookmarks))))
+   (mapcar ;; send it a list of queries we'd like to see read/unread info
+    ;; for.
+    (lambda(bm) (plist-get bm :query))
+    (seq-filter (lambda (bm) ;; exclude bookmarks that are not strings,
+                  ;; and with these flags.
+                  (and (stringp (plist-get bm :query))
+                       (not (or (plist-get bm :hide) (plist-get bm :hide-unread)))))
+                (mu4e-bookmarks))))
   ;; maybe request the list of contacts, automatically refreshed after
   ;; reindexing
   (unless mu4e~contacts (mu4e~request-contacts-maybe)))
@@ -825,9 +825,9 @@ When successful, call FUNC (if non-nil) afterwards."
 (defun mu4e-clear-caches ()
   "Clear any cached resources."
   (setq
-    mu4e-maildir-list nil
-    mu4e~contacts nil
-    mu4e~contacts-tstamp "0"))
+   mu4e-maildir-list nil
+   mu4e~contacts nil
+   mu4e~contacts-tstamp "0"))
 
 (defun mu4e~stop ()
   "Stop the mu4e session."
@@ -838,12 +838,12 @@ When successful, call FUNC (if non-nil) afterwards."
   (mu4e~proc-kill)
   ;; kill all mu4e buffers
   (mapc
-    (lambda (buf)
-      (with-current-buffer buf
-	      (when (member major-mode
-		            '(mu4e-headers-mode mu4e-view-mode mu4e-main-mode))
-	        (kill-buffer))))
-    (buffer-list)))
+   (lambda (buf)
+     (with-current-buffer buf
+       (when (member major-mode
+                     '(mu4e-headers-mode mu4e-view-mode mu4e-main-mode))
+         (kill-buffer))))
+   (buffer-list)))
 
 
 
@@ -862,31 +862,31 @@ Also scrolls to the final line, and update the progress throbber."
 
   (when (string-match mu4e~get-mail-password-regexp msg)
     (if (process-get proc 'x-interactive)
-	    (process-send-string proc
-			  (concat (read-passwd mu4e~get-mail-ask-password)
-			    "\n"))
+        (process-send-string proc
+                             (concat (read-passwd mu4e~get-mail-ask-password)
+                                     "\n"))
       ;; TODO kill process?
       (mu4e-error "Unrecognized password request")))
   (when (process-buffer proc)
     (let ((inhibit-read-only t)
-	         (procwin (get-buffer-window (process-buffer proc))))
+          (procwin (get-buffer-window (process-buffer proc))))
       ;; Insert at end of buffer. Leave point alone.
       (with-current-buffer (process-buffer proc)
-	      (goto-char (point-max))
-	      (if (string-match ".*\r\\(.*\\)" msg)
-	        (progn
-	          ;; kill even with \r
-	          (end-of-line)
-	          (let ((end (point)))
-	            (beginning-of-line)
-	            (delete-region (point) end))
-	          (insert (match-string 1 msg)))
-	        (insert msg)))
+        (goto-char (point-max))
+        (if (string-match ".*\r\\(.*\\)" msg)
+            (progn
+              ;; kill even with \r
+              (end-of-line)
+              (let ((end (point)))
+                (beginning-of-line)
+                (delete-region (point) end))
+              (insert (match-string 1 msg)))
+          (insert msg)))
       ;; Auto-scroll unless user is interacting with the window.
       (when (and (window-live-p procwin)
-	            (not (eq (selected-window) procwin)))
-	      (with-selected-window procwin
-	        (goto-char (point-max)))))))
+                 (not (eq (selected-window) procwin)))
+        (with-selected-window procwin
+          (goto-char (point-max)))))))
 
 (defun mu4e-update-index ()
   "Update the mu4e index."
@@ -906,9 +906,9 @@ Also scrolls to the final line, and update the progress throbber."
   "Create a temporary window with HEIGHT at the bottom of the
 frame to display buffer BUF."
   (let ((win
-	        (split-window
-	          (frame-root-window)
-	          (- (window-height (frame-root-window)) height))))
+         (split-window
+          (frame-root-window)
+          (- (window-height (frame-root-window)) height))))
     (set-window-buffer win buf)
     (set-window-dedicated-p win t)
     win))
@@ -921,13 +921,13 @@ frame to display buffer BUF."
   (unless mu4e-hide-index-messages
     (message nil))
   (if (or (not (eq (process-status proc) 'exit))
-	      (/= (process-exit-status proc) 0))
-    (progn
-	    (when mu4e-index-update-error-warning
-	      (mu4e-message "Update process returned with non-zero exit code")
-	      (sit-for 5))
-	    (when mu4e-index-update-error-continue
-	      (mu4e-update-index)))
+          (/= (process-exit-status proc) 0))
+      (progn
+        (when mu4e-index-update-error-warning
+          (mu4e-message "Update process returned with non-zero exit code")
+          (sit-for 5))
+        (when mu4e-index-update-error-continue
+          (mu4e-update-index)))
     (mu4e-update-index))
   (when (buffer-live-p mu4e~update-buffer)
     (unless (eq mu4e-split-view 'single-window)
@@ -943,24 +943,24 @@ frame to display buffer BUF."
 RUN-IN-BACKGROUND is non-nil (or called with prefix-argument),
 run in the background; otherwise, pop up a window."
   (let* ((process-connection-type t)
-	        (proc (start-process-shell-command
-		              "mu4e-update" mu4e~update-name
-		              mu4e-get-mail-command))
-	        (buf (process-buffer proc))
-	        (win (or run-in-background
-		             (mu4e~temp-window buf mu4e~update-buffer-height))))
+         (proc (start-process-shell-command
+                "mu4e-update" mu4e~update-name
+                mu4e-get-mail-command))
+         (buf (process-buffer proc))
+         (win (or run-in-background
+                  (mu4e~temp-window buf mu4e~update-buffer-height))))
     (setq mu4e~update-buffer buf)
     (when (window-live-p win)
       (with-selected-window win
-	      ;; ;;(switch-to-buffer buf)
-	      ;; (set-window-dedicated-p win t)
-	      (erase-buffer)
-	      (insert "\n") ;; FIXME -- needed so output starts
-	      (mu4e~update-mail-mode)))
+        ;; ;;(switch-to-buffer buf)
+        ;; (set-window-dedicated-p win t)
+        (erase-buffer)
+        (insert "\n") ;; FIXME -- needed so output starts
+        (mu4e~update-mail-mode)))
     (setq mu4e~progress-reporter
-      (unless mu4e-hide-index-messages
-	      (make-progress-reporter
-	        (mu4e-format "Retrieving mail..."))))
+          (unless mu4e-hide-index-messages
+            (make-progress-reporter
+             (mu4e-format "Retrieving mail..."))))
     (set-process-sentinel proc 'mu4e~update-sentinel-func)
     ;; if we're running in the foreground, handle password requests
     (unless run-in-background
@@ -975,8 +975,8 @@ in the background; otherwise, pop up a window."
   (unless mu4e-get-mail-command
     (mu4e-error "`mu4e-get-mail-command' is not defined"))
   (if (and (buffer-live-p mu4e~update-buffer)
-	      (process-live-p (get-buffer-process mu4e~update-buffer)))
-    (mu4e-message "Update process is already running")
+           (process-live-p (get-buffer-process mu4e~update-buffer)))
+      (mu4e-message "Update process is already running")
     (progn
       (run-hooks 'mu4e-update-pre-hook)
       (mu4e~update-mail-and-index-real run-in-background))))
@@ -985,7 +985,7 @@ in the background; otherwise, pop up a window."
   "Stop the update process by killing it."
   (interactive)
   (let* ((proc (and (buffer-live-p mu4e~update-buffer)
-		             (get-buffer-process mu4e~update-buffer))))
+                    (get-buffer-process mu4e~update-buffer))))
     (when (process-live-p proc)
       (kill-process proc t))))
 
@@ -1011,35 +1011,35 @@ either 'to-server, 'from-server or 'misc. This function is meant for debugging."
       (view-mode)
       (setq buffer-undo-list t)
       (let* ((inhibit-read-only t)
-	            (tstamp (propertize (format-time-string "%Y-%m-%d %T"
-				                            (current-time))
-			                  'face 'font-lock-string-face))
-	            (msg-face
-		            (cl-case type
-		              (from-server 'font-lock-type-face)
-		              (to-server   'font-lock-function-name-face)
-		              (misc        'font-lock-variable-name-face)
-		              (error       'font-lock-warning-face)
-		              (otherwise   (mu4e-error "Unsupported log type"))))
-	            (msg (propertize (apply 'format frm args) 'face msg-face)))
-	      (goto-char (point-max))
-	      (insert tstamp
-	        (cl-case type
-	          (from-server " <- ")
-	          (to-server   " -> ")
-	          (error       " !! ")
-	          (otherwise   " "))
-	        msg "\n")
+             (tstamp (propertize (format-time-string "%Y-%m-%d %T"
+                                                     (current-time))
+                                 'face 'font-lock-string-face))
+             (msg-face
+              (cl-case type
+                (from-server 'font-lock-type-face)
+                (to-server   'font-lock-function-name-face)
+                (misc        'font-lock-variable-name-face)
+                (error       'font-lock-warning-face)
+                (otherwise   (mu4e-error "Unsupported log type"))))
+             (msg (propertize (apply 'format frm args) 'face msg-face)))
+        (goto-char (point-max))
+        (insert tstamp
+                (cl-case type
+                  (from-server " <- ")
+                  (to-server   " -> ")
+                  (error       " !! ")
+                  (otherwise   " "))
+                msg "\n")
 
-	      ;; if `mu4e-log-max-lines is specified and exceeded, clearest the oldest
-	      ;; lines
-	      (when (numberp mu4e~log-max-lines)
-	        (let ((lines (count-lines (point-min) (point-max))))
-	          (when (> lines mu4e~log-max-lines)
-	            (goto-char (point-max))
-	            (forward-line (- mu4e~log-max-lines lines))
-	            (beginning-of-line)
-	            (delete-region (point-min) (point)))))))))
+        ;; if `mu4e-log-max-lines is specified and exceeded, clearest the oldest
+        ;; lines
+        (when (numberp mu4e~log-max-lines)
+          (let ((lines (count-lines (point-min) (point-max))))
+            (when (> lines mu4e~log-max-lines)
+              (goto-char (point-max))
+              (forward-line (- mu4e~log-max-lines lines))
+              (beginning-of-line)
+              (delete-region (point-min) (point)))))))))
 
 (defun mu4e-toggle-logging ()
   "Toggle between enabling/disabling debug-mode (in debug-mode,
@@ -1049,7 +1049,7 @@ mu4e logs some of its internal workings to a log-buffer. See
   (mu4e-log 'misc "logging disabled")
   (setq mu4e-debug (not mu4e-debug))
   (mu4e-message "debug logging has been %s"
-    (if mu4e-debug "enabled" "disabled"))
+                (if mu4e-debug "enabled" "disabled"))
   (mu4e-log 'misc "logging enabled"))
 
 (defun mu4e-show-log ()
@@ -1067,31 +1067,31 @@ STR is a string; N is the highest possible number in the list.
 This includes expanding e.g. 3-5 into 3,4,5.  If the letter
 \"a\" ('all')) is given, that is expanded to a list with numbers [1..n]."
   (let ((str-split (split-string str))
-	       beg end list)
+        beg end list)
     (dolist (elem str-split list)
       ;; special number "a" converts into all attachments 1-N.
       (when (equal elem "a")
-	      (setq elem (concat "1-" (int-to-string n))))
+        (setq elem (concat "1-" (int-to-string n))))
       (if (string-match "\\([0-9]+\\)-\\([0-9]+\\)" elem)
-	      ;; we have found a range A-B, which needs converting
-	      ;; into the numbers A, A+1, A+2, ... B.
-	      (progn
-	        (setq beg (string-to-number (match-string 1 elem))
-	          end (string-to-number (match-string 2 elem)))
-	        (while (<= beg end)
-            (cl-pushnew beg list :test 'equal)
-	          (setq beg (1+ beg))))
-	      ;; else just a number
+          ;; we have found a range A-B, which needs converting
+          ;; into the numbers A, A+1, A+2, ... B.
+          (progn
+            (setq beg (string-to-number (match-string 1 elem))
+                  end (string-to-number (match-string 2 elem)))
+            (while (<= beg end)
+              (cl-pushnew beg list :test 'equal)
+              (setq beg (1+ beg))))
+        ;; else just a number
         (cl-pushnew (string-to-number elem) list :test 'equal)))
     ;; Check that all numbers are valid.
     (mapc
-      (lambda (x)
-	        (cond
-	          ((> x n)
-	            (mu4e-warn "Attachment %d bigger than maximum (%d)" x n))
-	          ((< x 1)
-	            (mu4e-warn "Attachment number must be greater than 0 (%d)" x))))
-      list)))
+     (lambda (x)
+       (cond
+        ((> x n)
+         (mu4e-warn "Attachment %d bigger than maximum (%d)" x n))
+        ((< x 1)
+         (mu4e-warn "Attachment number must be greater than 0 (%d)" x))))
+     list)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1105,27 +1105,27 @@ MAXHEIGHT. Function tries to use imagemagick if available (ie.,
 emacs was compiled with inmagemagick support); otherwise MAXWIDTH
 and MAXHEIGHT are ignored."
   (let* ((have-im (and (fboundp 'imagemagick-types)
-		                (imagemagick-types))) ;; hmm, should check for specific type
-	        (identify (and have-im maxwidth
-		                  (executable-find mu4e-imagemagick-identify)))
-	        (props (and identify (shell-command-to-string
-				                         (format "%s -format '%%w' %s"
-				                           identify (shell-quote-argument imgpath)))))
-	        (width (and props (string-to-number props)))
-	        (img (if have-im
-		             (if (> (or width 0) (or maxwidth 0))
-		               (create-image imgpath 'imagemagick nil :width maxwidth)
-		               (create-image imgpath 'imagemagick))
-		             (create-image imgpath))))
+                       (imagemagick-types))) ;; hmm, should check for specific type
+         (identify (and have-im maxwidth
+                        (executable-find mu4e-imagemagick-identify)))
+         (props (and identify (shell-command-to-string
+                               (format "%s -format '%%w' %s"
+                                       identify (shell-quote-argument imgpath)))))
+         (width (and props (string-to-number props)))
+         (img (if have-im
+                  (if (> (or width 0) (or maxwidth 0))
+                      (create-image imgpath 'imagemagick nil :width maxwidth)
+                    (create-image imgpath 'imagemagick))
+                (create-image imgpath))))
     (when img
       (save-excursion
-	      (insert "\n")
-	      (let ((size (image-size img))) ;; inspired by gnus..
-	        (insert-char ?\n
-	          (max 0 (round (- (window-height) (or maxheight (cdr size)) 1) 2)))
-	        (insert-char ?\.
-	          (max 0 (round (- (window-width)  (or maxwidth (car size))) 2)))
-	        (insert-image img))))))
+        (insert "\n")
+        (let ((size (image-size img))) ;; inspired by gnus..
+          (insert-char ?\n
+                       (max 0 (round (- (window-height) (or maxheight (cdr size)) 1) 2)))
+          (insert-char ?\.
+                       (max 0 (round (- (window-width)  (or maxwidth (car size))) 2)))
+          (insert-image img))))))
 
 
 (defun mu4e-hide-other-mu4e-buffers ()
@@ -1137,12 +1137,12 @@ displaying it). Do _not_ bury the current buffer, though."
       ;; note: 'walk-windows' does not seem to work correctly when modifying
       ;; windows; therefore, the doloops here
       (dolist (frame (frame-list))
-	      (dolist (win (window-list frame nil))
-	        (with-current-buffer (window-buffer win)
-	          (unless (eq curbuf (current-buffer))
-	            (when (member major-mode '(mu4e-headers-mode mu4e-view-mode))
-		            (when (eq t (window-deletable-p win))
-		              (delete-window win))))))) t)))
+        (dolist (win (window-list frame nil))
+          (with-current-buffer (window-buffer win)
+            (unless (eq curbuf (current-buffer))
+              (when (member major-mode '(mu4e-headers-mode mu4e-view-mode))
+                (when (eq t (window-deletable-p win))
+                  (delete-window win))))))) t)))
 
 
 (defun mu4e-get-time-date (prompt)
@@ -1168,9 +1168,9 @@ displaying it). Do _not_ bury the current buffer, though."
     (setq buffer-read-only t)
     (define-key mu4e-org-mode-map (kbd "q")
       `(lambda ()
-	       (interactive)
-	       (bury-buffer)
-	       (switch-to-buffer ,curbuf)))))
+         (interactive)
+         (bury-buffer)
+         (switch-to-buffer ,curbuf)))))
 
 (defun mu4e-about ()
   "Show the mu4e 'about' page."
@@ -1197,13 +1197,13 @@ used in the view and compose modes."
     (goto-char (point-min))
     (when (search-forward-regexp "^\n" nil t) ;; search the first empty line
       (while (re-search-forward mu4e-cited-regexp nil t)
-	      (let* ((level (string-width (replace-regexp-in-string
-				                              "[^>]" "" (match-string 0))))
-	              (face  (unless (zerop level)
-			                   (intern-soft (format "mu4e-cited-%d-face" level)))))
-	        (when face
-	          (add-text-properties (line-beginning-position 1)
-				      (line-end-position 1) `(face ,face))))))))
+        (let* ((level (string-width (replace-regexp-in-string
+                                     "[^>]" "" (match-string 0))))
+               (face  (unless (zerop level)
+                        (intern-soft (format "mu4e-cited-%d-face" level)))))
+          (when face
+            (add-text-properties (line-beginning-position 1)
+                                 (line-end-position 1) `(face ,face))))))))
 
 (defun mu4e~fontify-signature ()
   "Give the message signatures a distinctive color. This is used in
@@ -1214,9 +1214,9 @@ the view and compose modes and will color each signature in digest messages adhe
       (goto-char (point-min))
       (while (re-search-forward "^-- *$" nil t)
         (let ((p (point))
-               (end (or
-                      (re-search-forward "\\(^-\\{30\\}.*$\\)" nil t) ;; 30 by RFC1153
-                      (point-max))))
+              (end (or
+                    (re-search-forward "\\(^-\\{30\\}.*$\\)" nil t) ;; 30 by RFC1153
+                    (point-max))))
           (add-text-properties p end '(face mu4e-footer-face)))))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1225,14 +1225,14 @@ the view and compose modes and will color each signature in digest messages adhe
 string will be shortened to fit if its length exceeds
 `mu4e-modeline-max-width'."
   (let* (;; Adjust the max-width to include the length of the " ..." string
-          (width (let ((w (- mu4e-modeline-max-width 4)))
-                   (if (> w 0) w 0)))
-          (str (let* ((l (length str))
-                       ;; If the input str is longer than the max-width, then will shorten
-                       (w (if (> l width) width l))
-                       ;; If the input str is longer than the max-width, then append " ..."
-                       (a (if (> l width) " ..." "")))
-                 (concat (substring str 0 w) a))))
+         (width (let ((w (- mu4e-modeline-max-width 4)))
+                  (if (> w 0) w 0)))
+         (str (let* ((l (length str))
+                     ;; If the input str is longer than the max-width, then will shorten
+                     (w (if (> l width) width l))
+                     ;; If the input str is longer than the max-width, then append " ..."
+                     (a (if (> l width) " ..." "")))
+                (concat (substring str 0 w) a))))
     ;; Escape the % character
     (replace-regexp-in-string "%" "%%" str t t)))
 
@@ -1243,9 +1243,9 @@ string will be shortened to fit if its length exceeds
   (let (buffers)
     (save-excursion
       (dolist (buffer (buffer-list t))
-	      (set-buffer buffer)
-	      (when (eq major-mode 'mu4e-compose-mode)
-	        (push (buffer-name buffer) buffers))))
+        (set-buffer buffer)
+        (when (eq major-mode 'mu4e-compose-mode)
+          (push (buffer-name buffer) buffers))))
     (nreverse buffers)))
 
 (provide 'mu4e-utils)

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -741,115 +741,115 @@ mu4e-compose-mode."
 
 ;; headers info
 (defconst mu4e-header-info
-  '( (:attachments
-      . ( :name "Attachments"
-          :shortname "Atts"
-          :help "Message attachments"
-          :require-full t
-          :sortable nil))
-     (:bcc
-      . ( :name "Bcc"
-                :shortname "Bcc"
-                :help "Blind Carbon-Copy recipients for the message"
-                :sortable t))
-     (:cc
-      . ( :name "Cc"
-                :shortname "Cc"
-                :help "Carbon-Copy recipients for the message"
-                :sortable t))
-     (:date
-      . ( :name "Date"
-                :shortname "Date"
-                :help "Date/time when the message was written"
-                :sortable t))
-     (:human-date .
-                  ( :name "Date"
-                          :shortname "Date"
-                          :help "Date/time when the message was written."
-                          :sortable :date))
-     (:flags .
-             ( :name "Flags"
-                     :shortname "Flgs"
-                     :help "Flags for the message"
-                     :sortable nil))
-     (:from .
-            ( :name "From"
-                    :shortname "From"
-                    :help "The sender of the message"
-                    :sortable t))
-     (:from-or-to .
-                  ( :name "From/To"
-                          :shortname "From/To"
-                          :help "Sender of the message if it's not me; otherwise the recipient"
-                          :sortable nil))
-     (:maildir .
-               ( :name "Maildir"
-                       :shortname "Maildir"
-                       :help "Maildir for this message"
-                       :sortable t))
-     (:list .
-            ( :name "List-Id"
-                    :shortname "List"
-                    :help "Mailing list id for this message"
-                    :sortable t))
-     (:mailing-list .
-                    ( :name "List"
-                            :shortname "List"
-                            :help "Mailing list friendly name for this message"
-                            :sortable :list))
-     (:message-id .
-                  ( :name "Message-Id"
-                          :shortname "MsgID"
-                          :help "Message-Id for this message"
-                          :sortable nil))
-     (:path .
-            ( :name "Path"
-                    :shortname "Path"
-                    :help "Full filesystem path to the message"
-                    :sortable t))
-     (:signature .
-                 ( :name "Signature"
-                         :shortname "Sgn"
-                         :help "Check for the cryptographic signature"
-                         :require-full t
-                         :sortable nil))
-     (:decryption .
-                  ( :name "Decryption"
-                          :shortname "Dec"
-                          :help "Check the cryptographic decryption status"
-                          :require-full t
-                          :sortable nil))
-     (:size .
-            ( :name "Size"
-                    :shortname "Size"
-                    :help "Size of the message"
-                    :sortable t))
-     (:subject .
-               ( :name "Subject"
-                       :shortname "Subject"
-                       :help "Subject of the message"
-                       :sortable t))
-     (:tags .
-            ( :name "Tags"
-                    :shortname "Tags"
-                    :help "Tags for the message"
-                    :sortable nil))
-     (:thread-subject .
-                      ( :name "Subject"
-                              :shortname "Subject"
-                              :help "Subject of the thread"
-                              :sortable :subject))
-     (:to .
-          ( :name "To"
-                  :shortname "To"
-                  :help "Recipient of the message"
-                  :sortable t))
-     (:user-agent .
-                  ( :name "User-Agent"
-                          :shortname "UA"
-                          :help "Program used for writing this message"
-                          :require-full t
-                          :sortable t)))
+  '((:attachments
+     . (:name "Attachments"
+        :shortname "Atts"
+        :help "Message attachments"
+        :require-full t
+        :sortable nil))
+    (:bcc
+     . (:name "Bcc"
+        :shortname "Bcc"
+        :help "Blind Carbon-Copy recipients for the message"
+        :sortable t))
+    (:cc
+     . (:name "Cc"
+        :shortname "Cc"
+        :help "Carbon-Copy recipients for the message"
+        :sortable t))
+    (:date
+     . (:name "Date"
+        :shortname "Date"
+        :help "Date/time when the message was written"
+        :sortable t))
+    (:human-date
+     . (:name "Date"
+        :shortname "Date"
+        :help "Date/time when the message was written."
+        :sortable :date))
+    (:flags
+     . (:name "Flags"
+        :shortname "Flgs"
+        :help "Flags for the message"
+        :sortable nil))
+    (:from
+     . (:name "From"
+        :shortname "From"
+        :help "The sender of the message"
+        :sortable t))
+    (:from-or-to
+     . (:name "From/To"
+        :shortname "From/To"
+        :help "Sender of the message if it's not me; otherwise the recipient"
+        :sortable nil))
+    (:maildir
+     . (:name "Maildir"
+        :shortname "Maildir"
+        :help "Maildir for this message"
+        :sortable t))
+    (:list
+     . (:name "List-Id"
+        :shortname "List"
+        :help "Mailing list id for this message"
+        :sortable t))
+    (:mailing-list
+     . (:name "List"
+        :shortname "List"
+        :help "Mailing list friendly name for this message"
+        :sortable :list))
+    (:message-id
+     . (:name "Message-Id"
+        :shortname "MsgID"
+        :help "Message-Id for this message"
+        :sortable nil))
+    (:path
+     . (:name "Path"
+        :shortname "Path"
+        :help "Full filesystem path to the message"
+        :sortable t))
+    (:signature
+     . (:name "Signature"
+        :shortname "Sgn"
+        :help "Check for the cryptographic signature"
+        :require-full t
+        :sortable nil))
+    (:decryption
+     . (:name "Decryption"
+        :shortname "Dec"
+        :help "Check the cryptographic decryption status"
+        :require-full t
+        :sortable nil))
+    (:size
+     . (:name "Size"
+        :shortname "Size"
+        :help "Size of the message"
+        :sortable t))
+    (:subject
+     . (:name "Subject"
+        :shortname "Subject"
+        :help "Subject of the message"
+        :sortable t))
+    (:tags
+     . (:name "Tags"
+        :shortname "Tags"
+        :help "Tags for the message"
+        :sortable nil))
+    (:thread-subject
+     . (:name "Subject"
+        :shortname "Subject"
+        :help "Subject of the thread"
+        :sortable :subject))
+    (:to
+     . (:name "To"
+        :shortname "To"
+        :help "Recipient of the message"
+        :sortable t))
+    (:user-agent
+     . (:name "User-Agent"
+        :shortname "UA"
+        :help "Program used for writing this message"
+        :require-full t
+        :sortable t)))
   "An alist of all possible header fields and information about them.
 This is used in the user-interface (the column headers in the header list, and
 the fields the message view).

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -40,7 +40,7 @@
 defaults, based on the XDG Base Directory Specification."
   :group 'mu4e
   :type '(choice (const :tag "Default location" nil)
-     (directory :tag "Specify location"))
+                 (directory :tag "Specify location"))
   :safe 'stringp)
 
 (defcustom mu4e-mu-binary (executable-find "mu")
@@ -52,7 +52,7 @@ path."
   :safe 'stringp)
 
 (make-obsolete-variable 'mu4e-maildir
-  "determined by server; see `mu4e-root-maildir'." "1.3.8")
+                        "determined by server; see `mu4e-root-maildir'." "1.3.8")
 
 (defcustom mu4e-org-support t
   "Support org-mode links."
@@ -103,7 +103,7 @@ corresponding message file in the filesystem.
 
 Having this option as t ensures that no non-existing messages are
 shown but can also be quite slow with large message stores."
-:type 'boolean :group 'mu4e :safe 'booleanp)
+  :type 'boolean :group 'mu4e :safe 'booleanp)
 
 (defcustom mu4e-index-lazy-check nil
   "Whether to only use a 'lazy check' during reindexing.
@@ -119,7 +119,7 @@ faster." :type 'boolean :group 'mu4e :safe 'booleanp)
 If nil, don't update automatically. Note, changes in
 `mu4e-update-interval' only take effect after restarting mu4e."
   :type '(choice (const :tag "No automatic update" nil)
-     (integer :tag "Seconds"))
+                 (integer :tag "Seconds"))
   :group 'mu4e
   :safe 'integerp)
 
@@ -156,11 +156,11 @@ the attachment dir. See Info node `(mu4e) Attachments' for details."
 
 ;; don't use the older vars anymore
 (make-obsolete-variable 'mu4e-user-mail-address-regexp
-  'mu4e-user-mail-address-list "0.9.9.x")
+                        'mu4e-user-mail-address-list "0.9.9.x")
 (make-obsolete-variable 'mu4e-my-email-addresses
-  'mu4e-user-mail-address-list "0.9.9.x")
+                        'mu4e-user-mail-address-list "0.9.9.x")
 (make-obsolete-variable 'mu4e-user-mail-address-list
-  "determined by server; see `mu4e-personal-addresses'." "1.3.8")
+                        "determined by server; see `mu4e-personal-addresses'." "1.3.8")
 
 (defcustom mu4e-use-fancy-chars nil
   "When set, allow fancy (Unicode) characters for marks/threads.
@@ -200,18 +200,18 @@ are plists" "1.3.7")
 
 (defcustom mu4e-bookmarks
   '(( :name  "Unread messages"
-      :query "flag:unread AND NOT flag:trashed"
-      :key ?u)
+             :query "flag:unread AND NOT flag:trashed"
+             :key ?u)
     ( :name "Today's messages"
-      :query "date:today..now"
-      :key ?t)
+            :query "date:today..now"
+            :key ?t)
     ( :name "Last 7 days"
-      :query "date:7d..now"
-      :show-unread t
-      :key ?w)
+            :query "date:7d..now"
+            :show-unread t
+            :key ?w)
     ( :name "Messages with images"
-      :query "mime:image/*"
-      :key ?p))
+            :query "mime:image/*"
+            :key ?p))
   "List of pre-defined queries that are shown on the main screen.
 
 Each of the list elements is a plist with at least:
@@ -247,9 +247,9 @@ A symbol which is either:
 Also see `mu4e-headers-visible-lines'
 and `mu4e-headers-visible-columns'."
   :type '(choice (const :tag "Split horizontally" horizontal)
-     (const :tag "Split vertically" vertical)
-     (const :tag "Single window" single-window)
-     (const :tag "Don't split" nil))
+                 (const :tag "Split vertically" vertical)
+                 (const :tag "Single window" single-window)
+                 (const :tag "Don't split" nil))
   :group 'mu4e-headers)
 
 (defcustom mu4e-view-max-specpdl-size 4096
@@ -263,7 +263,7 @@ and `mu4e-headers-visible-columns'."
   :group 'mu4e-view)
 
 (make-obsolete-variable 'mu4e-show-images
-  'mu4e-view-show-images "0.9.9.x")
+                        'mu4e-view-show-images "0.9.9.x")
 
 (defcustom mu4e-confirm-quit t
   "Whether to confirm to quit mu4e."
@@ -306,12 +306,12 @@ contexts match, we have the following choices:
 
 Also see `mu4e-compose-context-policy'."
   :type '(choice
-     (const :tag "Always ask what context to use, even if one matches"
-       always-ask)
-     (const :tag "Ask if none of the contexts match" ask)
-     (const :tag "Ask when there's no context yet" ask-if-none)
-     (const :tag "Pick the first context if none match" pick-first)
-     (const :tag "Don't change the context when none match" nil))
+          (const :tag "Always ask what context to use, even if one matches"
+                 always-ask)
+          (const :tag "Ask if none of the contexts match" ask)
+          (const :tag "Ask when there's no context yet" ask-if-none)
+          (const :tag "Pick the first context if none match" pick-first)
+          (const :tag "Don't change the context when none match" nil))
   :group 'mu4e)
 
 ;; crypto
@@ -331,8 +331,8 @@ The setting is a symbol:
  * `ask': ask before decrypting anything
  * nil:   don't try to decrypt anything."
   :type '(choice (const :tag "Try to decrypt automatically" t)
-     (const :tag "Ask before decrypting anything" ask)
-     (const :tag "Don't try to decrypt anything" nil))
+                 (const :tag "Ask before decrypting anything" ask)
+                 (const :tag "Don't try to decrypt anything" nil))
   :group 'mu4e-crypto)
 
 ;; completion; we put them here rather than in mu4e-compose, as mu4e-utils needs
@@ -376,14 +376,14 @@ time-based restriction."
   "Return the name and the mail-address of a CONTACT.
 It is used as the identity function for converting contacts to
 their canonical counterpart; useful as an example."
-    (let ((name (plist-get contact :name))
-           (mail (plist-get contact :mail)))
-      (list :name name :mail mail)))
+  (let ((name (plist-get contact :name))
+        (mail (plist-get contact :mail)))
+    (list :name name :mail mail)))
 
 (make-obsolete-variable 'mu4e-contacts-rewrite-function
-  "mu4e-contact-process-function (see docstring)" "mu4e 1.3.2")
+                        "mu4e-contact-process-function (see docstring)" "mu4e 1.3.2")
 (make-obsolete-variable 'mu4e-compose-complete-ignore-address-regexp
-  "mu4e-contact-process-function (see docstring)" "mu4e 1.3.2")
+                        "mu4e-contact-process-function (see docstring)" "mu4e 1.3.2")
 
 (defcustom mu4e-contact-process-function nil
   "Function for processing contact information for use in auto-completion.
@@ -406,10 +406,10 @@ an RFC-2822-compatible e-mail address."
 This can be a regexp matching the address, a list of regexps or a
 predicate function. A value of nil keeps all the addresses."
   :type '(choice
-           (const nil)
-           function
-           string
-           (repeat string))
+          (const nil)
+          function
+          string
+          (repeat string))
   :group 'mu4e-compose)
 
 (defcustom mu4e-compose-reply-recipients 'ask
@@ -417,8 +417,8 @@ predicate function. A value of nil keeps all the addresses."
 May be 'ask, 'all, 'sender. Note that that only applies to
 non-mailing-list message; for those, mu4e always asks."
   :type '(choice ask
-           all
-	         sender)
+                 all
+                 sender)
   :group 'mu4e-compose)
 
 (defcustom mu4e-compose-reply-to-address nil
@@ -434,8 +434,8 @@ Useful when this is not equal to the From: address."
 
 ;; backward compatibility
 (make-obsolete-variable 'mu4e-reply-to-address
-'mu4e-compose-reply-to-address
-  "v0.9.9")
+                        'mu4e-compose-reply-to-address
+                        "v0.9.9")
 
 (defcustom mu4e-compose-keep-self-cc nil
   "When non-nil. keep your e-mail address in Cc: when replying."
@@ -477,8 +477,8 @@ parameter refers to the original message being replied to / being
 forwarded / re-edited and is nil otherwise. `mu4e-drafts-folder'
 is only evaluated once."
   :type '(choice
-     (string :tag "Folder name")
-     (function :tag "Function return folder name"))
+          (string :tag "Folder name")
+          (function :tag "Function return folder name"))
   :group 'mu4e-folders)
 
 (defcustom mu4e-refile-folder "/archive"
@@ -488,8 +488,8 @@ function that takes a message (a msg plist, see
 `mu4e-message-field'), and returns a folder. Note that the
 message parameter refers to the message-at-point."
   :type '(choice
-     (string :tag "Folder name")
-     (function :tag "Function return folder name"))
+          (string :tag "Folder name")
+          (function :tag "Function return folder name"))
   :group 'mu4e-folders)
 
 (defcustom mu4e-sent-folder "/sent"
@@ -500,8 +500,8 @@ function that takes a message (a msg plist, see
 message parameter refers to the original message being replied to
 / being forwarded / re-edited, and is nil otherwise."
   :type '(choice
-     (string :tag "Folder name")
-     (function :tag "Function return folder name"))
+          (string :tag "Folder name")
+          (function :tag "Function return folder name"))
   :group 'mu4e-folders)
 
 (defcustom mu4e-trash-folder "/trash"
@@ -516,8 +516,8 @@ message-at-point. When using it when composing a message (see
 message being replied to / being forwarded / re-edited, and is
 nil otherwise."
   :type '(choice
-     (string :tag "Folder name")
-     (function :tag "Function return folder name"))
+          (string :tag "Folder name")
+          (function :tag "Function return folder name"))
   :group 'mu4e-folders)
 
 (defcustom mu4e-maildir-shortcuts nil
@@ -741,115 +741,115 @@ mu4e-compose-mode."
 
 ;; headers info
 (defconst mu4e-header-info
-  '( (:attachments .
-       ( :name "Attachments"
-   :shortname "Atts"
-   :help "Message attachments"
-   :require-full t
-   :sortable nil))
-     (:bcc .
-       ( :name "Bcc"
-   :shortname "Bcc"
-   :help "Blind Carbon-Copy recipients for the message"
-   :sortable t))
-     (:cc .
-       ( :name "Cc"
-   :shortname "Cc"
-   :help "Carbon-Copy recipients for the message"
-   :sortable t))
-     (:date .
-       ( :name "Date"
-   :shortname "Date"
-   :help "Date/time when the message was written"
-   :sortable t))
+  '( (:attachments
+      . ( :name "Attachments"
+          :shortname "Atts"
+          :help "Message attachments"
+          :require-full t
+          :sortable nil))
+     (:bcc
+      . ( :name "Bcc"
+                :shortname "Bcc"
+                :help "Blind Carbon-Copy recipients for the message"
+                :sortable t))
+     (:cc
+      . ( :name "Cc"
+                :shortname "Cc"
+                :help "Carbon-Copy recipients for the message"
+                :sortable t))
+     (:date
+      . ( :name "Date"
+                :shortname "Date"
+                :help "Date/time when the message was written"
+                :sortable t))
      (:human-date .
-       ( :name "Date"
-   :shortname "Date"
-   :help "Date/time when the message was written."
-   :sortable :date))
+                  ( :name "Date"
+                          :shortname "Date"
+                          :help "Date/time when the message was written."
+                          :sortable :date))
      (:flags .
-       ( :name "Flags"
-   :shortname "Flgs"
-   :help "Flags for the message"
-   :sortable nil))
+             ( :name "Flags"
+                     :shortname "Flgs"
+                     :help "Flags for the message"
+                     :sortable nil))
      (:from .
-       ( :name "From"
-   :shortname "From"
-   :help "The sender of the message"
-   :sortable t))
+            ( :name "From"
+                    :shortname "From"
+                    :help "The sender of the message"
+                    :sortable t))
      (:from-or-to .
-       ( :name "From/To"
-   :shortname "From/To"
-   :help "Sender of the message if it's not me; otherwise the recipient"
-   :sortable nil))
+                  ( :name "From/To"
+                          :shortname "From/To"
+                          :help "Sender of the message if it's not me; otherwise the recipient"
+                          :sortable nil))
      (:maildir .
-       ( :name "Maildir"
-   :shortname "Maildir"
-   :help "Maildir for this message"
-   :sortable t))
+               ( :name "Maildir"
+                       :shortname "Maildir"
+                       :help "Maildir for this message"
+                       :sortable t))
      (:list .
-       ( :name "List-Id"
-   :shortname "List"
-   :help "Mailing list id for this message"
-   :sortable t))
+            ( :name "List-Id"
+                    :shortname "List"
+                    :help "Mailing list id for this message"
+                    :sortable t))
      (:mailing-list .
-       ( :name "List"
-   :shortname "List"
-   :help "Mailing list friendly name for this message"
-   :sortable :list))
+                    ( :name "List"
+                            :shortname "List"
+                            :help "Mailing list friendly name for this message"
+                            :sortable :list))
      (:message-id .
-       ( :name "Message-Id"
-   :shortname "MsgID"
-   :help "Message-Id for this message"
-   :sortable nil))
+                  ( :name "Message-Id"
+                          :shortname "MsgID"
+                          :help "Message-Id for this message"
+                          :sortable nil))
      (:path .
-       ( :name "Path"
-   :shortname "Path"
-   :help "Full filesystem path to the message"
-   :sortable t))
+            ( :name "Path"
+                    :shortname "Path"
+                    :help "Full filesystem path to the message"
+                    :sortable t))
      (:signature .
-       ( :name "Signature"
-   :shortname "Sgn"
-   :help "Check for the cryptographic signature"
-   :require-full t
-   :sortable nil))
+                 ( :name "Signature"
+                         :shortname "Sgn"
+                         :help "Check for the cryptographic signature"
+                         :require-full t
+                         :sortable nil))
      (:decryption .
-       ( :name "Decryption"
-   :shortname "Dec"
-   :help "Check the cryptographic decryption status"
-   :require-full t
-   :sortable nil))
+                  ( :name "Decryption"
+                          :shortname "Dec"
+                          :help "Check the cryptographic decryption status"
+                          :require-full t
+                          :sortable nil))
      (:size .
-       ( :name "Size"
-   :shortname "Size"
-   :help "Size of the message"
-   :sortable t))
+            ( :name "Size"
+                    :shortname "Size"
+                    :help "Size of the message"
+                    :sortable t))
      (:subject .
-       ( :name "Subject"
-   :shortname "Subject"
-   :help "Subject of the message"
-   :sortable t))
+               ( :name "Subject"
+                       :shortname "Subject"
+                       :help "Subject of the message"
+                       :sortable t))
      (:tags .
-       ( :name "Tags"
-   :shortname "Tags"
-   :help "Tags for the message"
-   :sortable nil))
+            ( :name "Tags"
+                    :shortname "Tags"
+                    :help "Tags for the message"
+                    :sortable nil))
      (:thread-subject .
-       ( :name "Subject"
-   :shortname "Subject"
-   :help "Subject of the thread"
-   :sortable :subject))
+                      ( :name "Subject"
+                              :shortname "Subject"
+                              :help "Subject of the thread"
+                              :sortable :subject))
      (:to .
-       ( :name "To"
-   :shortname "To"
-   :help "Recipient of the message"
-   :sortable t))
+          ( :name "To"
+                  :shortname "To"
+                  :help "Recipient of the message"
+                  :sortable t))
      (:user-agent .
-       ( :name "User-Agent"
-   :shortname "UA"
-   :help "Program used for writing this message"
-   :require-full t
-   :sortable t)))
+                  ( :name "User-Agent"
+                          :shortname "UA"
+                          :help "Program used for writing this message"
+                          :require-full t
+                          :sortable t)))
   "An alist of all possible header fields and information about them.
 This is used in the user-interface (the column headers in the header list, and
 the fields the message view).
@@ -873,15 +873,15 @@ Note, `:sortable' is not supported for custom header fields.")
 
 (defvar mu4e-header-info-custom
   '( (:recipnum .
-       ( :name "Number of recipients"
-   :shortname "Recip#"
-   :help "Number of recipients for this message"
-   :function
-   (lambda (msg)
-     (format "%d"
-       (+ (length (mu4e-message-field msg :to))
-         (length (mu4e-message-field msg :cc))))))))
-"A list of custom (user-defined) headers.
+                ( :name "Number of recipients"
+                        :shortname "Recip#"
+                        :help "Number of recipients for this message"
+                        :function
+                        (lambda (msg)
+                          (format "%d"
+                                  (+ (length (mu4e-message-field msg :to))
+                                     (length (mu4e-message-field msg :cc))))))))
+  "A list of custom (user-defined) headers.
 The format is similar
 to `mu4e-header-info', but adds a :function property, which
 should point to a function that takes a message p-list as
@@ -897,7 +897,7 @@ argument, and returns a string. See the default value of
 (defconst mu4e~headers-buffer-name "*mu4e-headers*"
   "Name of the buffer for message headers.")
 
-; view
+;; view
 (defconst mu4e~view-buffer-name "*mu4e-view*"
   "Name for the message view buffer.")
 
@@ -919,7 +919,7 @@ mu4e-compose.")
 (defun mu4e-root-maildir()
   "Get the root maildir."
   (let ((root-maildir (and mu4e~server-props
-                        (plist-get mu4e~server-props :root-maildir))))
+                           (plist-get mu4e~server-props :root-maildir))))
     (unless root-maildir
       (mu4e-error "root maildir unknown; did you start mu4e?"))
     root-maildir))
@@ -927,7 +927,7 @@ mu4e-compose.")
 (defun mu4e-database-path()
   "Get the mu4e database path"
   (let ((path (and mu4e~server-props
-                        (plist-get mu4e~server-props :database-path))))
+                   (plist-get mu4e~server-props :database-path))))
     (unless path
       (mu4e-error "database-path unknown; did you start mu4e?"))
     path))
@@ -936,7 +936,7 @@ mu4e-compose.")
   "Get the user's personal addresses, if any. If none are set on the server-side,
 fall back to the obsolete `mu4e-user-mail-address-list'."
   (let ((addrs (and mu4e~server-props
-                (plist-get mu4e~server-props :personal-addresses))))
+                    (plist-get mu4e~server-props :personal-addresses))))
     (if addrs addrs mu4e-user-mail-address-list)))
 
 (defun mu4e-server-version()

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -1572,7 +1572,6 @@ URLs. The urls are fetched to `mu4e-attachment-dir'."
 (defun mu4e~view-handle-urls (prompt multi urlfunc)
   "If MULTI is nil, apply URLFUNC to a single uri, otherwise, apply
 it to a range of uris. PROMPT is the query to present to the user."
-  (interactive "P")
   (if multi
       (mu4e~view-handle-multi-urls prompt urlfunc)
     (mu4e~view-handle-single-url prompt urlfunc)))
@@ -1580,7 +1579,6 @@ it to a range of uris. PROMPT is the query to present to the user."
 (defun mu4e~view-handle-single-url (prompt urlfunc &optional num)
   "Apply URLFUNC to url NUM in the current message, prompting the
 user with PROMPT."
-  (interactive)
   (let* ((num (or num (mu4e~view-get-urls-num prompt)))
          (url (gethash num mu4e~view-link-map)))
     (unless url (mu4e-warn "Invalid number for URL"))
@@ -1596,7 +1594,6 @@ of urls. You can type multiple values separated by space, e.g.  1
 
 Furthermore, there is a shortcut \"a\" which means all urls, but as
 this is the default, you may not need it."
-  (interactive)
   (let* ((linkstr (mu4e~view-get-urls-num
                    "URL number range (or 'a' for 'all')" t))
          (count (hash-table-count mu4e~view-link-map))

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -61,7 +61,7 @@
 
 (defcustom mu4e-view-fields
   '(:from :to  :cc :subject :flags :date :maildir :mailing-list :tags
-	  :attachments :signature :decryption)
+          :attachments :signature :decryption)
   "Header fields to display in the message view buffer.
 For the complete list of available headers, see `mu4e-header-info'."
   :type (list 'symbol)
@@ -231,85 +231,85 @@ message."
   "Show some custom header field, or raise an error if it is not
 found."
   (let* ((item (or (assoc field mu4e-header-info-custom)
-		 (mu4e-error "field %S not found" field)))
-	  (func (or (plist-get (cdr-safe item) :function)
-		  (mu4e-error "no :function defined for field %S %S"
-		    field (cdr item)))))
+                   (mu4e-error "field %S not found" field)))
+         (func (or (plist-get (cdr-safe item) :function)
+                   (mu4e-error "no :function defined for field %S %S"
+                               field (cdr item)))))
     (funcall func msg)))
 
 (defun mu4e-view-message-text (msg)
   "Return the message to display (as a string), based on the MSG plist."
   (concat
-    (mapconcat
-      (lambda (field)
-	(let ((fieldval (mu4e-message-field msg field)))
-	  (cl-case field
-	    (:subject    (mu4e~view-construct-header field fieldval))
-	    (:path       (mu4e~view-construct-header field fieldval))
-	    (:maildir    (mu4e~view-construct-header field fieldval))
-	    (:user-agent (mu4e~view-construct-header field fieldval))
-	    ((:flags :tags) (mu4e~view-construct-flags-tags-header
-			      field fieldval))
+   (mapconcat
+    (lambda (field)
+      (let ((fieldval (mu4e-message-field msg field)))
+        (cl-case field
+          (:subject    (mu4e~view-construct-header field fieldval))
+          (:path       (mu4e~view-construct-header field fieldval))
+          (:maildir    (mu4e~view-construct-header field fieldval))
+          (:user-agent (mu4e~view-construct-header field fieldval))
+          ((:flags :tags) (mu4e~view-construct-flags-tags-header
+                           field fieldval))
 
-	    ;; contact fields
-	    (:to       (mu4e~view-construct-contacts-header msg field))
-	    (:from     (mu4e~view-construct-contacts-header msg field))
-	    (:cc       (mu4e~view-construct-contacts-header msg field))
-	    (:bcc      (mu4e~view-construct-contacts-header msg field))
+          ;; contact fields
+          (:to       (mu4e~view-construct-contacts-header msg field))
+          (:from     (mu4e~view-construct-contacts-header msg field))
+          (:cc       (mu4e~view-construct-contacts-header msg field))
+          (:bcc      (mu4e~view-construct-contacts-header msg field))
 
-	    ;; if we (`user-mail-address' are the From, show To, otherwise,
-	    ;; show From
-	    (:from-or-to
-	      (let* ((from (mu4e-message-field msg :from))
-		      (from (and from (cdar from))))
-		(if (mu4e-user-mail-address-p from)
-		  (mu4e~view-construct-contacts-header msg :to)
-		  (mu4e~view-construct-contacts-header msg :from))))
-	    ;; date
-	    (:date
-	      (let ((datestr
-		      (when fieldval (format-time-string mu4e-view-date-format
-				       fieldval))))
-		(if datestr (mu4e~view-construct-header field datestr) "")))
-	    ;; size
-	    (:size
-	      (mu4e~view-construct-header field (mu4e-display-size fieldval)))
-	    (:mailing-list
-	      (mu4e~view-construct-header field fieldval))
-	    (:message-id
-	      (mu4e~view-construct-header field fieldval))
-	    ;; attachments
-	    (:attachments (mu4e~view-construct-attachments-header msg))
-	    ;; pgp-signatures
-	    (:signature   (mu4e~view-construct-signature-header msg))
-	    ;; pgp-decryption
-	    (:decryption  (mu4e~view-construct-decryption-header msg))
-	    (t (mu4e~view-construct-header field
-		 (mu4e~view-custom-field msg field))))))
-      mu4e-view-fields "")
-    "\n"
-    (let* ((prefer-html
-	     (cond
-	       ((eq mu4e~view-html-text 'html) t)
-	       ((eq mu4e~view-html-text 'text) nil)
-	       (t mu4e-view-prefer-html)))
-	    (body (mu4e-message-body-text msg prefer-html)))
-      (setq mu4e~view-html-text nil)
-      (when (fboundp 'add-face-text-property)
-	(add-face-text-property 0 (length body) 'mu4e-view-body-face t body))
-      body)))
+          ;; if we (`user-mail-address' are the From, show To, otherwise,
+          ;; show From
+          (:from-or-to
+           (let* ((from (mu4e-message-field msg :from))
+                  (from (and from (cdar from))))
+             (if (mu4e-user-mail-address-p from)
+                 (mu4e~view-construct-contacts-header msg :to)
+               (mu4e~view-construct-contacts-header msg :from))))
+          ;; date
+          (:date
+           (let ((datestr
+                  (when fieldval (format-time-string mu4e-view-date-format
+                                                     fieldval))))
+             (if datestr (mu4e~view-construct-header field datestr) "")))
+          ;; size
+          (:size
+           (mu4e~view-construct-header field (mu4e-display-size fieldval)))
+          (:mailing-list
+           (mu4e~view-construct-header field fieldval))
+          (:message-id
+           (mu4e~view-construct-header field fieldval))
+          ;; attachments
+          (:attachments (mu4e~view-construct-attachments-header msg))
+          ;; pgp-signatures
+          (:signature   (mu4e~view-construct-signature-header msg))
+          ;; pgp-decryption
+          (:decryption  (mu4e~view-construct-decryption-header msg))
+          (t (mu4e~view-construct-header field
+                                         (mu4e~view-custom-field msg field))))))
+    mu4e-view-fields "")
+   "\n"
+   (let* ((prefer-html
+           (cond
+            ((eq mu4e~view-html-text 'html) t)
+            ((eq mu4e~view-html-text 'text) nil)
+            (t mu4e-view-prefer-html)))
+          (body (mu4e-message-body-text msg prefer-html)))
+     (setq mu4e~view-html-text nil)
+     (when (fboundp 'add-face-text-property)
+       (add-face-text-property 0 (length body) 'mu4e-view-body-face t body))
+     body)))
 
 (defun mu4e~view-embedded-winbuf ()
   "Get a buffer (shown in a window) for the embedded message."
   (let* ((buf (get-buffer-create mu4e~view-embedded-buffer-name))
-	  (win (or (get-buffer-window buf) (split-window-vertically))))
+         (win (or (get-buffer-window buf) (split-window-vertically))))
     (select-window win)
     (switch-to-buffer buf)))
 
 (defun mu4e~delete-all-overlays ()
   "`delete-all-overlays' with compatibility fallback."
   (if (functionp 'delete-all-overlays)
-    (delete-all-overlays)
+      (delete-all-overlays)
     (remove-overlays)))
 
 (defun mu4e-view (msg)
@@ -335,46 +335,46 @@ article-mode."
   ;; the reply handler to mu4e~proc-move)
   (unless (mu4e~view-mark-as-read-maybe msg)
     (if mu4e-view-use-gnus
-      (mu4e~view-gnus msg)
+        (mu4e~view-gnus msg)
       (mu4e~view-internal msg))))
 
 (defun mu4e~view-internal (msg)
   "Display MSG using mu4e's internal view mode."
   (let* ((embedded ;; is it as an embedded msg (ie. message/rfc822 att)?
-	   (when (gethash (mu4e-message-field msg :path)
-		   mu4e~path-parent-docid-map) t))
-	  (buf (if embedded
-		 (mu4e~view-embedded-winbuf)
-		 (get-buffer-create mu4e~view-buffer-name))))
+          (when (gethash (mu4e-message-field msg :path)
+                         mu4e~path-parent-docid-map) t))
+         (buf (if embedded
+                  (mu4e~view-embedded-winbuf)
+                (get-buffer-create mu4e~view-buffer-name))))
     (with-current-buffer buf
       (let ((inhibit-read-only t))
         (when (or embedded (not (mu4e~view-mark-as-read-maybe msg)))
-	  (erase-buffer)
-	  (mu4e~delete-all-overlays)
+          (erase-buffer)
+          (mu4e~delete-all-overlays)
           (insert (mu4e-view-message-text msg))
-	  (goto-char (point-min))
-	  (mu4e~fontify-cited)
-	  (mu4e~fontify-signature)
-	  (mu4e~view-make-urls-clickable)
-	  (mu4e~view-show-images-maybe msg)
-	  (mu4e-view-mode)
-	  (when embedded (local-set-key "q" 'kill-buffer-and-window))
-	  (when (not embedded) (setq mu4e~view-message msg))))
+          (goto-char (point-min))
+          (mu4e~fontify-cited)
+          (mu4e~fontify-signature)
+          (mu4e~view-make-urls-clickable)
+          (mu4e~view-show-images-maybe msg)
+          (mu4e-view-mode)
+          (when embedded (local-set-key "q" 'kill-buffer-and-window))
+          (when (not embedded) (setq mu4e~view-message msg))))
       (switch-to-buffer buf))))
 
 (defun mu4e~view-gnus (msg)
   "View MSG using Gnu's article mode. Experimental."
   (require 'gnus-art)
   (let ((marked-read (mu4e~view-mark-as-read-maybe msg))
-	 (path (mu4e-message-field msg :path))
-	 (inhibit-read-only t)
-	 ;; support signature verification
-	 (mm-verify-option 'known)
-	 (mm-decrypt-option 'known)
-	 (gnus-article-emulate-mime t)
-	 (gnus-buttonized-mime-types (append (list "multipart/signed"
-					       "multipart/encrypted")
-				       gnus-buttonized-mime-types)))
+        (path (mu4e-message-field msg :path))
+        (inhibit-read-only t)
+        ;; support signature verification
+        (mm-verify-option 'known)
+        (mm-decrypt-option 'known)
+        (gnus-article-emulate-mime t)
+        (gnus-buttonized-mime-types (append (list "multipart/signed"
+                                                  "multipart/encrypted")
+                                            gnus-buttonized-mime-types)))
     (switch-to-buffer (get-buffer-create mu4e~view-buffer-name))
     (erase-buffer)
     (unless marked-read
@@ -387,12 +387,12 @@ article-mode."
                           'prefer-utf-8)))
           (recode-region (point-min) (point-max) coding 'no-conversion)))
       (setq
-	      gnus-summary-buffer (get-buffer-create " *appease-gnus*")
-	      gnus-original-article-buffer (current-buffer))
+       gnus-summary-buffer (get-buffer-create " *appease-gnus*")
+       gnus-original-article-buffer (current-buffer))
       (run-hooks 'gnus-article-decode-hook)
       (let ((mu4e~view-rendering t) ; customize gnus in mu4e
-             (max-specpdl-size mu4e-view-max-specpdl-size)
-             (gnus-icalendar-additional-identities (mu4e-personal-addresses)))
+            (max-specpdl-size mu4e-view-max-specpdl-size)
+            (gnus-icalendar-additional-identities (mu4e-personal-addresses)))
         (gnus-article-prepare-display))
       (mu4e-view-mode)
       (setq mu4e~view-message msg)
@@ -405,14 +405,14 @@ article-mode."
 The action is chosen based on the `last-command-event'.
 Meant to be evoked from interactive commands."
   (if (and (eventp last-command-event)
-	   (mouse-event-p last-command-event))
+           (mouse-event-p last-command-event))
       (let ((posn (event-end last-command-event)))
-	(when (numberp (posn-point posn))
-	  (get-text-property
-	   (posn-point posn)
-	   prop
-	   (window-buffer (posn-window posn)))
-	  ))
+        (when (numberp (posn-point posn))
+          (get-text-property
+           (posn-point posn)
+           prop
+           (window-buffer (posn-window posn)))
+          ))
     (get-text-property (point) prop)))
 
 (defun mu4e~view-construct-header (field val &optional dont-propertize-val)
@@ -420,56 +420,56 @@ Meant to be evoked from interactive commands."
 VAL if VAL is non-nil. If DONT-PROPERTIZE-VAL is non-nil, do not
 add text-properties to VAL."
   (let* ((info (cdr (assoc field
-		      (append mu4e-header-info mu4e-header-info-custom))))
-	  (key (plist-get info :name))
-	  (val (if val (propertize val 'field 'mu4e-header-field-value
-				       'front-sticky '(field))))
-	  (help (plist-get info :help)))
+                           (append mu4e-header-info mu4e-header-info-custom))))
+         (key (plist-get info :name))
+         (val (if val (propertize val 'field 'mu4e-header-field-value
+                                  'front-sticky '(field))))
+         (help (plist-get info :help)))
     (if (and val (> (length val) 0))
-    (with-temp-buffer
-      (insert (propertize (concat key ":")
-		'field 'mu4e-header-field-key
-		'front-sticky '(field)
-		'keymap mu4e-view-header-field-keymap
-		'face 'mu4e-header-key-face
-		'help-echo help) " "
-	(if dont-propertize-val
-	  val
-	  (propertize val 'face 'mu4e-header-value-face)) "\n")
-      (when mu4e-view-fill-headers
-	;; temporarily set the fill column <margin> positions to the right, so
-	;; we can indent the following lines correctly
-	(let* ((margin 1)
-		(fill-column (max (- fill-column margin) 0)))
-	  (fill-region (point-min) (point-max))
-	  (goto-char (point-min))
-	  (while (and (zerop (forward-line 1)) (not (looking-at "^$")))
-	    (indent-to-column margin))))
-      (buffer-string))
-    "")))
+        (with-temp-buffer
+          (insert (propertize (concat key ":")
+                              'field 'mu4e-header-field-key
+                              'front-sticky '(field)
+                              'keymap mu4e-view-header-field-keymap
+                              'face 'mu4e-header-key-face
+                              'help-echo help) " "
+                              (if dont-propertize-val
+                                  val
+                                (propertize val 'face 'mu4e-header-value-face)) "\n")
+          (when mu4e-view-fill-headers
+            ;; temporarily set the fill column <margin> positions to the right, so
+            ;; we can indent the following lines correctly
+            (let* ((margin 1)
+                   (fill-column (max (- fill-column margin) 0)))
+              (fill-region (point-min) (point-max))
+              (goto-char (point-min))
+              (while (and (zerop (forward-line 1)) (not (looking-at "^$")))
+                (indent-to-column margin))))
+          (buffer-string))
+      "")))
 
 (defun mu4e~view-header-field-fold ()
   "Fold/unfold headers' value if there are more than one line."
   (interactive)
   (let ((name-pos (field-beginning))
-	(value-pos (1+ (field-end))))
+        (value-pos (1+ (field-end))))
     (if (and name-pos value-pos
-	     (eq (get-text-property name-pos 'field) 'mu4e-header-field-key))
-      (save-excursion
-	(let* ((folded))
-	  (mapc (lambda (o)
-		  (when (overlay-get o 'mu4e~view-header-field-folded)
-		    (delete-overlay o)
-		    (setq folded t)))
-		(overlays-at value-pos))
-	  (unless folded
-	    (let* ((o (make-overlay value-pos (field-end value-pos)))
-		   (vals (split-string (field-string value-pos) "\n" t))
-		   (val (if (= (length vals) 1)
-			    (car vals)
-			  (concat (substring (car vals) 0 -3) "..."))))
-	      (overlay-put o 'mu4e~view-header-field-folded t)
-	      (overlay-put o 'display val))))))))
+             (eq (get-text-property name-pos 'field) 'mu4e-header-field-key))
+        (save-excursion
+          (let* ((folded))
+            (mapc (lambda (o)
+                    (when (overlay-get o 'mu4e~view-header-field-folded)
+                      (delete-overlay o)
+                      (setq folded t)))
+                  (overlays-at value-pos))
+            (unless folded
+              (let* ((o (make-overlay value-pos (field-end value-pos)))
+                     (vals (split-string (field-string value-pos) "\n" t))
+                     (val (if (= (length vals) 1)
+                              (car vals)
+                            (concat (substring (car vals) 0 -3) "..."))))
+                (overlay-put o 'mu4e~view-header-field-folded t)
+                (overlay-put o 'display val))))))))
 
 (defun mu4e~view-compose-contact (&optional point)
   "Compose a message for the address at point."
@@ -482,7 +482,7 @@ add text-properties to VAL."
   "Compose a message for the address at (point)."
   (interactive "P")
   (let ((email (get-text-property (point) 'email))
-	 (long (get-text-property (point) 'long)))
+        (long (get-text-property (point) 'long)))
     (unless email (mu4e-error "No address at point"))
     (kill-new (if full long email))
     (mu4e-message "Address copied.")))
@@ -490,97 +490,97 @@ add text-properties to VAL."
 (defun mu4e~view-construct-contacts-header (msg field)
   "Add a header for a contact field (ie., :to, :from, :cc, :bcc)."
   (mu4e~view-construct-header field
-    (mapconcat
-      (lambda(c)
-	(let* ((name (when (car c)
-		       (replace-regexp-in-string "[[:cntrl:]]" "" (car c))))
-		(email (when (cdr c)
-			 (replace-regexp-in-string "[[:cntrl:]]" "" (cdr c))))
-		(short (or name email)) ;; name may be nil
-		(long (if name (format "%s <%s>" name email) email)))
-	  (propertize
-	    (if mu4e-view-show-addresses long short)
-	    'long long
-	    'short short
-	    'email email
-	    'keymap mu4e-view-contacts-header-keymap
-	    'face 'mu4e-contact-face
-	    'mouse-face 'highlight
-	    'help-echo (format "<%s>\n%s" email
-			 "[mouse-2] or C to compose a mail for this recipient"))))
-	  (mu4e-message-field msg field) ", ") t))
+                              (mapconcat
+                               (lambda(c)
+                                 (let* ((name (when (car c)
+                                                (replace-regexp-in-string "[[:cntrl:]]" "" (car c))))
+                                        (email (when (cdr c)
+                                                 (replace-regexp-in-string "[[:cntrl:]]" "" (cdr c))))
+                                        (short (or name email)) ;; name may be nil
+                                        (long (if name (format "%s <%s>" name email) email)))
+                                   (propertize
+                                    (if mu4e-view-show-addresses long short)
+                                    'long long
+                                    'short short
+                                    'email email
+                                    'keymap mu4e-view-contacts-header-keymap
+                                    'face 'mu4e-contact-face
+                                    'mouse-face 'highlight
+                                    'help-echo (format "<%s>\n%s" email
+                                                       "[mouse-2] or C to compose a mail for this recipient"))))
+                               (mu4e-message-field msg field) ", ") t))
 
 (defun mu4e~view-construct-flags-tags-header (field val)
   "Construct a Flags: header."
   (mu4e~view-construct-header
-    field
-    (mapconcat
-      (lambda (flag)
-	(propertize
-	  (if (symbolp flag)
-	    (symbol-name flag)
-	    flag)
-	  'face 'mu4e-special-header-value-face))
-      val
-      (propertize ", " 'face 'mu4e-header-value-face)) t))
+   field
+   (mapconcat
+    (lambda (flag)
+      (propertize
+       (if (symbolp flag)
+           (symbol-name flag)
+         flag)
+       'face 'mu4e-special-header-value-face))
+    val
+    (propertize ", " 'face 'mu4e-header-value-face)) t))
 
 (defun mu4e~view-construct-signature-header (msg)
   "Construct a Signature: header, if there are any signed parts."
   (let* ((parts (mu4e-message-field msg :parts))
-	  (verdicts
-	    (cl-remove-if 'null
-	      (mapcar (lambda (part) (mu4e-message-part-field part :signature))
-		parts)))
-	  (signers
-	    (mapconcat 'identity
-	      (cl-remove-if 'null
-		(mapcar (lambda (part) (mu4e-message-part-field part :signers))
-		  parts)) ", "))
-	  (val (when verdicts
-		 (mapconcat
-		   (lambda (v)
-		     (propertize (symbol-name v)
-		       'face (if (eq v 'verified)
-			       'mu4e-ok-face 'mu4e-warning-face)))
-		   verdicts ", ")))
-	  (btn (when val
-		 (with-temp-buffer
-		   (insert-text-button "Details"
-		     'action (lambda (b)
-			       (mu4e-view-verify-msg-popup
-				 (button-get b 'msg))))
-		   (buffer-string))))
-	  (val (when val (concat val signers " (" btn ")"))))
+         (verdicts
+          (cl-remove-if 'null
+                        (mapcar (lambda (part) (mu4e-message-part-field part :signature))
+                                parts)))
+         (signers
+          (mapconcat 'identity
+                     (cl-remove-if 'null
+                                   (mapcar (lambda (part) (mu4e-message-part-field part :signers))
+                                           parts)) ", "))
+         (val (when verdicts
+                (mapconcat
+                 (lambda (v)
+                   (propertize (symbol-name v)
+                               'face (if (eq v 'verified)
+                                         'mu4e-ok-face 'mu4e-warning-face)))
+                 verdicts ", ")))
+         (btn (when val
+                (with-temp-buffer
+                  (insert-text-button "Details"
+                                      'action (lambda (b)
+                                                (mu4e-view-verify-msg-popup
+                                                 (button-get b 'msg))))
+                  (buffer-string))))
+         (val (when val (concat val signers " (" btn ")"))))
     (mu4e~view-construct-header :signature val t)))
 
 (defun mu4e~view-construct-decryption-header (msg)
   "Construct a Decryption: header, if there are any encrypted parts."
   (let* ((parts (mu4e-message-field msg :parts))
-	 (verdicts
-	  (cl-remove-if 'null
-	    (mapcar (lambda (part)
-		      (mu4e-message-part-field part :decryption))
-	      parts)))
-	 (succeeded (cl-remove-if (lambda (v) (eq v 'failed)) verdicts))
-	 (failed (cl-remove-if (lambda (v) (eq v 'succeeded)) verdicts))
-	 (succ (when succeeded
-		 (propertize
-		  (concat (number-to-string (length succeeded))
-			  " part(s) decrypted")
-		  'face 'mu4e-ok-face)))
-	 (fail (when failed
-		 (propertize
-		  (concat (number-to-string (length failed))
-			  " part(s) failed")
-		  'face 'mu4e-warning-face)))
-	 (val (concat succ fail)))
+         (verdicts
+          (cl-remove-if 'null
+                        (mapcar (lambda (part)
+                                  (mu4e-message-part-field part :decryption))
+                                parts)))
+         (succeeded (cl-remove-if (lambda (v) (eq v 'failed)) verdicts))
+         (failed (cl-remove-if (lambda (v) (eq v 'succeeded)) verdicts))
+         (succ (when succeeded
+                 (propertize
+                  (concat (number-to-string (length succeeded))
+                          " part(s) decrypted")
+                  'face 'mu4e-ok-face)))
+         (fail (when failed
+                 (propertize
+                  (concat (number-to-string (length failed))
+                          " part(s) failed")
+                  'face 'mu4e-warning-face)))
+         (val (concat succ fail)))
     (mu4e~view-construct-header :decryption val t)))
 
 (defun mu4e~view-open-attach-from-binding ()
   "Open the attachment at point, or click location."
   (interactive)
   (let* (( msg (mu4e~view-get-property-from-event 'mu4e-msg))
-	 ( attnum (mu4e~view-get-property-from-event 'mu4e-attnum)))
+         ( attnum (mu4e~view-get-property-from-event 'mu4e-attnum)))
     (when (and msg attnum)
       (mu4e-view-open-attachment msg attnum))))
 
@@ -588,80 +588,80 @@ add text-properties to VAL."
   "Save the attachment at point, or click location."
   (interactive)
   (let* (( msg (mu4e~view-get-property-from-event 'mu4e-msg))
-	 ( attnum (mu4e~view-get-property-from-event 'mu4e-attnum)))
+         ( attnum (mu4e~view-get-property-from-event 'mu4e-attnum)))
     (when (and msg attnum)
       (mu4e-view-save-attachment-single msg attnum))))
 
 (defun mu4e~view-construct-attachments-header (msg)
   "Display attachment information; the field looks like something like:
-   	:parts ((:index 1 :name \"1.part\" :mime-type \"text/plain\"
-		 :type (leaf) :attachment nil :size 228)
-		(:index 2 :name \"analysis.doc\"
-		 :mime-type \"application/msword\"
-		 :type (leaf attachment) :attachment nil :size 605196))"
+        :parts ((:index 1 :name \"1.part\" :mime-type \"text/plain\"
+                 :type (leaf) :attachment nil :size 228)
+                (:index 2 :name \"analysis.doc\"
+                 :mime-type \"application/msword\"
+                 :type (leaf attachment) :attachment nil :size 605196))"
   (setq mu4e~view-attach-map ;; buffer local
-    (make-hash-table :size 64 :weakness nil))
+        (make-hash-table :size 64 :weakness nil))
   (let* ((id 0)
-	  (partcount (length (mu4e-message-field msg :parts)))
-	  (attachments
-	    ;; we only list parts that look like attachments, ie. that have a
-	    ;; non-nil :attachment property; we record a mapping between
-	    ;; user-visible numbers and the part indices
-	    (cl-remove-if-not
-	      (lambda (part)
-		(let* ((mtype (or (mu4e-message-part-field part :mime-type)
-				"application/octet-stream"))
-			(partsize (or (mu4e-message-part-field part :size) 0))
-			(attachtype (mu4e-message-part-field part :type))
-			(isattach
-			  (or ;; we consider parts marked either
-			    ;; "attachment" or "inline" as attachment.
-			    (member 'attachment attachtype)
-			    ;; list inline parts as attachment (so they can be
-			    ;; saved), unless they are text/plain, which are
-			    ;; usually just message footers in mailing lists
-			    ;;
-			    ;; however, slow bigger text parts as attachments,
-			    ;; except when they're the only part... it's
-			    ;; complicated.
-			    (and (member 'inline attachtype)
-			      (or
-				(and (> partcount 1) (> partsize 256))
-				(not (string-match "^text/plain" mtype)))))))
-		  (or ;; remove if it's not an attach *or* if it's an
-		    ;; image/audio/application type (but not a signature)
-		    isattach
-		    (string-match "^\\(image\\|audio\\)" mtype)
-		    (string= "message/rfc822" mtype)
-		    (string= "text/calendar" mtype)
-		    (and (string-match "^application" mtype)
-		      (not (string-match "signature" mtype))))))
-	      (mu4e-message-field msg :parts)))
-	  (attstr
-	    (mapconcat
-	      (lambda (part)
-		(let ((index (mu4e-message-part-field part :index))
-		       (name (mu4e-message-part-field part :name))
-		       (size (mu4e-message-part-field part :size)))
-		  (cl-incf id)
-		  (puthash id index mu4e~view-attach-map)
+         (partcount (length (mu4e-message-field msg :parts)))
+         (attachments
+          ;; we only list parts that look like attachments, ie. that have a
+          ;; non-nil :attachment property; we record a mapping between
+          ;; user-visible numbers and the part indices
+          (cl-remove-if-not
+           (lambda (part)
+             (let* ((mtype (or (mu4e-message-part-field part :mime-type)
+                               "application/octet-stream"))
+                    (partsize (or (mu4e-message-part-field part :size) 0))
+                    (attachtype (mu4e-message-part-field part :type))
+                    (isattach
+                     (or ;; we consider parts marked either
+                      ;; "attachment" or "inline" as attachment.
+                      (member 'attachment attachtype)
+                      ;; list inline parts as attachment (so they can be
+                      ;; saved), unless they are text/plain, which are
+                      ;; usually just message footers in mailing lists
+                      ;;
+                      ;; however, slow bigger text parts as attachments,
+                      ;; except when they're the only part... it's
+                      ;; complicated.
+                      (and (member 'inline attachtype)
+                           (or
+                            (and (> partcount 1) (> partsize 256))
+                            (not (string-match "^text/plain" mtype)))))))
+               (or ;; remove if it's not an attach *or* if it's an
+                ;; image/audio/application type (but not a signature)
+                isattach
+                (string-match "^\\(image\\|audio\\)" mtype)
+                (string= "message/rfc822" mtype)
+                (string= "text/calendar" mtype)
+                (and (string-match "^application" mtype)
+                     (not (string-match "signature" mtype))))))
+           (mu4e-message-field msg :parts)))
+         (attstr
+          (mapconcat
+           (lambda (part)
+             (let ((index (mu4e-message-part-field part :index))
+                   (name (mu4e-message-part-field part :name))
+                   (size (mu4e-message-part-field part :size)))
+               (cl-incf id)
+               (puthash id index mu4e~view-attach-map)
 
-		  (concat
-		    (propertize (format "[%d]" id)
-		      'face 'mu4e-attach-number-face)
-		    (propertize name 'face 'mu4e-link-face
-		      'keymap mu4e-view-attachments-header-keymap
-		      'mouse-face 'highlight
-		      'help-echo (concat
-				  "[mouse-1] or [M-RET] opens the attachment\n"
-				  "[mouse-2] or [S-RET] offers to save it")
-		      'mu4e-msg msg
-		      'mu4e-attnum id
-		      )
-		    (when (and size (> size 0))
-		      (propertize (format "(%s)" (mu4e-display-size size))
-				  'face 'mu4e-header-key-face)))))
-	      attachments ", ")))
+               (concat
+                (propertize (format "[%d]" id)
+                            'face 'mu4e-attach-number-face)
+                (propertize name 'face 'mu4e-link-face
+                            'keymap mu4e-view-attachments-header-keymap
+                            'mouse-face 'highlight
+                            'help-echo (concat
+                                        "[mouse-1] or [M-RET] opens the attachment\n"
+                                        "[mouse-2] or [S-RET] offers to save it")
+                            'mu4e-msg msg
+                            'mu4e-attnum id
+                            )
+                (when (and size (> size 0))
+                  (propertize (format "(%s)" (mu4e-display-size size))
+                              'face 'mu4e-header-key-face)))))
+           attachments ", ")))
     (when attachments
       (mu4e~view-construct-header :attachments attstr t))))
 
@@ -670,8 +670,8 @@ add text-properties to VAL."
 FUNC should be a function taking two arguments:
  1. the message MSG, and
  2. a plist describing the attachment. The plist looks like:
-    	 (:index 1 :name \"test123.doc\"
-	  :mime-type \"application/msword\" :attachment t :size 1234)."
+         (:index 1 :name \"test123.doc\"
+          :mime-type \"application/msword\" :attachment t :size 1234)."
   (dolist (part (mu4e-msg-field msg :parts))
     (funcall func msg part)))
 
@@ -679,205 +679,205 @@ FUNC should be a function taking two arguments:
   "Definition DEF only available in 'native' mode."
   `(lambda() (interactive)
      (if mu4e-view-use-gnus
-       (mu4e-warn "binding not supported with the gnus-based view")
+         (mu4e-warn "binding not supported with the gnus-based view")
        (,def))))
 
 (defvar mu4e-view-mode-map nil
   "Keymap for \"*mu4e-view*\" buffers.")
 (unless mu4e-view-mode-map
   (setq mu4e-view-mode-map
-    (let ((map (make-sparse-keymap)))
+        (let ((map (make-sparse-keymap)))
 
-      (define-key map  (kbd "C-S-u") 'mu4e-update-mail-and-index)
-      (define-key map  (kbd "C-c C-u") 'mu4e-update-mail-and-index)
+          (define-key map  (kbd "C-S-u") 'mu4e-update-mail-and-index)
+          (define-key map  (kbd "C-c C-u") 'mu4e-update-mail-and-index)
 
-      (define-key map "q" 'mu4e~view-quit-buffer)
+          (define-key map "q" 'mu4e~view-quit-buffer)
 
-      ;; note, 'z' is by-default bound to 'bury-buffer'
-      ;; but that's not very useful in this case
-      (define-key map "z" 'ignore)
+          ;; note, 'z' is by-default bound to 'bury-buffer'
+          ;; but that's not very useful in this case
+          (define-key map "z" 'ignore)
 
-      (define-key map "s" 'mu4e-headers-search)
-      (define-key map "S" 'mu4e-view-search-edit)
-      (define-key map "/" 'mu4e-view-search-narrow)
+          (define-key map "s" 'mu4e-headers-search)
+          (define-key map "S" 'mu4e-view-search-edit)
+          (define-key map "/" 'mu4e-view-search-narrow)
 
-      (define-key map (kbd "<M-left>")  'mu4e-headers-query-prev)
-      (define-key map (kbd "<M-right>") 'mu4e-headers-query-next)
+          (define-key map (kbd "<M-left>")  'mu4e-headers-query-prev)
+          (define-key map (kbd "<M-right>") 'mu4e-headers-query-next)
 
-      (define-key map "b" 'mu4e-headers-search-bookmark)
-      (define-key map "B" 'mu4e-headers-search-bookmark-edit)
+          (define-key map "b" 'mu4e-headers-search-bookmark)
+          (define-key map "B" 'mu4e-headers-search-bookmark-edit)
 
-      (define-key map "%" 'mu4e-view-mark-pattern)
-      (define-key map "t" 'mu4e-view-mark-subthread)
-      (define-key map "T" 'mu4e-view-mark-thread)
+          (define-key map "%" 'mu4e-view-mark-pattern)
+          (define-key map "t" 'mu4e-view-mark-subthread)
+          (define-key map "T" 'mu4e-view-mark-thread)
 
-      (define-key map "v" 'mu4e-view-verify-msg-popup)
+          (define-key map "v" 'mu4e-view-verify-msg-popup)
 
-      (define-key map "j" 'mu4e~headers-jump-to-maildir)
+          (define-key map "j" 'mu4e~headers-jump-to-maildir)
 
-      (define-key map "g" (mu4e~native-def mu4e-view-go-to-url))
-      (define-key map "k" (mu4e~native-def mu4e-view-save-url))
-      (define-key map "f" (mu4e~native-def mu4e-view-fetch-url))
+          (define-key map "g" (mu4e~native-def mu4e-view-go-to-url))
+          (define-key map "k" (mu4e~native-def mu4e-view-save-url))
+          (define-key map "f" (mu4e~native-def mu4e-view-fetch-url))
 
-      (define-key map "F" 'mu4e-compose-forward)
-      (define-key map "R" 'mu4e-compose-reply)
-      (define-key map "C" 'mu4e-compose-new)
-      (define-key map "E" 'mu4e-compose-edit)
+          (define-key map "F" 'mu4e-compose-forward)
+          (define-key map "R" 'mu4e-compose-reply)
+          (define-key map "C" 'mu4e-compose-new)
+          (define-key map "E" 'mu4e-compose-edit)
 
-      (define-key map "K" 'ignore) ;; for gnus mode
+          (define-key map "K" 'ignore) ;; for gnus mode
 
-      (define-key map "." 'mu4e-view-raw-message)
-      (define-key map "|" 'mu4e-view-pipe)
-      (define-key map "a" 'mu4e-view-action)
+          (define-key map "." 'mu4e-view-raw-message)
+          (define-key map "|" 'mu4e-view-pipe)
+          (define-key map "a" 'mu4e-view-action)
 
-      (define-key map ";" 'mu4e-context-switch)
+          (define-key map ";" 'mu4e-context-switch)
 
-      ;; toggle header settings
-      (define-key map "O" 'mu4e-headers-change-sorting)
-      (define-key map "P" 'mu4e-headers-toggle-threading)
-      (define-key map "Q" 'mu4e-headers-toggle-full-search)
-      (define-key map "W" 'mu4e-headers-toggle-include-related)
+          ;; toggle header settings
+          (define-key map "O" 'mu4e-headers-change-sorting)
+          (define-key map "P" 'mu4e-headers-toggle-threading)
+          (define-key map "Q" 'mu4e-headers-toggle-full-search)
+          (define-key map "W" 'mu4e-headers-toggle-include-related)
 
-      ;; change the number of headers
-      (define-key map (kbd "C-+") 'mu4e-headers-split-view-grow)
-      (define-key map (kbd "C--") 'mu4e-headers-split-view-shrink)
-      (define-key map (kbd "<C-kp-add>") 'mu4e-headers-split-view-grow)
-      (define-key map (kbd "<C-kp-subtract>") 'mu4e-headers-split-view-shrink)
+          ;; change the number of headers
+          (define-key map (kbd "C-+") 'mu4e-headers-split-view-grow)
+          (define-key map (kbd "C--") 'mu4e-headers-split-view-shrink)
+          (define-key map (kbd "<C-kp-add>") 'mu4e-headers-split-view-grow)
+          (define-key map (kbd "<C-kp-subtract>") 'mu4e-headers-split-view-shrink)
 
-      ;; intra-message navigation
-      (define-key map (kbd "SPC") 'mu4e-view-scroll-up-or-next)
-      (define-key map (kbd "<home>") 'beginning-of-buffer)
-      (define-key map (kbd "<end>") 'end-of-buffer)
-      (define-key map (kbd "RET") 'mu4e-scroll-up)
-      (define-key map (kbd "<backspace>") 'mu4e-scroll-down)
+          ;; intra-message navigation
+          (define-key map (kbd "SPC") 'mu4e-view-scroll-up-or-next)
+          (define-key map (kbd "<home>") 'beginning-of-buffer)
+          (define-key map (kbd "<end>") 'end-of-buffer)
+          (define-key map (kbd "RET") 'mu4e-scroll-up)
+          (define-key map (kbd "<backspace>") 'mu4e-scroll-down)
 
-      ;; navigation between messages
-      (define-key map "p" 'mu4e-view-headers-prev)
-      (define-key map "n" 'mu4e-view-headers-next)
-      ;; the same
-      (define-key map (kbd "<M-down>") 'mu4e-view-headers-next)
-      (define-key map (kbd "<M-up>") 'mu4e-view-headers-prev)
+          ;; navigation between messages
+          (define-key map "p" 'mu4e-view-headers-prev)
+          (define-key map "n" 'mu4e-view-headers-next)
+          ;; the same
+          (define-key map (kbd "<M-down>") 'mu4e-view-headers-next)
+          (define-key map (kbd "<M-up>") 'mu4e-view-headers-prev)
 
-      (define-key map (kbd "[") 'mu4e-view-headers-prev-unread)
-      (define-key map (kbd "]") 'mu4e-view-headers-next-unread)
+          (define-key map (kbd "[") 'mu4e-view-headers-prev-unread)
+          (define-key map (kbd "]") 'mu4e-view-headers-next-unread)
 
-      ;; switching to view mode (if it's visible)
-      (define-key map "y" 'mu4e-select-other-view)
+          ;; switching to view mode (if it's visible)
+          (define-key map "y" 'mu4e-select-other-view)
 
-      ;; attachments
-      (define-key map "e" (mu4e~native-def mu4e-view-save-attachment))
-      (define-key map "o" (mu4e~native-def mu4e-view-open-attachment))
-      (define-key map "A" (mu4e~native-def mu4e-view-attachment-action))
+          ;; attachments
+          (define-key map "e" (mu4e~native-def mu4e-view-save-attachment))
+          (define-key map "o" (mu4e~native-def mu4e-view-open-attachment))
+          (define-key map "A" (mu4e~native-def mu4e-view-attachment-action))
 
-      ;; marking/unmarking
-      (define-key map "d" 'mu4e-view-mark-or-move-to-trash)
-      (define-key map (kbd "<delete>") 'mu4e-view-mark-for-delete)
-      (define-key map (kbd "<deletechar>") 'mu4e-view-mark-for-delete)
-      (define-key map (kbd "D") 'mu4e-view-mark-for-delete)
-      (define-key map (kbd "m") 'mu4e-view-mark-for-move)
-      (define-key map (kbd "r") 'mu4e-view-mark-for-refile)
+          ;; marking/unmarking
+          (define-key map "d" 'mu4e-view-mark-or-move-to-trash)
+          (define-key map (kbd "<delete>") 'mu4e-view-mark-for-delete)
+          (define-key map (kbd "<deletechar>") 'mu4e-view-mark-for-delete)
+          (define-key map (kbd "D") 'mu4e-view-mark-for-delete)
+          (define-key map (kbd "m") 'mu4e-view-mark-for-move)
+          (define-key map (kbd "r") 'mu4e-view-mark-for-refile)
 
-      (define-key map (kbd "?") 'mu4e-view-mark-for-unread)
-      (define-key map (kbd "!") 'mu4e-view-mark-for-read)
+          (define-key map (kbd "?") 'mu4e-view-mark-for-unread)
+          (define-key map (kbd "!") 'mu4e-view-mark-for-read)
 
-      (define-key map (kbd "+") 'mu4e-view-mark-for-flag)
-      (define-key map (kbd "-") 'mu4e-view-mark-for-unflag)
-      (define-key map (kbd "=") 'mu4e-view-mark-for-untrash)
-      (define-key map (kbd "&") 'mu4e-view-mark-custom)
+          (define-key map (kbd "+") 'mu4e-view-mark-for-flag)
+          (define-key map (kbd "-") 'mu4e-view-mark-for-unflag)
+          (define-key map (kbd "=") 'mu4e-view-mark-for-untrash)
+          (define-key map (kbd "&") 'mu4e-view-mark-custom)
 
-      (define-key map (kbd "*")             'mu4e-view-mark-for-something)
-      (define-key map (kbd "<kp-multiply>") 'mu4e-view-mark-for-something)
-      (define-key map (kbd "<insert>")     'mu4e-view-mark-for-something)
-      (define-key map (kbd "<insertchar>") 'mu4e-view-mark-for-something)
+          (define-key map (kbd "*")             'mu4e-view-mark-for-something)
+          (define-key map (kbd "<kp-multiply>") 'mu4e-view-mark-for-something)
+          (define-key map (kbd "<insert>")     'mu4e-view-mark-for-something)
+          (define-key map (kbd "<insertchar>") 'mu4e-view-mark-for-something)
 
-      (define-key map (kbd "#") 'mu4e-mark-resolve-deferred-marks)
+          (define-key map (kbd "#") 'mu4e-mark-resolve-deferred-marks)
 
-      ;; misc
-      (define-key map "w" 'visual-line-mode)
-      (define-key map "#" (mu4e~native-def mu4e-view-toggle-hide-cited))
-      (define-key map "h" (mu4e~native-def mu4e-view-toggle-html))
-      (define-key map (kbd "M-q")
-        (lambda()
-          (interactive)
-	        (if 'mu4e-view-use-gnus
-            (article-fill-long-lines)
-            (mu4e-view-fill-long-lines))))
+          ;; misc
+          (define-key map "w" 'visual-line-mode)
+          (define-key map "#" (mu4e~native-def mu4e-view-toggle-hide-cited))
+          (define-key map "h" (mu4e~native-def mu4e-view-toggle-html))
+          (define-key map (kbd "M-q")
+            (lambda()
+              (interactive)
+              (if 'mu4e-view-use-gnus
+                  (article-fill-long-lines)
+                (mu4e-view-fill-long-lines))))
 
-      ;; next 3 only warn user when attempt in the message view
-      (define-key map "u" 'mu4e-view-unmark)
-      (define-key map "U" 'mu4e-view-unmark-all)
-      (define-key map "x" 'mu4e-view-marked-execute)
+          ;; next 3 only warn user when attempt in the message view
+          (define-key map "u" 'mu4e-view-unmark)
+          (define-key map "U" 'mu4e-view-unmark-all)
+          (define-key map "x" 'mu4e-view-marked-execute)
 
-      (define-key map "$" 'mu4e-show-log)
-      (define-key map "H" 'mu4e-display-manual)
+          (define-key map "$" 'mu4e-show-log)
+          (define-key map "H" 'mu4e-display-manual)
 
-      ;; menu
-      (define-key map [menu-bar] (make-sparse-keymap))
-      (let ((menumap (make-sparse-keymap "View")))
-	(define-key map [menu-bar headers] (cons "View" menumap))
+          ;; menu
+          (define-key map [menu-bar] (make-sparse-keymap))
+          (let ((menumap (make-sparse-keymap "View")))
+            (define-key map [menu-bar headers] (cons "View" menumap))
 
-	(define-key menumap [quit-buffer]
-	  '("Quit view" . mu4e~view-quit-buffer))
-	(define-key menumap [display-help] '("Help" . mu4e-display-manual))
+            (define-key menumap [quit-buffer]
+              '("Quit view" . mu4e~view-quit-buffer))
+            (define-key menumap [display-help] '("Help" . mu4e-display-manual))
 
-	(define-key menumap [sepa0] '("--"))
-	(define-key menumap [wrap-lines]
-	  '("Toggle wrap lines" . visual-line-mode))
-	(unless 'mu4e-view-use-gnus
-	  (define-key menumap [toggle-html]
-	    '("Toggle view-html" . mu4e-view-toggle-html)))
-	(define-key menumap [raw-view]
-	  '("View raw message" . mu4e-view-raw-message))
-	(define-key menumap [pipe]
-	  '("Pipe through shell" . mu4e-view-pipe))
+            (define-key menumap [sepa0] '("--"))
+            (define-key menumap [wrap-lines]
+              '("Toggle wrap lines" . visual-line-mode))
+            (unless 'mu4e-view-use-gnus
+              (define-key menumap [toggle-html]
+                '("Toggle view-html" . mu4e-view-toggle-html)))
+            (define-key menumap [raw-view]
+              '("View raw message" . mu4e-view-raw-message))
+            (define-key menumap [pipe]
+              '("Pipe through shell" . mu4e-view-pipe))
 
-	(unless mu4e-view-use-gnus
-	  (define-key menumap [sepa8] '("--"))
-	  (define-key menumap [open-att]
-	    '("Open attachment" . mu4e-view-open-attachment))
-	  (define-key menumap [extract-att]
-	    '("Extract attachment" . mu4e-view-save-attachment))
-	  (define-key menumap [save-url]
-	    '("Save URL to kill-ring" . mu4e-view-save-url))
-	  (define-key menumap [fetch-url]
-	    '("Fetch URL" . mu4e-view-fetch-url))
-	  (define-key menumap [goto-url]
-	    '("Visit URL" . mu4e-view-go-to-url)))
+            (unless mu4e-view-use-gnus
+              (define-key menumap [sepa8] '("--"))
+              (define-key menumap [open-att]
+                '("Open attachment" . mu4e-view-open-attachment))
+              (define-key menumap [extract-att]
+                '("Extract attachment" . mu4e-view-save-attachment))
+              (define-key menumap [save-url]
+                '("Save URL to kill-ring" . mu4e-view-save-url))
+              (define-key menumap [fetch-url]
+                '("Fetch URL" . mu4e-view-fetch-url))
+              (define-key menumap [goto-url]
+                '("Visit URL" . mu4e-view-go-to-url)))
 
-	(define-key menumap [sepa1] '("--"))
-	(define-key menumap [mark-delete]
-	  '("Mark for deletion" . mu4e-view-mark-for-delete))
-	(define-key menumap [mark-untrash]
-	  '("Mark for untrash" .  mu4e-view-mark-for-untrash))
-	(define-key menumap [mark-trash]
-	  '("Mark for trash" .  mu4e-view-mark-for-trash))
-	(define-key menumap [mark-move]
-	  '("Mark for move" . mu4e-view-mark-for-move))
+            (define-key menumap [sepa1] '("--"))
+            (define-key menumap [mark-delete]
+              '("Mark for deletion" . mu4e-view-mark-for-delete))
+            (define-key menumap [mark-untrash]
+              '("Mark for untrash" .  mu4e-view-mark-for-untrash))
+            (define-key menumap [mark-trash]
+              '("Mark for trash" .  mu4e-view-mark-for-trash))
+            (define-key menumap [mark-move]
+              '("Mark for move" . mu4e-view-mark-for-move))
 
-	(define-key menumap [sepa2] '("--"))
-	(define-key menumap [resend]  '("Resend" . mu4e-compose-resend))
-	(define-key menumap [forward]  '("Forward" . mu4e-compose-forward))
-	(define-key menumap [reply]  '("Reply" . mu4e-compose-reply))
-	(define-key menumap [compose-new]  '("Compose new" . mu4e-compose-new))
-	(define-key menumap [sepa3] '("--"))
+            (define-key menumap [sepa2] '("--"))
+            (define-key menumap [resend]  '("Resend" . mu4e-compose-resend))
+            (define-key menumap [forward]  '("Forward" . mu4e-compose-forward))
+            (define-key menumap [reply]  '("Reply" . mu4e-compose-reply))
+            (define-key menumap [compose-new]  '("Compose new" . mu4e-compose-new))
+            (define-key menumap [sepa3] '("--"))
 
-	(define-key menumap [query-next]
-	  '("Next query" . mu4e-headers-query-next))
-	(define-key menumap [query-prev]
-	  '("Previous query" . mu4e-headers-query-prev))
-	(define-key menumap [narrow-search]
-	  '("Narrow search" . mu4e-headers-search-narrow))
-	(define-key menumap [bookmark]
-	  '("Search bookmark" . mu4e-headers-search-bookmark))
-	(define-key menumap [jump]
-	  '("Jump to maildir" . mu4e~headers-jump-to-maildir))
-	(define-key menumap [search]
-	  '("Search" . mu4e-headers-search))
+            (define-key menumap [query-next]
+              '("Next query" . mu4e-headers-query-next))
+            (define-key menumap [query-prev]
+              '("Previous query" . mu4e-headers-query-prev))
+            (define-key menumap [narrow-search]
+              '("Narrow search" . mu4e-headers-search-narrow))
+            (define-key menumap [bookmark]
+              '("Search bookmark" . mu4e-headers-search-bookmark))
+            (define-key menumap [jump]
+              '("Jump to maildir" . mu4e~headers-jump-to-maildir))
+            (define-key menumap [search]
+              '("Search" . mu4e-headers-search))
 
-	(define-key menumap [sepa4]     '("--"))
-	(define-key menumap [next]      '("Next" . mu4e-view-headers-next))
-	(define-key menumap [previous]  '("Previous" . mu4e-view-headers-prev)))
-      map))
+            (define-key menumap [sepa4]     '("--"))
+            (define-key menumap [next]      '("Next" . mu4e-view-headers-next))
+            (define-key menumap [previous]  '("Previous" . mu4e-view-headers-prev)))
+          map))
 
   (fset 'mu4e-view-mode-map mu4e-view-mode-map))
 
@@ -904,15 +904,15 @@ FUNC should be a function taking two arguments:
 (defun mu4e~view-define-mode ()
   "Define the major-mode for the mu4e-view."
   (if mu4e-view-use-gnus
-    (define-derived-mode mu4e-view-mode gnus-article-mode "mu4e:view"
-      ;; remove some gnus stuff that does not apply
-      (define-key mu4e-view-mode-map [menu-bar Treatment] nil)
-      (define-key mu4e-view-mode-map [menu-bar Article] nil)
-      (define-key mu4e-view-mode-map [menu-bar post] nil)
-      "Major mode for viewing an e-mail message in mu4e, based on
+      (define-derived-mode mu4e-view-mode gnus-article-mode "mu4e:view"
+        ;; remove some gnus stuff that does not apply
+        (define-key mu4e-view-mode-map [menu-bar Treatment] nil)
+        (define-key mu4e-view-mode-map [menu-bar Article] nil)
+        (define-key mu4e-view-mode-map [menu-bar post] nil)
+        "Major mode for viewing an e-mail message in mu4e, based on
 Gnus' article-mode."
-      (setq mu4e~view-buffer-name gnus-article-buffer)
-      (mu4e~view-mode-body))
+        (setq mu4e~view-buffer-name gnus-article-buffer)
+        (mu4e~view-mode-body))
     (define-derived-mode mu4e-view-mode special-mode "mu4e:view"
       "Major mode for viewing an e-mail message in mu4e."
       (mu4e~view-mode-body))))
@@ -924,17 +924,17 @@ triggers any changes, nil otherwise. If this function does any
 changes, it triggers a refresh."
   (when (and mu4e-view-auto-mark-as-read msg)
     (let ((flags (mu4e-message-field msg :flags))
-	   (msgid (mu4e-message-field msg :message-id))
-	   (docid (mu4e-message-field msg :docid)))
+          (msgid (mu4e-message-field msg :message-id))
+          (docid (mu4e-message-field msg :docid)))
       ;; attached (embedded) messages don't have docids; leave them alone if it
       ;; is a new message
       (when (and docid (or (member 'unread flags) (member 'new flags)))
-	;; mark /all/ messages with this message-id as read, so all copies of
-	;; this message will be marked as read. We don't want an update thougn,
-	;; we want a full message, so images etc. work correctly.
-	(mu4e~proc-move msgid nil "+S-u-N" 'noview)
+        ;; mark /all/ messages with this message-id as read, so all copies of
+        ;; this message will be marked as read. We don't want an update thougn,
+        ;; we want a full message, so images etc. work correctly.
+        (mu4e~proc-move msgid nil "+S-u-N" 'noview)
         (mu4e~proc-view docid mu4e-view-show-images (mu4e~decrypt-p msg))
-	t))))
+        t))))
 
 (defun mu4e~view-browse-url-func (url)
   "Return a function that executes `browse-url' with URL.
@@ -942,9 +942,9 @@ The browser that is called depends on
 `browse-url-browser-function' and `browse-url-mailto-function'."
   (save-match-data
     (if (string-match "^mailto:" url)
-	(lambda ()
-	  (interactive)
-	  (browse-url-mail url))
+        (lambda ()
+          (interactive)
+          (browse-url-mail url))
       (lambda ()
         (interactive)
         (browse-url url)))))
@@ -957,24 +957,24 @@ If the url is mailto link, start writing an email to that address."
   (let* (( url (or url (mu4e~view-get-property-from-event 'mu4e-url))))
     (when url
       (if (string-match-p "^mailto:" url)
-	  (browse-url-mail url)
-	(browse-url url)))))
+          (browse-url-mail url)
+        (browse-url url)))))
 
 (defun mu4e~view-show-images-maybe (msg)
   "Show attached images, if `mu4e-show-images' is non-nil."
   (when (and (display-images-p) mu4e-view-show-images)
     (mu4e-view-for-each-part msg
-      (lambda (_msg part)
-	(when (string-match "^image/"
-		(or (mu4e-message-part-field part :mime-type)
-		  "application/object-stream"))
-	  (let ((imgfile (mu4e-message-part-field part :temp)))
-	    (when (and imgfile (file-exists-p imgfile))
- 	      (save-excursion
-		(goto-char (point-max))
-		(mu4e-display-image imgfile
-		  mu4e-view-image-max-width
-		  mu4e-view-image-max-height)))))))))
+                             (lambda (_msg part)
+                               (when (string-match "^image/"
+                                                   (or (mu4e-message-part-field part :mime-type)
+                                                       "application/object-stream"))
+                                 (let ((imgfile (mu4e-message-part-field part :temp)))
+                                   (when (and imgfile (file-exists-p imgfile))
+                                     (save-excursion
+                                       (goto-char (point-max))
+                                       (mu4e-display-image imgfile
+                                                           mu4e-view-image-max-width
+                                                           mu4e-view-image-max-height)))))))))
 
 (defvar mu4e~view-beginning-of-url-regexp
   "https?\\://\\|mailto:"
@@ -988,26 +988,26 @@ Also number them so they can be opened using `mu4e-view-go-to-url'."
   (let ((num 0))
     (save-excursion
       (setq mu4e~view-link-map ;; buffer local
-	(make-hash-table :size 32 :weakness nil))
+            (make-hash-table :size 32 :weakness nil))
       (goto-char (point-min))
       (while (re-search-forward mu4e~view-beginning-of-url-regexp nil t)
-	(let ((bounds (thing-at-point-bounds-of-url-at-point)))
-	  (when bounds
-	    (let* ((url (thing-at-point-url-at-point))
-		    (ov (make-overlay (car bounds) (cdr bounds))))
-	      (puthash (cl-incf num) url mu4e~view-link-map)
-	      (add-text-properties
-		(car bounds)
-		(cdr bounds)
-		`(face mu4e-link-face
-		   mouse-face highlight
-		   mu4e-url ,url
-		   keymap ,mu4e-view-clickable-urls-keymap
-		   help-echo
-		   "[mouse-1] or [M-RET] to open the link"))
-	      (overlay-put ov 'after-string
-		(propertize (format "\u200B[%d]" num)
-		  'face 'mu4e-url-number-face)))))))))
+        (let ((bounds (thing-at-point-bounds-of-url-at-point)))
+          (when bounds
+            (let* ((url (thing-at-point-url-at-point))
+                   (ov (make-overlay (car bounds) (cdr bounds))))
+              (puthash (cl-incf num) url mu4e~view-link-map)
+              (add-text-properties
+               (car bounds)
+               (cdr bounds)
+               `(face mu4e-link-face
+                      mouse-face highlight
+                      mu4e-url ,url
+                      keymap ,mu4e-view-clickable-urls-keymap
+                      help-echo
+                      "[mouse-1] or [M-RET] to open the link"))
+              (overlay-put ov 'after-string
+                           (propertize (format "\u200B[%d]" num)
+                                       'face 'mu4e-url-number-face)))))))))
 
 
 (defun mu4e~view-hide-cited ()
@@ -1025,16 +1025,16 @@ this view."
      (unless (buffer-live-p (mu4e-get-headers-buffer))
        (mu4e-error "no headers buffer connected"))
      (let* ((msg (mu4e-message-at-point))
-	    (docid (mu4e-message-field msg :docid)))
+            (docid (mu4e-message-field msg :docid)))
        (unless docid
-	 (mu4e-error "message without docid: action is not possible."))
+         (mu4e-error "message without docid: action is not possible."))
        (with-current-buffer (mu4e-get-headers-buffer)
-	 (unless (eq mu4e-split-view 'single-window)
-	   (when (get-buffer-window)
-	     (select-window (get-buffer-window))))
-	 (if (mu4e~headers-goto-docid docid)
-	   ,@body
-	   (mu4e-error "cannot find message in headers buffer."))))))
+         (unless (eq mu4e-split-view 'single-window)
+           (when (get-buffer-window)
+             (select-window (get-buffer-window))))
+         (if (mu4e~headers-goto-docid docid)
+             ,@body
+           (mu4e-error "cannot find message in headers buffer."))))))
 
 (defun mu4e-view-headers-next (&optional n)
   "Move point to the next message header in the headers buffer
@@ -1043,7 +1043,7 @@ docid. Otherwise, return nil. Optionally, takes an integer
 N (prefix argument), to the Nth next header."
   (interactive "P")
   (mu4e~view-in-headers-context
-    (mu4e~headers-move (or n 1))))
+   (mu4e~headers-move (or n 1))))
 
 (defun mu4e-view-headers-prev (&optional n)
   "Move point to the previous message header in the headers buffer
@@ -1052,7 +1052,7 @@ docid. Otherwise, return nil. Optionally, takes an integer
 N (prefix argument), to the Nth previous header."
   (interactive "P")
   (mu4e~view-in-headers-context
-    (mu4e~headers-move (- (or n 1)))))
+   (mu4e~headers-move (- (or n 1)))))
 
 (defun mu4e~view-prev-or-next-unread (backwards)
   "Move point to the next or previous (when BACKWARDS is non-`nil')
@@ -1060,16 +1060,16 @@ unread message header in the headers buffer connected with this
 message view. If this succeeds, return the new docid. Otherwise,
 return nil."
   (mu4e~view-in-headers-context
-    (mu4e~headers-prev-or-next-unread backwards))
+   (mu4e~headers-prev-or-next-unread backwards))
   (if (eq mu4e-split-view 'single-window)
       (when (eq (window-buffer) (mu4e-get-view-buffer))
-	(with-current-buffer (mu4e-get-headers-buffer)
-	 (mu4e-headers-view-message)))
+        (with-current-buffer (mu4e-get-headers-buffer)
+          (mu4e-headers-view-message)))
     (mu4e-select-other-view)
     (mu4e-headers-view-message)))
 
 (defun mu4e-view-headers-prev-unread ()
-"Move point to the previous unread message header in the headers
+  "Move point to the previous unread message header in the headers
 buffer connected with this message view. If this succeeds, return
 the new docid. Otherwise, return nil."
   (interactive)
@@ -1090,14 +1090,14 @@ the new docid. Otherwise, return nil."
   "Toggle hiding of cited lines in the message body."
   (interactive)
   (if mu4e~view-cited-hidden
-    (mu4e-view-refresh)
+      (mu4e-view-refresh)
     (mu4e~view-hide-cited)))
 
 (defun mu4e-view-toggle-html ()
   "Toggle html-display of the message body (if any)."
   (interactive)
   (setq mu4e~view-html-text
-    (if mu4e~message-body-html 'text 'html))
+        (if mu4e~message-body-html 'text 'html))
   (mu4e-view-refresh))
 
 (defun mu4e-view-refresh ()
@@ -1113,11 +1113,11 @@ bymessage-at-point.  The actions are specified in
 `mu4e-view-actions'."
   (interactive)
   (let* ((msg (or msg (mu4e-message-at-point)))
-	  (actionfunc (mu4e-read-option "Action: " mu4e-view-actions)))
+         (actionfunc (mu4e-read-option "Action: " mu4e-view-actions)))
     (funcall actionfunc msg)))
 
 (defun mu4e-view-mark-pattern ()
-    "Ask user for a kind of mark (move, delete etc.), a field to
+  "Ask user for a kind of mark (move, delete etc.), a field to
 match and a regular expression to match with. Then, mark all
 matching messages with that mark."
   (interactive)
@@ -1131,7 +1131,7 @@ selection."
   (interactive)
   (mu4e~view-in-headers-context
    (if markpair (mu4e-headers-mark-thread nil markpair)
-       (call-interactively 'mu4e-headers-mark-thread))))
+     (call-interactively 'mu4e-headers-mark-thread))))
 
 (defun mu4e-view-mark-subthread (&optional markpair)
   "Ask user for a kind of mark (move, delete etc.), and apply it
@@ -1147,7 +1147,7 @@ selection."
   "Run `mu4e-headers-search-narrow' in the headers buffer."
   (interactive)
   (mu4e~view-in-headers-context
-    (call-interactively 'mu4e-headers-search-narrow)))
+   (call-interactively 'mu4e-headers-search-narrow)))
 
 (defun mu4e-view-search-edit ()
   "Run `mu4e-headers-search-edit' in the headers buffer."
@@ -1162,23 +1162,23 @@ Add this function to `mu4e-view-mode-hook' to enable this feature."
     (save-excursion
       (goto-char (point-min))
       (while (re-search-forward
-	      (concat "^" message-mark-insert-begin) nil t)
-	(setq ov-beg (match-beginning 0)
-	      ov-end (match-end 0)
-	      ov-inv (make-overlay ov-beg ov-end)
-	      beg    ov-end)
-	(overlay-put ov-inv 'invisible t)
-	(when (re-search-forward
-	       (concat "^" message-mark-insert-end) nil t)
-	  (setq ov-beg (match-beginning 0)
-		ov-end (match-end 0)
-		ov-inv (make-overlay ov-beg ov-end)
-		end    ov-beg)
-	  (overlay-put ov-inv 'invisible t))
-	(when (and beg end)
-	  (let ((ov (make-overlay beg end)))
-	    (overlay-put ov 'face 'mu4e-region-code))
-	  (setq beg nil end nil))))))
+              (concat "^" message-mark-insert-begin) nil t)
+        (setq ov-beg (match-beginning 0)
+              ov-end (match-end 0)
+              ov-inv (make-overlay ov-beg ov-end)
+              beg    ov-end)
+        (overlay-put ov-inv 'invisible t)
+        (when (re-search-forward
+               (concat "^" message-mark-insert-end) nil t)
+          (setq ov-beg (match-beginning 0)
+                ov-end (match-end 0)
+                ov-inv (make-overlay ov-beg ov-end)
+                end    ov-beg)
+          (overlay-put ov-inv 'invisible t))
+        (when (and beg end)
+          (let ((ov (make-overlay beg end)))
+            (overlay-put ov 'face 'mu4e-region-code))
+          (setq beg nil end nil))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Wash functions
@@ -1188,19 +1188,19 @@ Add this function to `mu4e-view-mode-hook' to enable this feature."
   (with-current-buffer (mu4e-get-view-buffer)
     (save-excursion
       (let ((inhibit-read-only t)
-	    (width (window-width (get-buffer-window (current-buffer)))))
-	(save-restriction
-	  (message-goto-body)
-	  (while (not (eobp))
-	    (end-of-line)
-	    (when (>= (current-column) (min fill-column width))
-	      (narrow-to-region (min (1+ (point)) (point-max))
-				(point-at-bol))
-	      (let ((goback (point-marker)))
-		(fill-paragraph nil)
-		(goto-char (marker-position goback)))
-	      (widen))
-	    (forward-line 1)))))))
+            (width (window-width (get-buffer-window (current-buffer)))))
+        (save-restriction
+          (message-goto-body)
+          (while (not (eobp))
+            (end-of-line)
+            (when (>= (current-column) (min fill-column width))
+              (narrow-to-region (min (1+ (point)) (point-max))
+                                (point-at-bol))
+              (let ((goback (point-marker)))
+                (fill-paragraph nil)
+                (goto-char (marker-position goback)))
+              (widen))
+            (forward-line 1)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; attachment handling
@@ -1214,43 +1214,43 @@ return the corresponding string."
   (let* ((count (hash-table-count mu4e~view-attach-map)) (def))
     (when (zerop count) (mu4e-warn "No attachments for this message"))
     (if (not multi)
-      (if (= count 1)
-	(read-number (mu4e-format "%s: " prompt) 1)
-	(read-number (mu4e-format "%s (1-%d): " prompt count)))
+        (if (= count 1)
+            (read-number (mu4e-format "%s: " prompt) 1)
+          (read-number (mu4e-format "%s (1-%d): " prompt count)))
       (progn
-	(setq def (if (= count 1) "1" (format "1-%d" count)))
-	(read-string (mu4e-format "%s (default %s): " prompt def)
-	  nil nil def)))))
+        (setq def (if (= count 1) "1" (format "1-%d" count)))
+        (read-string (mu4e-format "%s (default %s): " prompt def)
+                     nil nil def)))))
 
 (defun mu4e~view-get-attach (msg attnum)
   "Return the attachment plist in MSG corresponding to attachment
 number ATTNUM."
   (let* ((partid (gethash attnum mu4e~view-attach-map))
-	 (attach
-	   (cl-find-if
-	     (lambda (part)
-	       (eq (mu4e-message-part-field part :index) partid))
-	     (mu4e-message-field msg :parts))))
+         (attach
+          (cl-find-if
+           (lambda (part)
+             (eq (mu4e-message-part-field part :index) partid))
+           (mu4e-message-field msg :parts))))
     (or attach (mu4e-error "Not a valid attachment"))))
 
 (defun mu4e~view-request-attachment-path (fname path)
   "Ask the user where to save FNAME (default is PATH/FNAME)."
   (let ((fpath (expand-file-name
-		(read-file-name
-		 (mu4e-format "Save as ")
-		 path nil nil fname) path)))
+                (read-file-name
+                 (mu4e-format "Save as ")
+                 path nil nil fname) path)))
     (if (file-directory-p fpath)
-      (expand-file-name fname fpath)
+        (expand-file-name fname fpath)
       fpath)))
 
 (defun mu4e~view-request-attachments-dir (path)
   "Ask the user where to save multiple attachments (default is PATH)."
   (let ((fpath (expand-file-name
-		(read-directory-name
-		 (mu4e-format "Save in directory ")
-		 path nil nil nil) path)))
+                (read-directory-name
+                 (mu4e-format "Save in directory ")
+                 path nil nil nil) path)))
     (if (file-directory-p fpath)
-	fpath)))
+        fpath)))
 
 (defun mu4e-view-save-attachment-single (&optional msg attnum)
   "Save attachment number ATTNUM from MSG.
@@ -1258,23 +1258,23 @@ If MSG is nil use the message returned by `message-at-point'.
 If ATTNUM is nil ask for the attachment number."
   (interactive)
   (let* ((msg (or msg (mu4e-message-at-point)))
-	  (attnum (or attnum
-		    (mu4e~view-get-attach-num "Attachment to save" msg)))
-	  (att (mu4e~view-get-attach msg attnum))
-	  (fname  (plist-get att :name))
-	  (mtype  (plist-get att :mime-type))
-	  (path (concat
-		  (mu4e~get-attachment-dir fname mtype) "/"))
-	  (index (plist-get att :index))
-	  (retry t) (fpath))
+         (attnum (or attnum
+                     (mu4e~view-get-attach-num "Attachment to save" msg)))
+         (att (mu4e~view-get-attach msg attnum))
+         (fname  (plist-get att :name))
+         (mtype  (plist-get att :mime-type))
+         (path (concat
+                (mu4e~get-attachment-dir fname mtype) "/"))
+         (index (plist-get att :index))
+         (retry t) (fpath))
     (while retry
       (setq fpath (mu4e~view-request-attachment-path fname path))
       (setq retry
-	(and (file-exists-p fpath)
-	  (not (y-or-n-p (mu4e-format "Overwrite '%s'?" fpath))))))
+            (and (file-exists-p fpath)
+                 (not (y-or-n-p (mu4e-format "Overwrite '%s'?" fpath))))))
     (mu4e~proc-extract
-      'save (mu4e-message-field msg :docid)
-      index mu4e-decryption-policy fpath)))
+     'save (mu4e-message-field msg :docid)
+     index mu4e-decryption-policy fpath)))
 
 (defun mu4e-view-save-attachment-multi (&optional msg)
   "Offer to save multiple email attachments from the current message.
@@ -1287,30 +1287,30 @@ Furthermore, there is a shortcut \"a\" which so means all
 attachments, but as this is the default, you may not need it."
   (interactive)
   (let* ((msg (or msg (mu4e-message-at-point)))
-	 (attachstr (mu4e~view-get-attach-num
-		     "Attachment number range (or 'a' for 'all')" msg t))
-	 (count (hash-table-count mu4e~view-attach-map))
-	 (attachnums (mu4e-split-ranges-to-numbers attachstr count)))
+         (attachstr (mu4e~view-get-attach-num
+                     "Attachment number range (or 'a' for 'all')" msg t))
+         (count (hash-table-count mu4e~view-attach-map))
+         (attachnums (mu4e-split-ranges-to-numbers attachstr count)))
     (if mu4e-save-multiple-attachments-without-asking
-	(let* ((path (concat (mu4e~get-attachment-dir) "/"))
-	       (attachdir (mu4e~view-request-attachments-dir path)))
-	  (dolist (num attachnums)
-	    (let* ((att (mu4e~view-get-attach msg num))
-		   (fname  (plist-get att :name))
-		   (index (plist-get att :index))
-		   (retry t)
-		   fpath)
-	      (while retry
-		(setq fpath (expand-file-name (concat attachdir fname) path))
-		(setq retry
-		      (and (file-exists-p fpath)
-			(not (y-or-n-p
-			       (mu4e-format "Overwrite '%s'?" fpath))))))
-	      (mu4e~proc-extract
-		'save (mu4e-message-field msg :docid)
-		index mu4e-decryption-policy fpath))))
+        (let* ((path (concat (mu4e~get-attachment-dir) "/"))
+               (attachdir (mu4e~view-request-attachments-dir path)))
+          (dolist (num attachnums)
+            (let* ((att (mu4e~view-get-attach msg num))
+                   (fname  (plist-get att :name))
+                   (index (plist-get att :index))
+                   (retry t)
+                   fpath)
+              (while retry
+                (setq fpath (expand-file-name (concat attachdir fname) path))
+                (setq retry
+                      (and (file-exists-p fpath)
+                           (not (y-or-n-p
+                                 (mu4e-format "Overwrite '%s'?" fpath))))))
+              (mu4e~proc-extract
+               'save (mu4e-message-field msg :docid)
+               index mu4e-decryption-policy fpath))))
       (dolist (num attachnums)
-	(mu4e-view-save-attachment-single msg num)))))
+        (mu4e-view-save-attachment-single msg num)))))
 
 (defalias #'mu4e-view-save-attachment #'mu4e-view-save-attachment-multi)
 
@@ -1350,15 +1350,15 @@ ATTNUM is nil ask for the attachment number."
   "Open MSG's attachment ATTACHNUM with CMD.
 If CMD is nil, ask user for it."
   (let* ((att (mu4e~view-get-attach msg attachnum))
-	 (ext (file-name-extension (plist-get att :name)))
-	 (cmd (or cmd
-		  (read-string
-		   (mu4e-format "Shell command to open it with: ")
-		   (assoc-default ext mu4e-view-attachment-assoc)
-		   'mu4e~view-open-with-hist)))
-	 (index (plist-get att :index)))
+         (ext (file-name-extension (plist-get att :name)))
+         (cmd (or cmd
+                  (read-string
+                   (mu4e-format "Shell command to open it with: ")
+                   (assoc-default ext mu4e-view-attachment-assoc)
+                   'mu4e~view-open-with-hist)))
+         (index (plist-get att :index)))
     (mu4e~view-temp-action
-      (mu4e-message-field msg :docid) index "open-with" cmd)))
+     (mu4e-message-field msg :docid) index "open-with" cmd)))
 
 (defvar mu4e~view-pipe-hist nil
   "History list for the pipe argument.")
@@ -1367,26 +1367,26 @@ If CMD is nil, ask user for it."
   "Feed MSG's attachment ATTACHNUM through pipe PIPECMD.
 If PIPECMD is nil, ask user for it."
   (let* ((att (mu4e~view-get-attach msg attachnum))
-	  (pipecmd (or pipecmd
-		     (read-string
-		       (mu4e-format "Pipe: ")
-		       nil
-		       'mu4e~view-pipe-hist)))
-	  (index (plist-get att :index)))
+         (pipecmd (or pipecmd
+                      (read-string
+                       (mu4e-format "Pipe: ")
+                       nil
+                       'mu4e~view-pipe-hist)))
+         (index (plist-get att :index)))
     (mu4e~view-temp-action
-      (mu4e-message-field msg :docid) index "pipe" pipecmd)))
+     (mu4e-message-field msg :docid) index "pipe" pipecmd)))
 
 (defun mu4e-view-open-attachment-emacs (msg attachnum)
   "Open MSG's attachment ATTACHNUM in the current emacs instance."
   (let* ((att (mu4e~view-get-attach msg attachnum))
-	  (index (plist-get att :index)))
+         (index (plist-get att :index)))
     (mu4e~view-temp-action (mu4e-message-field msg :docid) index "emacs")))
 
 (defun mu4e-view-import-attachment-diary (msg attachnum)
   "Open MSG's attachment ATTACHNUM in the current emacs instance."
   (interactive)
   (let* ((att (mu4e~view-get-attach msg attachnum))
-	  (index (plist-get att :index)))
+         (index (plist-get att :index)))
     (mu4e~view-temp-action (mu4e-message-field msg :docid) index "diary")))
 
 (defun mu4e-view-attachment-action (&optional msg)
@@ -1395,16 +1395,16 @@ If MSG is nil use the message returned by `message-at-point'.
 The actions are specified in `mu4e-view-attachment-actions'."
   (interactive)
   (let* ((msg (or msg (mu4e-message-at-point)))
-	 (actionfunc (mu4e-read-option
-		      "Action on attachment: "
-		      mu4e-view-attachment-actions))
-	 (multi (eq actionfunc 'mu4e-view-save-attachment-multi))
-	 (attnum (unless multi
-		   (mu4e~view-get-attach-num "Which attachment" msg multi))))
+         (actionfunc (mu4e-read-option
+                      "Action on attachment: "
+                      mu4e-view-attachment-actions))
+         (multi (eq actionfunc 'mu4e-view-save-attachment-multi))
+         (attnum (unless multi
+                   (mu4e~view-get-attach-num "Which attachment" msg multi))))
     (cond ((and actionfunc attnum)
-	   (funcall actionfunc msg attnum))
-	  ((and actionfunc multi)
-	   (funcall actionfunc msg)))))
+           (funcall actionfunc msg attnum))
+          ((and actionfunc multi)
+           (funcall actionfunc msg)))))
 
 ;; handler-function to handle the response we get from the server when we
 ;; want to do something with one of the attachments.
@@ -1412,33 +1412,33 @@ The actions are specified in `mu4e-view-attachment-actions'."
   "Handler function for doing things with temp files (ie.,
 attachments) in response to a (mu4e~proc-extract 'temp ... )."
   (cond
-    ((string= what "open-with")
-      ;; 'param' will be the program to open-with
-      (start-process "*mu4e-open-with-proc*" "*mu4e-open-with*" param path))
-    ((string= what "pipe")
-      ;; 'param' will be the pipe command, path the infile for this
-      (mu4e-process-file-through-pipe path param))
-    ;; if it's mu4e, it's some embedded message; 'param' may contain the docid
-    ;; of the parent message.
-    ((string= what "mu4e")
-      ;; remember the mapping path->docid, which maps the path of the embedded
-      ;; message to the docid of its parent
-      (puthash path docid mu4e~path-parent-docid-map)
-      (mu4e~proc-view-path path mu4e-view-show-images mu4e-decryption-policy))
-    ((string= what "emacs")
-      (find-file path)
-      ;; make the buffer read-only since it usually does not make
-      ;; sense to edit the temp buffer; use C-x C-q if you insist...
-      (setq buffer-read-only t))
-    ((string= what "diary")
-     (icalendar-import-file path diary-file))
-    (t (mu4e-error "Unsupported action %S" what))))
+   ((string= what "open-with")
+    ;; 'param' will be the program to open-with
+    (start-process "*mu4e-open-with-proc*" "*mu4e-open-with*" param path))
+   ((string= what "pipe")
+    ;; 'param' will be the pipe command, path the infile for this
+    (mu4e-process-file-through-pipe path param))
+   ;; if it's mu4e, it's some embedded message; 'param' may contain the docid
+   ;; of the parent message.
+   ((string= what "mu4e")
+    ;; remember the mapping path->docid, which maps the path of the embedded
+    ;; message to the docid of its parent
+    (puthash path docid mu4e~path-parent-docid-map)
+    (mu4e~proc-view-path path mu4e-view-show-images mu4e-decryption-policy))
+   ((string= what "emacs")
+    (find-file path)
+    ;; make the buffer read-only since it usually does not make
+    ;; sense to edit the temp buffer; use C-x C-q if you insist...
+    (setq buffer-read-only t))
+   ((string= what "diary")
+    (icalendar-import-file path diary-file))
+   (t (mu4e-error "Unsupported action %S" what))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun mu4e-view-mark-custom ()
   "Run some custom mark function."
   (mu4e~view-in-headers-context
-    (mu4e-headers-mark-custom)))
+   (mu4e-headers-mark-custom)))
 
 (defun mu4e~view-split-view-p ()
   "Return t if we're in split-view, nil otherwise."
@@ -1450,10 +1450,10 @@ If `mu4e-view-scroll-to-next' is non-nil, and we can't scroll-up
 anymore, go the next message."
   (interactive)
   (condition-case nil
-    (scroll-up)
+      (scroll-up)
     (error
-      (when mu4e-view-scroll-to-next
-	(mu4e-view-headers-next)))))
+     (when mu4e-view-scroll-to-next
+       (mu4e-view-headers-next)))))
 
 (defun mu4e-scroll-up ()
   "Scroll text of selected window up one line."
@@ -1471,7 +1471,7 @@ Otherwise, warn user that unmarking only works in the header
 list."
   (interactive)
   (if (mu4e~view-split-view-p)
-    (mu4e~view-in-headers-context (mu4e-mark-unmark-all))
+      (mu4e~view-in-headers-context (mu4e-mark-unmark-all))
     (mu4e-message "Unmarking needs to be done in the header list view")))
 
 (defun mu4e-view-unmark ()
@@ -1480,18 +1480,18 @@ Otherwise, warn user that unmarking only works in the header
 list."
   (interactive)
   (if (mu4e~view-split-view-p)
-    (mu4e-view-mark-for-unmark)
+      (mu4e-view-mark-for-unmark)
     (mu4e-message "Unmarking needs to be done in the header list view")))
 
 (defmacro mu4e~view-defun-mark-for (mark)
   "Define a function mu4e-view-mark-for-MARK."
   (let ((funcname (intern (format "mu4e-view-mark-for-%s" mark)))
-	(docstring (format "Mark the current message for %s." mark)))
+        (docstring (format "Mark the current message for %s." mark)))
     `(progn
        (defun ,funcname () ,docstring
-	 (interactive)
-	 (mu4e~view-in-headers-context
-	  (mu4e-headers-mark-and-next ',mark)))
+              (interactive)
+              (mu4e~view-in-headers-context
+               (mu4e-headers-mark-and-next ',mark)))
        (put ',funcname 'definition-name ',mark))))
 
 (mu4e~view-defun-mark-for move)
@@ -1510,7 +1510,7 @@ list."
   "Execute the marked actions."
   (interactive)
   (mu4e~view-in-headers-context
-    (mu4e-mark-execute-all)))
+   (mu4e-mark-execute-all)))
 
 (defun mu4e-view-mark-or-move-to-trash (&optional n)
   "See `mu4e-headers-mark-or-move-to-trash'."
@@ -1531,21 +1531,21 @@ string."
   (let* ((count (hash-table-count mu4e~view-link-map)) (def))
     (when (zerop count) (mu4e-error "No links for this message"))
     (if (not multi)
-      (if (= count 1)
-	(read-number (mu4e-format "%s: " prompt) 1)
-	(read-number (mu4e-format "%s (1-%d): " prompt count)))
+        (if (= count 1)
+            (read-number (mu4e-format "%s: " prompt) 1)
+          (read-number (mu4e-format "%s (1-%d): " prompt count)))
       (progn
-	(setq def (if (= count 1) "1" (format "1-%d" count)))
-	(read-string (mu4e-format "%s (default %s): " prompt def)
-	  nil nil def)))))
+        (setq def (if (= count 1) "1" (format "1-%d" count)))
+        (read-string (mu4e-format "%s (default %s): " prompt def)
+                     nil nil def)))))
 
 (defun mu4e-view-go-to-url (&optional multi)
   "Offer to go to url(s). If MULTI (prefix-argument) is nil, go to
 a single one, otherwise, offer to go to a range of urls."
   (interactive "P")
   (mu4e~view-handle-urls "URL to visit"
-    multi
-    (lambda (url) (mu4e~view-browse-url-from-binding url))))
+                         multi
+                         (lambda (url) (mu4e~view-browse-url-from-binding url))))
 
 (defun mu4e-view-save-url (&optional multi)
   "Offer to save urls(s) to the kill-ring. If
@@ -1553,9 +1553,9 @@ MULTI (prefix-argument) is nil, save a single one, otherwise, offer
 to save a range of URLs."
   (interactive "P")
   (mu4e~view-handle-urls "URL to save" multi
-    (lambda (url)
-      (kill-new url)
-      (mu4e-message "Saved %s to the kill-ring" url))))
+                         (lambda (url)
+                           (kill-new url)
+                           (mu4e-message "Saved %s to the kill-ring" url))))
 
 (defun mu4e-view-fetch-url (&optional multi)
   "Offer to fetch (download) urls(s). If MULTI (prefix-argument) is nil,
@@ -1563,18 +1563,18 @@ download a single one, otherwise, offer to fetch a range of
 URLs. The urls are fetched to `mu4e-attachment-dir'."
   (interactive "P")
   (mu4e~view-handle-urls "URL to fetch" multi
-    (lambda (url)
-      (let ((target (concat (mu4e~get-attachment-dir url) "/"
-		      (file-name-nondirectory url))))
-	(url-copy-file url target)
-      (mu4e-message "Fetched %s -> %s" url target)))))
+                         (lambda (url)
+                           (let ((target (concat (mu4e~get-attachment-dir url) "/"
+                                                 (file-name-nondirectory url))))
+                             (url-copy-file url target)
+                             (mu4e-message "Fetched %s -> %s" url target)))))
 
 (defun mu4e~view-handle-urls (prompt multi urlfunc)
   "If MULTI is nil, apply URLFUNC to a single uri, otherwise, apply
 it to a range of uris. PROMPT is the query to present to the user."
   (interactive "P")
   (if multi
-    (mu4e~view-handle-multi-urls prompt urlfunc)
+      (mu4e~view-handle-multi-urls prompt urlfunc)
     (mu4e~view-handle-single-url prompt urlfunc)))
 
 (defun mu4e~view-handle-single-url (prompt urlfunc &optional num)
@@ -1582,7 +1582,7 @@ it to a range of uris. PROMPT is the query to present to the user."
 user with PROMPT."
   (interactive)
   (let* ((num (or num (mu4e~view-get-urls-num prompt)))
-	 (url (gethash num mu4e~view-link-map)))
+         (url (gethash num mu4e~view-link-map)))
     (unless url (mu4e-warn "Invalid number for URL"))
     (funcall urlfunc url)))
 
@@ -1598,9 +1598,9 @@ Furthermore, there is a shortcut \"a\" which means all urls, but as
 this is the default, you may not need it."
   (interactive)
   (let* ((linkstr (mu4e~view-get-urls-num
-		      "URL number range (or 'a' for 'all')" t))
-	  (count (hash-table-count mu4e~view-link-map))
-	  (linknums (mu4e-split-ranges-to-numbers linkstr count)))
+                   "URL number range (or 'a' for 'all')" t))
+         (count (hash-table-count mu4e~view-link-map))
+         (linknums (mu4e-split-ranges-to-numbers linkstr count)))
     (dolist (num linknums)
       (mu4e~view-handle-single-url prompt urlfunc num))))
 
@@ -1617,15 +1617,15 @@ this is the default, you may not need it."
   "Display the raw contents of message at point in a new buffer."
   (interactive)
   (let ((path (mu4e-message-field-at-point :path))
-	 (buf (get-buffer-create mu4e~view-raw-buffer-name)))
+        (buf (get-buffer-create mu4e~view-raw-buffer-name)))
     (unless (and path (file-readable-p path))
       (mu4e-error "Not a readable file: %S" path))
     (with-current-buffer buf
       (let ((inhibit-read-only t))
-	(erase-buffer)
-	(insert-file-contents path)
-	(view-mode)
-	(goto-char (point-min))))
+        (erase-buffer)
+        (insert-file-contents path)
+        (view-mode)
+        (goto-char (point-min))))
     (switch-to-buffer buf)))
 
 (defun mu4e-view-pipe (cmd)
@@ -1642,26 +1642,26 @@ Then, display the results."
 If MSG is nil, use the message at point."
   (interactive)
   (let* ((msg (or msg (mu4e-message-at-point)))
-	  (path (mu4e-message-field msg :path))
-	  (cmd (format "%s verify --verbose %s %s"
-		 mu4e-mu-binary
-		 (shell-quote-argument path)
-		 (if mu4e-decryption-policy
-		     "--decrypt --use-agent"
-		     "")))
-	  (output (shell-command-to-string cmd))
-	    ;; create a new one
-	  (buf (get-buffer-create mu4e~verify-buffer-name))
-	  (win (or (get-buffer-window buf)
-		 (split-window-vertically (- (window-height) 6)))))
+         (path (mu4e-message-field msg :path))
+         (cmd (format "%s verify --verbose %s %s"
+                      mu4e-mu-binary
+                      (shell-quote-argument path)
+                      (if mu4e-decryption-policy
+                          "--decrypt --use-agent"
+                        "")))
+         (output (shell-command-to-string cmd))
+         ;; create a new one
+         (buf (get-buffer-create mu4e~verify-buffer-name))
+         (win (or (get-buffer-window buf)
+                  (split-window-vertically (- (window-height) 6)))))
     (with-selected-window win
       (let ((inhibit-read-only t))
-	;; (set-window-dedicated-p win t)
-	(switch-to-buffer buf)
-	(erase-buffer)
-	(insert output)
-	(goto-char (point-min))
-	(local-set-key "q" 'kill-buffer-and-window))
+        ;; (set-window-dedicated-p win t)
+        (switch-to-buffer buf)
+        (erase-buffer)
+        (insert output)
+        (goto-char (point-min))
+        (local-set-key "q" 'kill-buffer-and-window))
       (setq buffer-read-only t))
     (select-window win)))
 
@@ -1672,40 +1672,40 @@ other windows."
   (interactive)
   (if (eq mu4e-split-view 'single-window)
       (when (buffer-live-p (mu4e-get-view-buffer))
-	(kill-buffer (mu4e-get-view-buffer)))
+        (kill-buffer (mu4e-get-view-buffer)))
     (unless (eq major-mode 'mu4e-view-mode)
       (mu4e-error "Must be in mu4e-view-mode (%S)" major-mode))
     (let ((curbuf (current-buffer))
-	  (curwin (selected-window))
-	  (headers-win))
+          (curwin (selected-window))
+          (headers-win))
       (walk-windows
-	(lambda (win)
-	  ;; check whether the headers buffer window is visible
-	  (when (eq (mu4e-get-headers-buffer) (window-buffer win))
-	    (setq headers-win win))
-	  ;; and kill any _other_ (non-selected) window that shows the current
-	  ;; buffer
-	  (when
-	    (and
-	      (eq curbuf (window-buffer win)) ;; does win show curbuf?
-	      (not (eq curwin win))	    ;; but it's not the curwin?
-	      (not (one-window-p))) ;; and not the last one on the frame?
-	    (delete-window win))))  ;; delete it!
+       (lambda (win)
+         ;; check whether the headers buffer window is visible
+         (when (eq (mu4e-get-headers-buffer) (window-buffer win))
+           (setq headers-win win))
+         ;; and kill any _other_ (non-selected) window that shows the current
+         ;; buffer
+         (when
+             (and
+              (eq curbuf (window-buffer win)) ;; does win show curbuf?
+              (not (eq curwin win))         ;; but it's not the curwin?
+              (not (one-window-p))) ;; and not the last one on the frame?
+           (delete-window win))))  ;; delete it!
       ;; now, all *other* windows should be gone.
       ;; if the headers view is also visible, kill ourselves + window; otherwise
       ;; switch to the headers view
       (if (window-live-p headers-win)
-	;; headers are visible
-	(progn
-	  (kill-buffer-and-window) ;; kill the view win
-	  (setq mu4e~headers-view-win nil)
-	  (select-window headers-win)) ;; and switch to the headers win...
-	;; headers are not visible...
-	(progn
-	  (kill-buffer)
-	  (setq mu4e~headers-view-win nil)
-	  (when (buffer-live-p (mu4e-get-headers-buffer))
-	    (switch-to-buffer (mu4e-get-headers-buffer))))))))
+          ;; headers are visible
+          (progn
+            (kill-buffer-and-window) ;; kill the view win
+            (setq mu4e~headers-view-win nil)
+            (select-window headers-win)) ;; and switch to the headers win...
+        ;; headers are not visible...
+        (progn
+          (kill-buffer)
+          (setq mu4e~headers-view-win nil)
+          (when (buffer-live-p (mu4e-get-headers-buffer))
+            (switch-to-buffer (mu4e-get-headers-buffer))))))))
 
 (provide 'mu4e-view)
 ;;; mu4e-view ends here

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -905,12 +905,12 @@ FUNC should be a function taking two arguments:
   "Define the major-mode for the mu4e-view."
   (if mu4e-view-use-gnus
       (define-derived-mode mu4e-view-mode gnus-article-mode "mu4e:view"
+        "Major mode for viewing an e-mail message in mu4e, based on
+Gnus' article-mode."
         ;; remove some gnus stuff that does not apply
         (define-key mu4e-view-mode-map [menu-bar Treatment] nil)
         (define-key mu4e-view-mode-map [menu-bar Article] nil)
         (define-key mu4e-view-mode-map [menu-bar post] nil)
-        "Major mode for viewing an e-mail message in mu4e, based on
-Gnus' article-mode."
         (setq mu4e~view-buffer-name gnus-article-buffer)
         (mu4e~view-mode-body))
     (define-derived-mode mu4e-view-mode special-mode "mu4e:view"

--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -60,9 +60,9 @@ window, unless BACKGROUND (prefix-argument) is non-nil."
   "Quit the mu4e session."
   (interactive)
   (if mu4e-confirm-quit
-	  (when (y-or-n-p (mu4e-format "Are you sure you want to quit?"))
-		(mu4e~stop))
-	(mu4e~stop)))
+      (when (y-or-n-p (mu4e-format "Are you sure you want to quit?"))
+        (mu4e~stop))
+    (mu4e~stop)))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (provide 'mu4e)

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -2891,7 +2891,7 @@ Defining a new custom action comes down to writing an elisp-function to do the
 work. Functions that operate on messages receive a @var{msg} parameter, which
 corresponds to the message at point. Something like:
 @lisp
-  (defun my-action-func (msg)
+(defun my-action-func (msg)
   "Describe my message function."
   ;; do stuff
   )
@@ -2903,7 +2903,7 @@ corresponds to the message at point, and an @var{attachment-num}, which is the
 number of the attachment as seen in the message view. An attachment function
 looks like:
 @lisp
-  (defun my-attachment-action-func (msg attachment-num)
+(defun my-attachment-action-func (msg attachment-num)
   "Describe my attachment function."
   ;; do stuff
   )

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -2864,8 +2864,8 @@ edited. When you compose a totally new message, the @var{msg} parameter is
 @node Actions
 @chapter Actions
 
-@t{mu4e} lets you define custom actions for messages in the @ref{Headers view}
-and for both messages and attachments in the @ref{Message view}. Custom
+@t{mu4e} lets you define custom actions for messages in @ref{Headers view}
+and for both messages and attachments in @ref{Message view}. Custom
 actions allow you to easily extend @t{mu4e} for specific needs --- for example,
 marking messages as spam in a spam filter or applying an attachment with a
 source code patch.

--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -1,6 +1,4 @@
-;;; org-mu4e -- Support for links to mu4e messages/queries from within -*- lexical-binding: t -*-
-;;; org-mode, and for writing message in org-mode, sending them as
-;;; rich-text
+;;; org-mu4e -- support for links to mu4e messages and writing org-mode messages -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2012-2019 Dirk-Jan C. Binnema
 
@@ -25,6 +23,9 @@
 ;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+
+;; Support for links to mu4e messages/queries from within org-mode,
+;; and for writing message in org-mode, sending them as rich-text.
 
 ;;; Code:
 

--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -58,21 +58,21 @@
 (defun org~mu4e-mime-file (ext path id)
   "Create a file of type EXT at PATH with ID for an attachment."
   (format (concat "<#part type=\"%s\" filename=\"%s\" "
-      "disposition=inline id=\"<%s>\">\n<#/part>\n")
-    ext path id))
+                  "disposition=inline id=\"<%s>\">\n<#/part>\n")
+          ext path id))
 
 (defun org~mu4e-mime-multipart (plain html &optional images)
   "Create a multipart/alternative with PLAIN and HTML alternatives.
 If the html portion of the message includes IMAGES, wrap the html
 and images in a multipart/related part."
   (concat "<#multipart type=alternative><#part type=text/plain>"
-    plain
-    (when images "<#multipart type=related>")
-    "<#part type=text/html>"
-    html
-    images
-    (when images "<#/multipart>\n")
-    "<#/multipart>\n"))
+          plain
+          (when images "<#multipart type=related>")
+          "<#part type=text/html>"
+          html
+          images
+          (when images "<#/multipart>\n")
+          "<#/multipart>\n"))
 
 (defun org~mu4e-mime-replace-images (str current-file)
   "Replace images in html files STR in CURRENT-FILE with cid links."
@@ -90,7 +90,7 @@ and images in a multipart/related part."
                 (ext (file-name-extension path))
                 (id (replace-regexp-in-string "[\/\\\\]" "_" path)))
            (cl-pushnew (org~mu4e-mime-file
-                         (concat "image/" ext) path id)
+                        (concat "image/" ext) path id)
                        html-images
                        :test 'equal)
            id)))
@@ -102,36 +102,36 @@ and images in a multipart/related part."
   (unless (fboundp 'org-export-string-as)
     (mu4e-error "Required function 'org-export-string-as not found"))
   (let* ((begin
-       (save-excursion
-         (goto-char (point-min))
-         (search-forward mail-header-separator)))
-      (end (point-max))
-      (raw-body (buffer-substring begin end))
-      (tmp-file (make-temp-name (expand-file-name "mail"
-          temporary-file-directory)))
-      ;; because we probably don't want to skip part of our mail
-      (org-export-skip-text-before-1st-heading nil)
-      ;; because we probably don't want to export a huge style file
-      (org-export-htmlize-output-type 'inline-css)
-      ;; makes the replies with ">"s look nicer
-      (org-export-preserve-breaks t)
-      ;; dvipng for inline latex because MathJax doesn't work in mail
-      (org-export-with-LaTeX-fragments
-        (if (executable-find "dvipng") 'dvipng
-          (mu4e-message "Cannot find dvipng, ignore inline LaTeX") nil))
-      ;; to hold attachments for inline html images
-      (html-and-images
-        (org~mu4e-mime-replace-images
-                (org-export-string-as raw-body 'html t)
-    tmp-file))
-      (html-images (cdr html-and-images))
-      (html (car html-and-images)))
-      (delete-region begin end)
-      (save-excursion
-  (goto-char begin)
-  (newline)
-  (insert (org~mu4e-mime-multipart
-      raw-body html (mapconcat 'identity html-images "\n"))))))
+          (save-excursion
+            (goto-char (point-min))
+            (search-forward mail-header-separator)))
+         (end (point-max))
+         (raw-body (buffer-substring begin end))
+         (tmp-file (make-temp-name (expand-file-name "mail"
+                                                     temporary-file-directory)))
+         ;; because we probably don't want to skip part of our mail
+         (org-export-skip-text-before-1st-heading nil)
+         ;; because we probably don't want to export a huge style file
+         (org-export-htmlize-output-type 'inline-css)
+         ;; makes the replies with ">"s look nicer
+         (org-export-preserve-breaks t)
+         ;; dvipng for inline latex because MathJax doesn't work in mail
+         (org-export-with-LaTeX-fragments
+          (if (executable-find "dvipng") 'dvipng
+            (mu4e-message "Cannot find dvipng, ignore inline LaTeX") nil))
+         ;; to hold attachments for inline html images
+         (html-and-images
+          (org~mu4e-mime-replace-images
+           (org-export-string-as raw-body 'html t)
+           tmp-file))
+         (html-images (cdr html-and-images))
+         (html (car html-and-images)))
+    (delete-region begin end)
+    (save-excursion
+      (goto-char begin)
+      (newline)
+      (insert (org~mu4e-mime-multipart
+               raw-body html (mapconcat 'identity html-images "\n"))))))
 
 ;; next some functions to make the org/mu4e-compose-mode switch as smooth as
 ;; possible.
@@ -140,10 +140,10 @@ and images in a multipart/related part."
   (save-excursion
     (goto-char (point-min))
     (let* ((eoh (when (search-forward mail-header-separator)
-      (match-end 0)))
-      (olay (make-overlay (point-min) eoh)))
+                  (match-end 0)))
+           (olay (make-overlay (point-min) eoh)))
       (when olay
-  (overlay-put olay 'face 'font-lock-comment-face)))))
+        (overlay-put olay 'face 'font-lock-comment-face)))))
 
 (defun org~mu4e-mime-undecorate-headers ()
   "Don't make the headers visually distinctive.
@@ -151,7 +151,7 @@ and images in a multipart/related part."
   (save-excursion
     (goto-char (point-min))
     (let* ((eoh (when (search-forward mail-header-separator)
-      (match-end 0))))
+                  (match-end 0))))
       (remove-overlays (point-min) eoh))))
 
 (defvar org-mu4e-convert-to-html nil
@@ -171,34 +171,34 @@ rich-text version of what is assumed to be an org mode body."
 or org-mode (when in the body)."
   (interactive)
   (let* ((sepapoint
-     (save-excursion
-       (goto-char (point-min))
-       (search-forward-regexp mail-header-separator nil t))))
+          (save-excursion
+            (goto-char (point-min))
+            (search-forward-regexp mail-header-separator nil t))))
     ;; only do stuff when the sepapoint exist; note that after sending the
     ;; message, this function maybe called on a message with the sepapoint
     ;; stripped. This is why we don't use `message-point-in-header'.
     (when sepapoint
       (cond
-  ;; we're in the body, but in mu4e-compose-mode?
-  ;; if so, switch to org-mode
-  ((and (> (point) sepapoint) (eq major-mode 'mu4e-compose-mode))
-    (org-mode)
-    (add-hook 'before-save-hook
-      (lambda ()
-        (mu4e-error "Switch to mu4e-compose-mode (M-m) before saving"))
-      nil t)
-    (org~mu4e-mime-decorate-headers)
-    (local-set-key (kbd "M-m")
-      (lambda (keyseq)
-        (interactive "kEnter mu4e-compose-mode key sequence: ")
-        (let ((func (lookup-key mu4e-compose-mode-map keyseq)))
-    (if func (funcall func) (insert keyseq))))))
-  ;; we're in the headers, but in org-mode?
-  ;; if so, switch to mu4e-compose-mode
-  ((and (<= (point) sepapoint) (eq major-mode 'org-mode))
-          (org~mu4e-mime-undecorate-headers)
-    (mu4e-compose-mode)
-    (add-hook 'message-send-hook 'org~mu4e-mime-convert-to-html-maybe nil t)))
+       ;; we're in the body, but in mu4e-compose-mode?
+       ;; if so, switch to org-mode
+       ((and (> (point) sepapoint) (eq major-mode 'mu4e-compose-mode))
+        (org-mode)
+        (add-hook 'before-save-hook
+                  (lambda ()
+                    (mu4e-error "Switch to mu4e-compose-mode (M-m) before saving"))
+                  nil t)
+        (org~mu4e-mime-decorate-headers)
+        (local-set-key (kbd "M-m")
+                       (lambda (keyseq)
+                         (interactive "kEnter mu4e-compose-mode key sequence: ")
+                         (let ((func (lookup-key mu4e-compose-mode-map keyseq)))
+                           (if func (funcall func) (insert keyseq))))))
+       ;; we're in the headers, but in org-mode?
+       ;; if so, switch to mu4e-compose-mode
+       ((and (<= (point) sepapoint) (eq major-mode 'org-mode))
+        (org~mu4e-mime-undecorate-headers)
+        (mu4e-compose-mode)
+        (add-hook 'message-send-hook 'org~mu4e-mime-convert-to-html-maybe nil t)))
       ;; and add the hook
       (add-hook 'post-command-hook 'org~mu4e-mime-switch-headers-or-body t t))))
 
@@ -212,12 +212,12 @@ Edit the message body using org mode. DEPRECATED."
   ;; post-command-hook is set; hackish...but a buffer-local variable does not
   ;; seem to survive buffer switching
   (if (not (member 'org~mu4e-mime-switch-headers-or-body post-command-hook))
-    (progn
-      (org~mu4e-mime-switch-headers-or-body)
-      (mu4e-message
-  (concat
-    "org-mu4e-compose-org-mode enabled; "
-    "press M-m before issuing message-mode commands")))
+      (progn
+        (org~mu4e-mime-switch-headers-or-body)
+        (mu4e-message
+         (concat
+          "org-mu4e-compose-org-mode enabled; "
+          "press M-m before issuing message-mode commands")))
     (progn ;; otherwise, remove crap
       (remove-hook 'post-command-hook 'org~mu4e-mime-switch-headers-or-body t)
       (org~mu4e-mime-undecorate-headers) ;; shut off org-mode stuff


### PR DESCRIPTION
As mentioned in #1571 completely messes up indentation of Emacs lisp files.

The commit 173deff6a03bae1171e39ca8da916386ca9bbf67 ("editorconfig: Don't misconfigure indentation for Emacs lisp files") has more details.

In addition to removing the `.editorconfig` configuration this pr configures `.dir-locals.el` and then fixes the indentation.

And then it also fixes quite a few other assorted issues I ran into along the way.  Let me know if this does too much.  I can split this up into more pull-requests and explain in more details why I did what I did.