### PR TITLE
Use outline-minor-mode section headings

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -26,6 +26,7 @@
 ;; manual)
 
 ;;; Code:
+
 (require 'cl-lib)
 (require 'ido)
 
@@ -42,19 +43,17 @@
 (defvar mu4e-view-date-format)
 
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
+
 (defun mu4e-action-count-lines (msg)
   "Count the number of lines in the e-mail MSG.
 Works for headers view and message-view."
   (message "Number of lines: %s"
            (shell-command-to-string
             (concat "wc -l < " (shell-quote-argument (mu4e-message-field msg :path))))))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;;; UNNAMED
 
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defvar mu4e-msg2pdf
   (let ((exec-path (cons (concat mu4e-builddir "/toys/msg2pdf/") exec-path)))
     (locate-file "msg2pdf" exec-path exec-suffixes))
@@ -75,8 +74,8 @@ Works for the message view."
     (unless (and pdf (file-exists-p pdf))
       (mu4e-warn "Failed to create PDF file"))
     (find-file pdf)))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
+
+;;; UNNAMED
 
 (defun mu4e~action-header-to-html (msg field)
   "Convert the FIELD of MSG to an HTML string."
@@ -156,12 +155,9 @@ privacy aspects in `(mu4e) Displaying rich-text messages'."
     (mu4e-error "No xwidget support available"))
   (xwidget-webkit-browse-url
    (concat "file://" (mu4e~write-body-to-html msg)) t))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;;; UNNAMED
 
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defconst mu4e-text2speech-command "festival --tts"
   "Program that speaks out text it receives on standard input.")
 
@@ -173,11 +169,9 @@ privacy aspects in `(mu4e) Displaying rich-text messages'."
     (insert (mu4e-message-field msg :body-txt))
     (shell-command-on-region (point-min) (point-max)
                              mu4e-text2speech-command)))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;;; UNNAMED
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defvar mu4e-captured-message nil
   "The most recently captured message.")
 
@@ -187,18 +181,15 @@ Later, we can create an attachment based on this message with
 `mu4e-compose-attach-captured-message'."
   (setq mu4e-captured-message msg)
   (message "Message has been captured"))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;;; UNNAMED
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun mu4e-action-copy-message-file-path (msg)
   "Save the full path for the current MSG to the kill ring."
   (kill-new (mu4e-message-field msg :path)))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
+
 (defvar mu4e-org-contacts-file nil
   "File to store contact information for org-contacts.
 Needed by `mu4e-action-add-org-contact'.")
@@ -236,11 +227,8 @@ file where you store your org-contacts."
     (message "%S" org-capture-templates)
     (when (fboundp 'org-capture)
       (org-capture nil key))))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
 
 (defvar mu4e~patch-directory-history nil
   "History of directories we have applied patches to.")
@@ -280,11 +268,8 @@ bother asking for the git tree again (useful for bulk actions)."
                (if signoff "--signoff" "")
                (shell-quote-argument (mu4e-message-field msg :path)))))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
 
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defvar mu4e-action-tags-header "X-Keywords"
   "Header where tags are stored.
 Used by `mu4e-action-retag-message'. Make sure it is one of the

--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -383,7 +383,7 @@ the message."
          nil nil nil
          msgid (and (eq major-mode 'mu4e-view-mode)
                     (not (eq mu4e-split-view 'single-window))))))))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;;; _
 (provide 'mu4e-actions)
 ;;; mu4e-actions.el ends here

--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -1,12 +1,12 @@
 ;;; mu4e-actions.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2011-2019 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -943,5 +943,6 @@ is supplied, or Transient Mark mode is enabled and the mark is active."
 (define-key mu4e-compose-mode-map
   (vector 'remap 'end-of-buffer) 'mu4e-compose-goto-bottom)
 
+;;; _
 (provide 'mu4e-compose)
 ;;; mu4e-compose.el ends here

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -63,9 +63,9 @@
 ;;
 ;;   c) this is handled in our handler for the `sent'-message from the backend
 ;;   (`mu4e-sent-handler')
-;;
 
 ;;; Code:
+
 (require 'cl-lib)
 (require 'message)
 (require 'mail-parse)
@@ -80,8 +80,8 @@
 (require 'mu4e-draft)
 (require 'mu4e-context)
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Composing / Sending messages
+;;; Composing / Sending messages
+
 (defgroup mu4e-compose nil
   "Customizations for composing/sending messages."
   :group 'mu4e)
@@ -203,7 +203,7 @@ place to do that."
   "The compose-type for this buffer.
 This is a symbol, `new', `forward', `reply' or `edit'.")
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
 
 (defun mu4e-compose-attach-message (msg)
   "Insert message MSG as an attachment."
@@ -224,7 +224,7 @@ Messages are captured with `mu4e-action-capture-message'."
     (mu4e-warn "No message has been captured"))
   (mu4e-compose-attach-message mu4e-captured-message))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
 
 ;; 'fcc' refers to saving a copy of a sent message to a certain folder. that's
 ;; what these 'Sent mail' folders are for!
@@ -321,9 +321,11 @@ Message-ID."
                 ;; update the file on disk -- ie., without the separator
                 (mu4e~proc-add (buffer-file-name)))) nil t))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; address completion; inspired by org-contacts.el and
+;;; address completion
+
+;; inspired by org-contacts.el and
 ;; https://github.com/nordlow/elisp/blob/master/mine/completion-styles-cycle.el
+
 (defun mu4e~compose-complete-handler (str pred action)
   "Complete address STR with predication PRED for ACTION."
   (cond
@@ -374,7 +376,8 @@ removing the In-Reply-To header."
   (unless (message-fetch-field "in-reply-to")
     (message-remove-header "References")))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
+
 (defvar mu4e-compose-mode-map nil
   "Keymap for \"*mu4e-compose*\" buffers.")
 (unless mu4e-compose-mode-map
@@ -814,7 +817,7 @@ draft message."
   (mu4e-compose 'new))
 
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
 ;; mu4e-compose-func and mu4e-send-func are wrappers so we can set ourselves
 ;; as default emacs mailer (define-mail-user-agent etc.)
 
@@ -900,7 +903,7 @@ buffer buried."
   "Return the `mu4e-user-agent' symbol."
   'mu4e-user-agent)
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
 
 (defun mu4e-compose-goto-top (&optional arg)
   "Go to the beginning of the message or buffer.

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -1,12 +1,12 @@
 ;;; mu4e-compose.el -- part of mu4e, the mu mail user agent for emacs -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2011-2020 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -24,6 +24,9 @@
 
 ;; A mu4e 'context' is a set of variable-settings and functions, which can be
 ;; used e.g. to switch between accounts.
+
+;;; Code:
+
 (require 'cl-lib)
 (require 'mu4e-utils)
 

--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -280,5 +280,6 @@ match, POLICY determines what to do:
                           (mu4e~context-ask-user "Select context: ")))
          (otherwise nil))))))
 
