### PR TITLE
mu4e: Fix quoting in M-q keybinding definition

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -861,7 +861,7 @@ FUNC should be a function taking two arguments:
           (define-key map (kbd "M-q")
             (lambda()
               (interactive)
-              (if 'mu4e-view-use-gnus
+              (if mu4e-view-use-gnus
                   (article-fill-long-lines)
                 (mu4e-view-fill-long-lines))))
 


### PR DESCRIPTION
In the keybinding defintions for mu4e-view-mode-map, the variable
mu4e-view-use-gnus was used quoted in an if condition, which means that the
condition always evaluated to true. Therefore, M-q would always be bound to
article-fill-long lines and never to mu4e-view-fill-long-lines.