### PR TITLE
Fix revert buffer

### DIFF
--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -235,7 +235,8 @@ non-nil."
       (setq mu4e~context-current context)
 
       (run-hooks 'mu4e-context-changed-hook)
-      (mu4e-message "Switched context to %s" (mu4e-context-name context)))
+      (mu4e-message "Switched context to %s" (mu4e-context-name context))
+      (force-mode-line-update))
     context))
 
 (defun mu4e~context-autoswitch (&optional msg policy)

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1898,7 +1898,7 @@ other windows."
       ;; now, all *other* windows should be gone. kill ourselves, and return
       ;; to the main view
       (kill-buffer)
-      (mu4e~main-view))))
+      (mu4e~main-view 'refresh))))
 
 ;;; _
 (provide 'mu4e-headers)


### PR DESCRIPTION
This is in continuation of #1562.
This PR allows using revert-buffer in mu4e-main instead of binding "g" to mu4e.
`mu4e~start` is no more using `mu4e-index-updated-hook`, the call is directly done in `mu4e-info-handler` which is cleaner.
Main buffer is correctly updated when quitting headers.
Mode-line is updated when changing context.