+;;; _
 (provide 'mu4e-context)
 ;;; mu4e-context.el ends here

--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -281,3 +281,4 @@ match, POLICY determines what to do:
          (otherwise nil))))))
 
 (provide 'mu4e-context)
+;;; mu4e-context.el ends here

--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -1,12 +1,12 @@
 ;;; mu4e-context.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2015-2020 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-contrib.el
+++ b/mu4e/mu4e-contrib.el
@@ -20,6 +20,9 @@
 ;;; Commentary:
 
 ;; Some user-contributed functions for mu4e
+
+;;; Code:
+
 (require 'mu4e-headers)
 (require 'mu4e-view)
 (require 'bookmark)

--- a/mu4e/mu4e-contrib.el
+++ b/mu4e/mu4e-contrib.el
@@ -219,3 +219,4 @@ buffers found, compose a new message and then attach the file."
 ;;; end of eshell functions
 
 (provide 'mu4e-contrib)
+;;; mu4e-contrib.el ends here

--- a/mu4e/mu4e-contrib.el
+++ b/mu4e/mu4e-contrib.el
@@ -1,9 +1,9 @@
 ;;; mu4e-contrib.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2013-2020 Dirk-Jan C. Binnema
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-contrib.el
+++ b/mu4e/mu4e-contrib.el
@@ -31,6 +31,8 @@
 ;; Contributed by sabof
 (defvar bookmark-make-record-function)
 
+;;; Various simple commands
+
 (defun mu4e-headers-mark-all-unread-read ()
   "Put a ! \(read) mark on all visible unread messages."
   (interactive)
@@ -45,8 +47,6 @@
   (mu4e-headers-mark-all-unread-read)
   (mu4e-mark-execute-all t))
 
-;;;
-
 (defun mu4e-headers-mark-all ()
   "Mark all messages within current query results and ask user to execute which action."
   (interactive)
@@ -54,8 +54,6 @@
    (cons 'something nil)
    (lambda (_msg _param) t))
   (mu4e-mark-execute-all))
-
-;;;
 
 ;;; Bookmark handlers
 ;;
@@ -109,13 +107,13 @@ BOOKMARK is a bookmark name or a bookmark record."
                            ,(bookmark-get-bookmark-record bmk))))
                       bookmark))))
 
-
-
-;;; handling spam with Bogofilter with possibility to define it for SpamAssassin
-;;; contributed by Gour
-
-;;  to add the actions to the menu, you can use something like:
-
+;;; Bogofilter/SpamAssassin
+;;
+;; Support for handling spam with Bogofilter with the possibility
+;; to define it for SpamAssassin, contributed by Gour.
+;;
+;; To add the actions to the menu, you can use something like:
+;;
 ;; (add-to-list 'mu4e-headers-actions
 ;;              '("sMark as spam" . mu4e-register-msg-as-spam) t)
 ;; (add-to-list 'mu4e-headers-actions
@@ -166,11 +164,12 @@ For example for bogofile, use \"/usr/bin/bogofilter -Sn < %s\"")
     (shell-command command))
   (mu4e-view-mark-for-something))
 
-;;; end of spam-filtering functions
+;;; Eshell functions
+;;
+;; Code for `gnus-dired-attached' modified to run from eshell,
+;; allowing files to be attached to an email via mu4e using the
+;; eshell.  Does not depend on gnus.
 
-;;; eshell functions
-;; Code for 'gnus-dired-attached' modified to run from eshell, allowing files to
-;; be attached to an email via mu4e using the eshell. Does not depend on gnus.
 (defun eshell/mu4e-attach (&rest args)
   "Attach files to a mu4e message using eshell. If no mu4e
 buffers found, compose a new message and then attach the file."

--- a/mu4e/mu4e-contrib.el
+++ b/mu4e/mu4e-contrib.el
@@ -216,7 +216,7 @@ buffers found, compose a new message and then attach the file."
                    (setq files-to-attach (cdr files-to-attach)))
                  (message "Attached file(s) %s" files-str))
         (message "No buffer to attach file to.")))))
-;;; end of eshell functions
 
+;;; _
 (provide 'mu4e-contrib)
 ;;; mu4e-contrib.el ends here

--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -602,6 +602,6 @@ will be created from either `mu4e~draft-reply-construct', or
     (unless mu4e~draft-drafts-folder
       (mu4e-error "Failed to determine drafts folder"))))
 
-
+;;; _
 (provide 'mu4e-draft)
 ;;; mu4e-draft.el ends here

--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -31,10 +31,8 @@
 (require 'mu4e-utils)
 (require 'mu4e-message)
 (require 'message) ;; mail-header-separator
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Options
 
 (defcustom mu4e-compose-dont-reply-to-self nil
   "If non-nil, don't include self.
@@ -74,6 +72,8 @@ mu4e-specific version of `message-signature'."
   "Whether to compose messages in a new frame."
   :type 'boolean
   :group 'mu4e-compose)
+
+;;; UNNAMED
 
 (defvar mu4e-user-agent-string
   (format "mu4e %s; emacs %s" mu4e-mu-version emacs-version)
@@ -145,8 +145,7 @@ References. If both are empty, return nil."
     (mapconcat (lambda (id) (format "<%s>" id)) refs " ")))
 
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; determine the recipient fields for new messages
+;;; Determine the recipient fields for new messages
 
 (defun mu4e~draft-recipients-list-to-string (lst)
   "Convert a lst LST of address cells into a string.
@@ -271,9 +270,10 @@ message. Return nil if there are no recipients for the particular field."
       (mu4e-error "Unsupported field")))))
 
 ;;; RFC2822 handling of phrases in mail-addresses
-;;; The optional display-name contains a phrase, it sits before the angle-addr
-;;; as specified in RFC2822 for email-addresses in header fields.
-;;; contributed by jhelberg
+;;
+;; The optional display-name contains a phrase, it sits before the
+;; angle-addr as specified in RFC2822 for email-addresses in header
+;; fields.  Contributed by jhelberg.
 
 (defun mu4e~rfc822-phrase-type (ph)
   "Return an atom or quoted-string for the phrase PH.
@@ -317,7 +317,8 @@ This is based on the variable `user-full-name' and
       (format "%s" user-mail-address))))
 
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
+
 (defun mu4e~draft-insert-mail-header-separator ()
   "Insert `mail-header-separator' in the first empty line of the message.
 `message-mode' needs this line to know where the headers end and

--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -26,7 +26,7 @@
 ;; one-line descriptions of emails, aka 'headers' (not to be confused with
 ;; headers like 'To:' or 'Subject:')
 
-;; Code:
+;;; Code:
 (require 'cl-lib)
 (require 'fringe)
 (require 'hl-line)

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1892,6 +1892,6 @@ other windows."
       (kill-buffer)
       (mu4e~main-view))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; _
 (provide 'mu4e-headers)
 ;;; mu4e-headers.el ends here

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1894,3 +1894,4 @@ other windows."
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (provide 'mu4e-headers)
+;;; mu4e-headers.el ends here

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -27,6 +27,7 @@
 ;; headers like 'To:' or 'Subject:')
 
 ;;; Code:
+
 (require 'cl-lib)
 (require 'fringe)
 (require 'hl-line)
@@ -44,7 +45,8 @@
 (declare-function mu4e-view       "mu4e-view")
 (declare-function mu4e~main-view  "mu4e-main")
 
-;; the headers view
+;;; Options
+
 (defgroup mu4e-headers nil
   "Settings for the headers view."
   :group 'mu4e)
@@ -217,6 +219,8 @@ but also manually invoked searches."
   :type 'hook
   :group 'mu4e-headers)
 
+;;; Public variables
+
 (defvar mu4e-headers-sort-field :date
   "Field to sort the headers by. Must be a symbol,
 one of: `:date', `:subject', `:size', `:prio', `:from', `:to.',
@@ -225,6 +229,8 @@ one of: `:date', `:subject', `:size', `:prio', `:from', `:to.',
 (defvar mu4e-headers-sort-direction 'descending
   "Direction to sort by; a symbol either `descending' (sorting
   Z->A) or `ascending' (sorting A->Z).")
+
+;;;; Fancy marks
 
 ;; marks for headers of the form; each is a cons-cell (basic . fancy)
 ;; each of which is basic ascii char and something fancy, respectively
@@ -240,7 +246,8 @@ one of: `:date', `:subject', `:size', `:prio', `:from', `:to.',
 (defvar mu4e-headers-signed-mark    '("s" . "☡") "Signed.")
 (defvar mu4e-headers-unread-mark    '("u" . "⎕") "Unread.")
 
-;; thread prefix marks
+;;;; Graph drawing
+
 (defvar mu4e-headers-thread-child-prefix '("├>" . "┣▶ ")
   "Prefix for messages in sub threads that do have a following sibling.")
 
@@ -265,6 +272,8 @@ This prefix should have the same length as `mu4e-headers-thread-connection-prefi
 
 (defvar mu4e-headers-thread-duplicate-prefix '("=" . "≡ ")
   "Prefix for duplicate messages.")
+
+;;;; Various
 
 (defvar mu4e-headers-actions
   '( ("capture message"  . mu4e-action-capture-message)
@@ -304,9 +313,7 @@ PREDICATE-FUNC as PARAM. This is useful for getting user-input.")
   "Whether to show all results.
 If this is nil show results up to `mu4e-headers-results-limit')")
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;;;; internal variables/constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Internal variables/constants
 
 ;; docid cookies
 (defconst mu4e~headers-docid-pre "\376"
@@ -330,7 +337,8 @@ followed by the docid, followed by `mu4e~headers-docid-post'.")
      ("to"      . :to))
   "List of cells describing the various sort-options.
 In the format needed for `mu4e-read-option'.")
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; UNNAMED
 
 (defun mu4e~headers-clear (&optional msg)
   "Clear the header buffer and related data structures."
@@ -343,9 +351,8 @@ In the format needed for `mu4e-read-option'.")
           (goto-char (point-min))
           (insert (propertize msg 'face 'mu4e-system-face 'intangible t)))))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; handler functions
-;;
+;;; Handler functions
+
 ;; next are a bunch of handler functions; those will be called from mu4e~proc in
 ;; response to output from the server process
 
@@ -428,8 +435,9 @@ If SKIP-HOOK is absent or nil, `mu4e-message-changed-hook' will be invoked."
   (unless skip-hook
     (run-hooks 'mu4e-message-changed-hook)))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;;; UNNAMED
+
 (defun mu4e~headers-contact-str (contacts)
   "Turn the list of contacts CONTACTS (with elements (NAME . EMAIL)
 into a string."
@@ -438,7 +446,8 @@ into a string."
      (let ((name (car ct)) (email (cdr ct)))
        (or name email "?"))) contacts ", "))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
+
 (defun mu4e~headers-thread-prefix-map (type)
   "Return the thread prefix based on the symbol TYPE."
   (let ((get-prefix
@@ -454,13 +463,11 @@ into a string."
       ('duplicate     (funcall get-prefix mu4e-headers-thread-duplicate-prefix))
       (t              "?"))))
 
-;;;; headers in the buffer are prefixed by an invisible string with the docid
-;;;; followed by an EOT ('end-of-transmission', \004, ^D) non-printable ascii
-;;;; character. this string also has a text-property with the docid. the former
-;;;; is used for quickly finding a certain header, the latter for retrieving the
-;;;; docid at point without string matching etc.
-
-
+;; headers in the buffer are prefixed by an invisible string with the docid
+;; followed by an EOT ('end-of-transmission', \004, ^D) non-printable ascii
+;; character. this string also has a text-property with the docid. the former
+;; is used for quickly finding a certain header, the latter for retrieving the
+;; docid at point without string matching etc.
 
 (defun mu4e~headers-docid-pos (docid)
   "Return the pos of the beginning of the line with the header with
@@ -596,7 +603,8 @@ while our display may be different)."
                         ('signed    (funcall get-prefix mu4e-headers-signed-mark))
                         ('unread    (funcall get-prefix mu4e-headers-unread-mark)))))))
     str))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; UNNAMED
 
 (defconst mu4e-headers-from-or-to-prefix '("" . "To ")
   "Prefix for the :from-or-to field.
@@ -795,9 +803,10 @@ after the end of the search results."
 
     ;; run-hooks
     (run-hooks 'mu4e-headers-found-hook)))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
+;;; UNNAMED
+
 (defmacro mu4e~headers-defun-mark-for (mark)
   "Define a function mu4e~headers-mark-MARK."
   (let ((funcname (intern (format "mu4e-headers-mark-for-%s" mark)))
@@ -821,7 +830,8 @@ after the end of the search results."
 (mu4e~headers-defun-mark-for unread)
 (mu4e~headers-defun-mark-for action)
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
+
 (defvar mu4e-move-to-trash-patterns '()
   "List of regexps to match for moving to trash instead of flagging them.
 This is particularly useful for mailboxes that don't use the
@@ -844,7 +854,8 @@ Also see `mu4e-view-mark-or-move-to-trash'."
                              mu4e-trash-folder))
       (mu4e-headers-next))))
 
-;;; headers-mode and mode-map ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Headers-mode and mode-map
+
 (defvar mu4e-headers-mode-map nil
   "Keymap for *mu4e-headers* buffers.")
 (unless mu4e-headers-mode-map
@@ -930,7 +941,6 @@ Also see `mu4e-view-mark-or-move-to-trash'."
 
           (define-key map "U" 'mu4e-mark-unmark-all)
           (define-key map "x" 'mu4e-mark-execute-all)
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
           (define-key map "a" 'mu4e-headers-action)
 
@@ -1111,8 +1121,8 @@ no user-interaction ongoing."
   (mu4e~mark-initialize) ;; initialize the marking subsystem
   (hl-line-mode 1))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; highlighting
+;;; Highlighting
+
 (defvar mu4e~highlighted-docid nil
   "The highlighted docid")
 
@@ -1130,7 +1140,8 @@ Also, unhighlight any previously highlighted headers."
         (hl-line-highlight)))
     (setq mu4e~highlighted-docid docid)))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
+
 (defun mu4e~headers-select-window ()
   "When there is a visible window for the headers buffer, make sure
 to select it. This is needed when adding new headers, otherwise
@@ -1147,7 +1158,8 @@ message plist, or nil if not found."
        (when (and this-msgid (string= msgid this-msgid))
          msg)))))
 
-;;;; markers mark headers for
+;;; UNNAMED markers mark headers for
+
 (defun mu4e~headers-mark (docid mark)
   "(Visually) mark the header for DOCID with character MARK."
   (with-current-buffer (mu4e-get-headers-buffer)
@@ -1198,7 +1210,8 @@ docid is not found."
       (unless ignore-missing
         (mu4e-error "Cannot find message with docid %S" docid)))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
+
 (defcustom mu4e-query-rewrite-function 'identity
   "Function that takes a search expression string, and returns a
   possibly changed search expression string.
@@ -1296,8 +1309,7 @@ of `mu4e-split-view', and return a window for the message view."
                   (t ;; no splitting; just use the currently selected one
                    (selected-window)))))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; search-based marking
+;;; Search-based marking
 
 (defun mu4e-headers-for-each (func)
   "Call FUNC for each header, moving point to the header.
@@ -1459,10 +1471,10 @@ descendants."
   (if markpair (mu4e-headers-mark-thread t markpair)
     (let ((current-prefix-arg t))
       (call-interactively 'mu4e-headers-mark-thread))))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
-;;; the query past / present / future ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; The query past / present / future
+
 (defvar mu4e~headers-query-past nil
   "Stack of queries before the present one.")
 (defvar mu4e~headers-query-future nil
@@ -1505,10 +1517,10 @@ or `past'."
      (unless mu4e~headers-query-future
        (mu4e-warn "No more next queries"))
      (pop mu4e~headers-query-future))))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
-;;; interactive functions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Interactive functions
+
 (defvar mu4e~headers-search-hist nil
   "History list of searches.")
 

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1,12 +1,12 @@
 ;;; mu4e-headers.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2011-2020 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-icalendar.el
+++ b/mu4e/mu4e-icalendar.el
@@ -1,5 +1,5 @@
 ;;; mu4e-icalendar.el --- reply to iCalendar meeting requests (part of mu4e)  -*- lexical-binding: t; -*- -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2019- Christophe Troestler
 
 ;; Author: Christophe Troestler <Christophe.Troestler@umons.ac.be>
@@ -8,7 +8,7 @@
 ;; Version: 0.0
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-icalendar.el
+++ b/mu4e/mu4e-icalendar.el
@@ -184,6 +184,6 @@ given in the doc of `gnus-icalendar-event-reply-from-buffer'."
         (insert beg-date " " end-time " End of: " txt "\n"))
       (write-region (point-min) (point-max) filename t))))
 
-
+;;; _
 (provide 'mu4e-icalendar)
 ;;; mu4e-icalendar.el ends here

--- a/mu4e/mu4e-lists.el
+++ b/mu4e/mu4e-lists.el
@@ -97,5 +97,6 @@ be used as the shortname."
   :group 'mu4e-headers
   :type '(repeat (regexp)))
 
+;;; _
 (provide 'mu4e-lists)
 ;;; mu4e-lists.el ends here

--- a/mu4e/mu4e-lists.el
+++ b/mu4e/mu4e-lists.el
@@ -25,6 +25,7 @@
 ;; In this file, we create a table of list-id -> shortname for mailing lists.
 ;; The shortname (friendly) should a at most 8 characters, camel-case
 
+;;; Code:
 
 (defvar mu4e~mailing-lists
   '( ("bbdb-info.lists.sourceforge.net"                       . "BBDB")

--- a/mu4e/mu4e-lists.el
+++ b/mu4e/mu4e-lists.el
@@ -1,12 +1,12 @@
 ;;; mu4e-lists.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2011-2016 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-lists.el
+++ b/mu4e/mu4e-lists.el
@@ -98,3 +98,4 @@ be used as the shortname."
   :type '(repeat (regexp)))
 
 (provide 'mu4e-lists)
+;;; mu4e-lists.el ends here

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -287,5 +287,6 @@ clicked."
           (sit-for 1)
           (mu4e~main-menu))))))
 
+;;; _
 (provide 'mu4e-main)
 ;;; mu4e-main.el ends here

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -23,12 +23,15 @@
 ;;; Commentary:
 
 ;;; Code:
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (require 'smtpmail)      ;; the queueing stuff (silence elint)
 (require 'mu4e-utils)    ;; utility functions
 (require 'mu4e-context)  ;; the context
 (require 'mu4e-vars)  ;; the context
 (require 'cl-lib)
+
+
+;;; Mode
 
 (defconst mu4e~main-buffer-name " *mu4e-main*"
   "*internal* Name of the mu4e main view buffer.")
@@ -152,8 +155,7 @@ clicked."
      "")
    "\n"))
 
-;; NEW
-;; This is the old `mu4e~main-view' function but without
+;; NEW This is the old `mu4e~main-view' function but without
 ;; buffer switching at the end.
 (defun mu4e~main-view-real (_ignore-auto _noconfirm)
   (let ((buf (get-buffer-create mu4e~main-buffer-name))
@@ -241,10 +243,9 @@ clicked."
     (goto-char (point-min)))
   (add-to-list 'global-mode-string '(:eval (mu4e-context-label))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Interactive functions
-;; NEW
-;; Toggle mail sending mode without switching
+;;; Commands
+
+;; NEW Toggle mail sending mode without switching
 (defun mu4e~main-toggle-mail-sending-mode ()
   "Toggle sending mail mode, either queued or direct."
   (interactive)

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -1,12 +1,12 @@
 ;;; mu4e-main.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2011-2020 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -288,3 +288,4 @@ clicked."
           (mu4e~main-menu))))))
 
 (provide 'mu4e-main)
+;;; mu4e-main.el ends here

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -26,6 +26,7 @@
 ;; currently in the headers buffer.
 
 ;;; Code:
+
 (require 'cl-lib)
 (require 'mu4e-proc)
 (require 'mu4e-utils)
@@ -35,6 +36,8 @@
 (declare-function mu4e~headers-mark "mu4e-headers")
 (declare-function mu4e~headers-goto-docid "mu4e-headers")
 (declare-function mu4e-headers-next "mu4e-headers")
+
+;;; UNNAMED
 
 (defcustom mu4e-headers-leave-behavior 'ask
   "What to do when user leaves the headers view.
@@ -63,7 +66,8 @@ message, showing the target makes this quite a bit slower (showing
 the target uses an Emacs feature called 'overlays', which aren't
 particularly fast).")
 
-;;; insert stuff;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Insert stuff
+
 (defvar mu4e~mark-map nil
   "Contains a mapping of docid->markinfo.
 When a message is marked, the information is added here. markinfo
@@ -432,7 +436,8 @@ If NO-CONFIRMATION is non-nil, don't ask user for confirmation."
 (defun mu4e-mark-docid-marked-p (docid)
   "Is the given DOCID marked?"
   (when (gethash docid mu4e~mark-map) t))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; UNNAMED
 
 (defun mu4e-mark-marks-num ()
   "Return the number of mark-instances in the current buffer."

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -1,12 +1,12 @@
 ;;; mu4e-mark.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2011-2020 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -459,5 +459,6 @@ action', return nil means 'don't do anything'."
        (when (eq what 'apply)
          (mu4e-mark-execute-all t))))))
 
+;;; _
 (provide 'mu4e-mark)
 ;;; mu4e-mark.el ends here

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -344,5 +344,6 @@ Emacs. Based on code by Titus von der Malsburg."
        (call-process-shell-command mu4e-html2text-command tmp-file t t)
        (delete-file tmp-file))) msg))
 
+;;; _
 (provide 'mu4e-message)
 ;;; mu4e-message.el ends here

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -1,12 +1,12 @@
 ;;; mu4e-message.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2012-2020 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -25,6 +25,7 @@
 ;; Functions to get data from mu4e-message plist structure
 
 ;;; Code:
+
 (require 'cl-lib)
 (require 'mu4e-vars)
 (require 'mu4e-utils)
@@ -83,7 +84,8 @@ message-plist and the text, which is the plain-text version,
 ossibly converted from html and/or transformed by earlier rewrite
 functions.")
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; UNNAMED
+
 (defsubst mu4e-message-field-raw (msg field)
   "Retrieve FIELD from message plist MSG.
 FIELD is one of :from, :to, :cc, :bcc, :subject, :data,
@@ -307,7 +309,8 @@ A part would look something like:
 Eiter in the headers buffer or the view buffer. Field is a
 symbol, see `mu4e-header-info'."
   (plist-get (mu4e-message-at-point) field))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; UNNAMED
 
 (defun mu4e~html2text-wrapper (func msg)
   "Apply FUNC on a temporary buffer with html from MSG.

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -345,4 +345,4 @@ Emacs. Based on code by Titus von der Malsburg."
        (delete-file tmp-file))) msg))
 
 (provide 'mu4e-message)
-;;; mu4e-message ends here
+;;; mu4e-message.el ends here

--- a/mu4e/mu4e-org.el
+++ b/mu4e/mu4e-org.el
@@ -151,6 +151,7 @@ it with org)."
   (org-capture))
 
 (make-obsolete 'org-mu4e-store-and-capture 'org-mu4e-store-and-capture "1.3.6")
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; _
 (provide 'mu4e-org)
 ;;; mu4e-org.el ends here

--- a/mu4e/mu4e-org.el
+++ b/mu4e/mu4e-org.el
@@ -24,9 +24,10 @@
 
 ;;; Commentary:
 
+;; The expect version here is org 8.x.
+
 ;;; Code:
 
-;; The expect version here is org 8.x
 (require 'org)
 
 (defgroup mu4e-org nil

--- a/mu4e/mu4e-org.el
+++ b/mu4e/mu4e-org.el
@@ -1,5 +1,5 @@
 ;;; mu4e-org -- Org-links to mu4e messages/queries -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2012-2020 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
@@ -8,7 +8,7 @@
 ;; Version: 0.0
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of 1the License, or

--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -488,5 +488,6 @@ result will be delivered to the function registered as
                   :extract-images ,images
                   :extract-encrypted ,decrypt)))
 
+;;; _
 (provide 'mu4e-proc)
 ;;; mu4e-proc.el ends here

--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -1,12 +1,12 @@
 ;;; mu4e-proc.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2011-2019 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -23,12 +23,12 @@
 ;;; Commentary:
 
 ;;; Code:
+
 (require 'mu4e-vars)
 (require 'mu4e-utils)
 (require 'mu4e-meta)
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; internal vars
+;;; Internal vars
 
 (defvar mu4e~proc-buf nil
   "Buffer (string) for data received from the backend.")
@@ -48,6 +48,8 @@
   (concat mu4e~cookie-pre "\\([[:xdigit:]]+\\)" mu4e~cookie-post)
   "Regular expression matching the length cookie.
 Match 1 will be the length (in hex).")
+
+;;; Functions
 
 (defun mu4e~proc-running-p  ()
   "Whether the mu process is running."

--- a/mu4e/mu4e-speedbar.el
+++ b/mu4e/mu4e-speedbar.el
@@ -129,5 +129,6 @@
 (defun mu4e-headers-speedbar-buttons (buffer) (mu4e-speedbar-buttons buffer))
 (defun mu4e-view-speedbar-buttons (buffer) (mu4e-speedbar-buttons buffer))
 
+;;; _
 (provide 'mu4e-speedbar)
 ;;; mu4e-speedbar.el ends here

--- a/mu4e/mu4e-speedbar.el
+++ b/mu4e/mu4e-speedbar.el
@@ -1,5 +1,5 @@
 ;;; mu4e-speedbar --- Speedbar support for mu4e -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2012-2020 Antono Vasiljev, Dirk-Jan C. Binnema
 
 ;; Author: Antono Vasiljev <self@antono.info>
@@ -7,7 +7,7 @@
 ;; Keywords: file, tags, tools
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation; either version 3, or (at your option)

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -1249,4 +1249,4 @@ string will be shortened to fit if its length exceeds
     (nreverse buffers)))
 
 (provide 'mu4e-utils)
-;;; End of mu4e-utils.el
+;;; mu4e-utils.el ends here

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -1,12 +1,12 @@
 ;;; mu4e-utils.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2011-2020 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -1248,5 +1248,6 @@ string will be shortened to fit if its length exceeds
           (push (buffer-name buffer) buffers))))
     (nreverse buffers)))
 
+;;; _
 (provide 'mu4e-utils)
 ;;; mu4e-utils.el ends here

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -901,6 +901,9 @@ argument, and returns a string. See the default value of
 (defconst mu4e~headers-buffer-name "*mu4e-headers*"
   "Name of the buffer for message headers.")
 
+(defvar mu4e~headers-last-query nil
+  "The present (most recent) query.")
+
 ;;;; View
 
 (defconst mu4e~view-buffer-name "*mu4e-view*"
@@ -916,9 +919,6 @@ argument, and returns a string. See the default value of
 We need to keep this information around to quickly re-sort
 subsets of the contacts in the completions function in
 mu4e-compose.")
-
-(defvar mu4e~headers-last-query nil
-  "The present (most recent) query.")
 
 (defvar mu4e~server-props nil
   "Information  we receive from the mu4e server process \(in the 'pong-handler').")

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -1,12 +1,12 @@
 ;;; mu4e-vars.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2011-2020 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -1021,8 +1021,7 @@ sexp received from the server process.")
 
 (defvar mu4e-temp-func 'mu4e~view-temp-handler
   "A function called for each (:temp <file> <cookie>) sexp.")
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; _
 (provide 'mu4e-vars)
 ;;; mu4e-vars.el ends here

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -24,12 +24,12 @@
 
 ;;; Code:
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Customization
 (require 'mu4e-meta)
 (require 'message)
 
 (declare-function mu4e-error "mu4e-utils")
+
+;;; Customization
 
 (defgroup mu4e nil
   "mu4e - mu for emacs"
@@ -314,7 +314,8 @@ Also see `mu4e-compose-context-policy'."
           (const :tag "Don't change the context when none match" nil))
   :group 'mu4e)
 
-;; crypto
+;;;; Crypto
+
 (defgroup mu4e-crypto nil
   "Crypto-related settings."
   :group 'mu4e)
@@ -335,14 +336,15 @@ The setting is a symbol:
                  (const :tag "Don't try to decrypt anything" nil))
   :group 'mu4e-crypto)
 
-;; completion; we put them here rather than in mu4e-compose, as mu4e-utils needs
-;; the variables.
+;;;; Address completion
+;;
+;; We put these options here rather than in mu4e-compose, because
+;; mu4e-utils needs them.
 
 (defgroup mu4e-compose nil
   "Message-composition related settings."
   :group 'mu4e)
 
-;; address completion
 (defcustom mu4e-compose-complete-addresses t
   "Whether to do auto-completion of e-mail addresses."
   :type 'boolean
@@ -368,10 +370,10 @@ time-based restriction."
   :type 'string
   :group 'mu4e-compose)
 
-;;; names and mail-addresses can be mapped onto their canonical
-;;; counterpart.  use the customizeable function
-;;; mu4e-canonical-contact-function to do that.  below the identity
-;;; function for mapping a contact onto the canonical one.
+;; names and mail-addresses can be mapped onto their canonical
+;; counterpart.  use the customizeable function
+;; mu4e-canonical-contact-function to do that.  below the identity
+;; function for mapping a contact onto the canonical one.
 (defun mu4e-contact-identity (contact)
   "Return the name and the mail-address of a CONTACT.
 It is used as the identity function for converting contacts to
@@ -447,6 +449,8 @@ Useful when this is not equal to the From: address."
 This is the message being replied to, forwarded or edited; used
 in `mu4e-compose-pre-hook'. For new messages, it is nil.")
 
+;;;; Calendar
+
 (defgroup mu4e-icalendar nil
   "Icalendar related settings."
   :group 'mu4e)
@@ -463,7 +467,8 @@ in `mu4e-compose-pre-hook'. For new messages, it is nil.")
   :group 'mu4e-icalendar)
 
 
-;; Folders
+;;;; Folders
+
 (defgroup mu4e-folders nil
   "Special folders."
   :group 'mu4e)
@@ -543,7 +548,8 @@ be quoted, since mu4e does this automatically for you."
   :group 'mu4e
   :type 'boolean)
 
-;; Faces
+;;; Faces
+
 (defgroup mu4e-faces nil
   "Type faces (fonts) used in mu4e."
   :group 'mu4e
@@ -739,7 +745,8 @@ mu4e-compose-mode."
   "Face for highlighting marked region in mu4e-view buffer."
   :group 'mu4e-faces)
 
-;; headers info
+;;; Header information
+
 (defconst mu4e-header-info
   '((:attachments
      . (:name "Attachments"
@@ -888,21 +895,21 @@ should point to a function that takes a message p-list as
 argument, and returns a string. See the default value of
 `mu4e-header-info-custom for an example.")
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Run-time variables
+;;;; Headers
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; run-time vars used in multiple places
-
-;; headers
 (defconst mu4e~headers-buffer-name "*mu4e-headers*"
   "Name of the buffer for message headers.")
 
-;; view
+;;;; View
+
 (defconst mu4e~view-buffer-name "*mu4e-view*"
   "Name for the message view buffer.")
 
 (defconst mu4e~view-embedded-buffer-name " *mu4e-embedded-view*"
   "Name for the embedded message view buffer.")
+
+;;;; Other
 
 (defvar mu4e~contacts nil
   "Hash that maps contacts (ie. 'name <e-mail>') to an integer for sorting.
@@ -947,19 +954,19 @@ fall back to the obsolete `mu4e-user-mail-address-list'."
     version))
 
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; our handlers funcs these handler funcs define what happens when we receive a
-;; certain message from the server
+;;; Handler functions
+;;
+;; The handler funcions define what happens when we receive a certain
+;; message from the server.  Here we register our handler functions;
+;; these connect server messages to functions to handle them.
+;;
+;; These bindings form mu4e's central nervous system so it's not
+;; really recommended to override them (they reference various
+;; internal bits, which could change).
+
 (defun mu4e~default-handler (&rest args)
   "Dummy handler function with arbitrary ARGS."
   (error "Not handled: %S" args))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; register our handler functions; these connect server messages to functions
-;; to handle them.
-;;
-;; these form mu4e's central nervous system so it's not really recommended
-;; to override them (they reference various internal bits which could change)
 
 (defvar mu4e-error-func 'mu4e-error-handler
   "Function called for each error received.

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -1705,4 +1705,4 @@ other windows."
             (switch-to-buffer (mu4e-get-headers-buffer))))))))
 
 (provide 'mu4e-view)
-;;; mu4e-view ends here
+;;; mu4e-view.el ends here

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -26,6 +26,7 @@
 ;; viewing e-mail messages
 
 ;;; Code:
+
 (require 'cl-lib)
 (require 'mu4e-utils) ;; utility functions
 (require 'mu4e-vars)
@@ -48,7 +49,8 @@
 (defvar gnus-icalendar-additional-identities)
 (defvar mu4e~headers-view-win)
 
-;; the message view
+;;; Options
+
 (defgroup mu4e-view nil
   "Settings for the message view."
   :group 'mu4e)
@@ -149,11 +151,15 @@ The first letter of NAME is used as a shortcut character."
   :group 'mu4e-view
   :type '(alist :key-type string :value-type function))
 
+;;; Variables
+
 (defvar-local mu4e~view-message nil
   "The message being viewed in view mode.")
 
 (defvar mu4e-view-fill-headers t
   "If non-nil, automatically fill the headers when viewing them.")
+
+;;; Keymaps
 
 (defvar mu4e-view-header-field-keymap
   (let ((map (make-sparse-keymap)))
@@ -193,7 +199,8 @@ off, for example when using a read-only file-system."
   :type 'boolean
   :group 'mu4e-view)
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Variables
+
 (defvar mu4e~view-cited-hidden nil "Whether cited lines are hidden.")
 (put 'mu4e~view-cited-hidden 'permanent-local t)
 
@@ -216,7 +223,8 @@ message extracted at some path.")
 (defvar mu4e~view-html-text nil
   "Should we prefer html or text just this once? A symbol `text'
 or `html' or nil.")
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; UNNAMED Main
 
 (defun mu4e-view-message-with-message-id (msgid)
   "View message with message-id MSGID. This (re)creates a
@@ -1082,9 +1090,8 @@ the new docid. Otherwise, return nil."
   (interactive)
   (mu4e~view-prev-or-next-unread nil))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Interactive functions
+;;; Interactive functions
 
 (defun mu4e-view-toggle-hide-cited ()
   "Toggle hiding of cited lines in the message body."
@@ -1180,8 +1187,8 @@ Add this function to `mu4e-view-mode-hook' to enable this feature."
             (overlay-put ov 'face 'mu4e-region-code))
           (setq beg nil end nil))))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Wash functions
+;;; Wash functions
+
 (defun mu4e-view-fill-long-lines ()
   "Fill lines that are wider than the window width or `fill-column'."
   (interactive)
@@ -1202,8 +1209,8 @@ Add this function to `mu4e-view-mode-hook' to enable this feature."
               (widen))
             (forward-line 1)))))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; attachment handling
+;;; Attachment handling
+
 (defun mu4e~view-get-attach-num (prompt _msg &optional multi)
   "Ask the user with PROMPT for an attachment number for MSG, and
 ensure it is valid. The number is [1..n] for attachments
@@ -1433,7 +1440,8 @@ attachments) in response to a (mu4e~proc-extract 'temp ... )."
    ((string= what "diary")
     (icalendar-import-file path diary-file))
    (t (mu4e-error "Unsupported action %S" what))))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; UNNAMED Utilities
 
 (defun mu4e-view-mark-custom ()
   "Run some custom mark function."
@@ -1443,6 +1451,8 @@ attachments) in response to a (mu4e~proc-extract 'temp ... )."
 (defun mu4e~view-split-view-p ()
   "Return t if we're in split-view, nil otherwise."
   (member mu4e-split-view '(horizontal vertical)))
+
+;;; Scroll commands
 
 (defun mu4e-view-scroll-up-or-next ()
   "Scroll-up the current message.
@@ -1464,6 +1474,8 @@ anymore, go the next message."
   "Scroll text of selected window down one line."
   (interactive)
   (scroll-down 1))
+
+;;; Mark commands
 
 (defun mu4e-view-unmark-all ()
   "If we're in split-view, unmark all messages.
@@ -1519,8 +1531,8 @@ list."
    (mu4e-headers-mark-or-move-to-trash)
    (mu4e~headers-move (or n 1))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; URL handling
+;;; URL handling
+
 (defun mu4e~view-get-urls-num (prompt &optional multi)
   "Ask the user with PROMPT for an URL number for MSG, and ensure
 it is valid. The number is [1..n] for URLs \[0..(n-1)] in the
@@ -1605,7 +1617,7 @@ this is the default, you may not need it."
   "Evaluate FUNC(uri) for each uri in the current message."
   (maphash (lambda (_num uri) (funcall func uri)) mu4e~view-link-map))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Various commands
 
 (defconst mu4e~view-raw-buffer-name " *mu4e-raw-view*"
   "Name for the raw message view buffer.")

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -105,6 +105,13 @@ the end of a message. Otherwise, don't move to the next message."
   :type 'boolean
   :group 'mu4e-view)
 
+(defcustom mu4e-view-auto-mark-as-read t
+  "Automatically mark messages are 'read' when you read
+them. This is typically the expected behavior, but can be turned
+off, for example when using a read-only file-system."
+  :type 'boolean
+  :group 'mu4e-view)
+
 (defcustom mu4e-save-multiple-attachments-without-asking nil
   "If non-nil, saving multiple attachments asks once for a
 directory and saves all attachments in the chosen directory."
@@ -151,14 +158,6 @@ The first letter of NAME is used as a shortcut character."
   :group 'mu4e-view
   :type '(alist :key-type string :value-type function))
 
-;;; Variables
-
-(defvar-local mu4e~view-message nil
-  "The message being viewed in view mode.")
-
-(defvar mu4e-view-fill-headers t
-  "If non-nil, automatically fill the headers when viewing them.")
-
 ;;; Keymaps
 
 (defvar mu4e-view-header-field-keymap
@@ -192,14 +191,13 @@ The first letter of NAME is used as a shortcut character."
     map)
   "Keymap used in the \"Attachements\" header field.")
 
-(defcustom mu4e-view-auto-mark-as-read t
-  "Automatically mark messages are 'read' when you read
-them. This is typically the expected behavior, but can be turned
-off, for example when using a read-only file-system."
-  :type 'boolean
-  :group 'mu4e-view)
-
 ;;; Variables
+
+(defvar-local mu4e~view-message nil
+  "The message being viewed in view mode.")
+
+(defvar mu4e-view-fill-headers t
+  "If non-nil, automatically fill the headers when viewing them.")
 
 (defvar mu4e~view-cited-hidden nil "Whether cited lines are hidden.")
 (put 'mu4e~view-cited-hidden 'permanent-local t)

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -1704,5 +1704,6 @@ other windows."
           (when (buffer-live-p (mu4e-get-headers-buffer))
             (switch-to-buffer (mu4e-get-headers-buffer))))))))
 
+;;; _
 (provide 'mu4e-view)
 ;;; mu4e-view.el ends here

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -1,12 +1,12 @@
 ;;; mu4e-view.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2011-2020 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 ;; Maintainer: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -1,5 +1,5 @@
 ;;; mu4e.el --- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2011-2019 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
@@ -8,7 +8,7 @@
 ;; Version: 0.0
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -25,6 +25,7 @@
 ;;; Commentary:
 
 ;;; Code:
+
 (require 'mu4e-vars)
 (require 'mu4e-headers)  ;; headers view
 (require 'mu4e-view)     ;; message view
@@ -39,15 +40,12 @@
 (when mu4e-org-support
   (require 'mu4e-org))      ;; support for org-mode links
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; we can't properly use compose buffers that are revived using
-;; desktop-save-mode; so let's turn that off
+;; We can't properly use compose buffers that are revived using
+;; desktop-save-mode; so let's turn that off.
 (require 'desktop)
 (add-to-list 'desktop-modes-not-to-save 'mu4e-compose-mode)
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;###autoload
 (defun mu4e (&optional background)
   "If mu4e is not running yet, start it. Then, show the main

--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -63,7 +63,7 @@ window, unless BACKGROUND (prefix-argument) is non-nil."
       (when (y-or-n-p (mu4e-format "Are you sure you want to quit?"))
         (mu4e~stop))
     (mu4e~stop)))
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;;; _
 (provide 'mu4e)
 ;;; mu4e.el ends here

--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -66,5 +66,4 @@ window, unless BACKGROUND (prefix-argument) is non-nil."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (provide 'mu4e)
-
 ;;; mu4e.el ends here

--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -27,9 +27,10 @@
 ;; Support for links to mu4e messages/queries from within org-mode,
 ;; and for writing message in org-mode, sending them as rich-text.
 
+;; At least version 8.x of Org mode is required.
+
 ;;; Code:
 
-;; The expect version here is org 8.x
 (require 'org)
 (require 'mu4e-compose)
 
@@ -41,16 +42,15 @@
 (declare-function mu4e-message                      "mu4e-message")
 (declare-function mu4e-compose-mode                 "mu4e-compose")
 
-
-
 
-;;; editing with org-mode ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
+;;; Editing with org-mode
+;;
 ;; below, some functions for the org->html conversion
 ;; based on / inspired by Eric Schulte's org-mime.el
 ;; Homepage: http://orgmode.org/worg/org-contrib/org-mime.php
 ;;
 ;; EXPERIMENTAL
+
 (defvar org-export-skip-text-before-1st-heading)
 (defvar org-export-htmlize-output-type)
 (defvar org-export-preserve-breaks)

--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -227,5 +227,4 @@ Edit the message body using org mode. DEPRECATED."
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (provide 'org-mu4e)
-
 ;;; org-mu4e.el ends here

--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -1,5 +1,5 @@
 ;;; org-mu4e -- support for links to mu4e messages and writing org-mode messages -*- lexical-binding: t -*-
-;;
+
 ;; Copyright (C) 2012-2019 Dirk-Jan C. Binnema
 
 ;; Author: Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
@@ -8,7 +8,7 @@
 ;; Version: 0.0
 
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; GNU Emacs is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of 1the License, or

--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -225,6 +225,6 @@ Edit the message body using org mode. DEPRECATED."
       (mu4e-compose-mode)
       (message "org-mu4e-compose-org-mode disabled"))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; _
 (provide 'org-mu4e)
 ;;; org-mu4e.el ends here


### PR DESCRIPTION
(Don't merge this just yet, see bottom.)

`outline-minor-mode` is a mode that can be used to deal with sections in source files like one does in Org mode files.  The file is structures into a tree of sections, subsections and so on.  Sections can be collapsed and expanded, and the visibility of complete subtrees or all sections in the buffer can be easily by cycled.  This is useful for much the same reason that it is useful in Org mode buffers, or in Magit buffers.

However this assumes that the source files actually follow Emacs' conventions for section headers in source files, which (phrased in the context of lisp files) goes as follows:

- A comment line that begins with only one or two semicolons is just a plain old comment.
- A comment line that begins with three or more semicolons, followed by a space, followed by some text, is a section heading.
- The number of semicolons specifies the level of the section.  Three=section, four=subsection, five=subsubsection etc.

----

I would like to encourage you not only to merge this pr but to also start using `outline-minor-mode` yourself.  It is immensely useful for navigation (and especially when getting familiar with a unknown codebase, though that does not apply for you in this case.))

Here is my basic configuration, which you might want to adapt:

``` emacs-lisp
(add-hook 'emacs-lisp-mode-hook 'outline-minor-mode)

(use-package bicycle
  :demand t ; https://github.com/jwiegley/use-package/issues/705
  :after outline
  :bind (:map outline-minor-mode-map
              ([C-tab] . bicycle-cycle)
              ([S-tab] . bicycle-cycle-global)))
```

And to make the headings prettier you should also use:

``` emacs-lisp
(use-package outline-minor-faces
  :after outline
  :config (add-hook 'outline-minor-mode-hook
                    'outline-minor-faces-add-font-lock-keywords))

(use-package backline
  :after outline
  :config (advice-add 'outline-flag-region :after 'backline-update))
```

Disclaimer: I am the author of `bicycle`, `outline-minor-faces` and `backline`.

You can try out what this does in the `magit` repository, for example.  It makes heavy use of sections.

----

This converts existing section headings that previously did not conform to the Emacs conventions.

It also replaces section **separators** (things like `;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;`) into section *headings*.  Because I am not familiar with the code base, I often did not know what heading to use.  In such cases I used `;;; UNNAMED` as temporary heading.

You probably don't want to merge this without first adding an additional commit, which replaces these placeholders with the appropriate headings.