### PR TITLE
Add support for displaying maildirs and their counts

### DIFF
--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -147,6 +147,38 @@ clicked."
                    "\n")))
 
 
+(defun mu4e~main-maildirs ()
+  "Return a string of maildirs with their counts."
+  (cl-loop with mds = (mu4e~maildirs-with-query)
+           with longest = (mu4e~longest-of-maildirs-and-bookmarks)
+           with queries = (plist-get mu4e~server-props :queries)
+           for m in mds
+           for key = (string (plist-get m :key))
+           for name = (plist-get m :name)
+           for query = (plist-get m :query)
+           for qcounts = (and (stringp query)
+                              (cl-loop for q in queries
+                                       when (string= (plist-get q :query) query)
+                                       collect q))
+           concat (concat
+                   ;; menu entry
+                   (mu4e~main-action-str
+                    (concat "\t* [j" key "] " name)
+                    (concat "j" key))
+                   ;; append all/unread numbers, if available.
+                   (if qcounts
+                       (let ((unread (plist-get (car qcounts) :unread))
+                             (count  (plist-get (car qcounts) :count)))
+                         (format
+                          "%s (%s/%s)"
+                          (make-string (- longest (length name)) ? )
+                          (propertize (number-to-string unread)
+                                      'face 'mu4e-header-key-face)
+                          count))
+                     "")
+                   "\n")))
+
+
 (defun mu4e~key-val (key val &optional unit)
   "Return a key / value pair."
   (concat
@@ -197,6 +229,9 @@ When REFRESH is non nil refresh infos from server."
        "\n"
        (propertize "  Bookmarks\n\n" 'face 'mu4e-title-face)
        (mu4e~main-bookmarks)
+       "\n"
+       (propertize "  Maildirs\n\n" 'face 'mu4e-title-face)
+       (mu4e~main-maildirs)
        "\n"
        (propertize "  Misc\n\n" 'face 'mu4e-title-face)
 

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -117,8 +117,7 @@ clicked."
 (defun mu4e~main-bookmarks ()
   ;; TODO: it's a bit uncool to hard-code the "b" shortcut...
   (cl-loop with bmks = (mu4e-bookmarks)
-           with longest = (cl-loop for b in bmks
-                                   maximize (length (plist-get b :name)))
+           with longest = (mu4e~longest-of-maildirs-and-bookmarks)
            with queries = (plist-get mu4e~server-props :queries)
            for bm in bmks
            for key = (string (plist-get bm :key))

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -110,7 +110,14 @@ clicked."
     (define-key map (kbd "RET") func)
     (put-text-property 0 (length newstr) 'keymap map newstr)
     (put-text-property (string-match "\\[.+$" newstr)
-                       (- (length newstr) 1) 'mouse-face 'highlight newstr)
+                       ;; only subtract one from length of newstr if we're
+                       ;; actually consuming the first letter (e.g.
+                       ;; `func-or-shortcut' is a function, meaning we put
+                       ;; braces around the first letter of `str')
+                       (if (stringp func-or-shortcut)
+                           (length newstr)
+                         (- (length newstr) 1))
+                       'mouse-face 'highlight newstr)
     newstr))
 
 

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -148,7 +148,7 @@ clicked."
                              (count  (plist-get (car qcounts) :count)))
                          (format
                           "%s (%s/%s)"
-                          (make-string (- longest (length name)) ? )
+                          (make-string (- longest (string-width name)) ? )
                           (propertize (number-to-string unread)
                                       'face 'mu4e-header-key-face)
                           count))
@@ -184,7 +184,7 @@ clicked."
                              (count  (plist-get (car qcounts) :count)))
                          (format
                           "%s (%s/%s)"
-                          (make-string (- longest (length name)) ? )
+                          (make-string (- longest (string-width name)) ? )
                           (propertize (number-to-string unread)
                                       'face 'mu4e-header-key-face)
                           count))

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -132,7 +132,10 @@ clicked."
            for query = (plist-get bm :query)
            for qcounts = (and (stringp query)
                               (cl-loop for q in queries
-                                       when (string= (plist-get q :query) query)
+                                       when (string=
+                                             (decode-coding-string
+                                              (plist-get q :query) 'utf-8 t)
+                                             query)
                                        collect q))
            concat (concat
                    ;; menu entry
@@ -164,7 +167,11 @@ clicked."
            for query = (plist-get m :query)
            for qcounts = (and (stringp query)
                               (cl-loop for q in queries
-                                       when (string= (plist-get q :query) query)
+                                       when (string=
+                                             (decode-coding-string
+                                              (plist-get q :query)
+                                              'utf-8 t)
+                                             query)
                                        collect q))
            concat (concat
                    ;; menu entry

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -802,14 +802,14 @@ non-nil). Otherwise, check various requireme`'nts, then start mu4e.
 When successful, call FUNC (if non-nil) afterwards."
   (setq mu4e-pong-func (lambda (info) (mu4e~pong-handler info func)))
   (mu4e~proc-ping
-   (mapcar
-    ;; send it a list of queries we'd like to see read/unread info for.
-    (lambda(bm) (plist-get bm :query))
-    (seq-filter (lambda (bm) ;; exclude bookmarks that are not strings,
-                  ;; and with these flags.
+   (mapcar ;; send it a list of queries we'd like to see read/unread info for
+    (lambda (bm) (plist-get bm :query))
+    (seq-filter (lambda (bm) ;; exclude bookmarks that are not strings, and with
+                             ;; these flags
                   (and (stringp (plist-get bm :query))
                        (not (or (plist-get bm :hide) (plist-get bm :hide-unread)))))
-                (mu4e-bookmarks))))
+                (append (mu4e-bookmarks)
+                        (mu4e~maildirs-with-query)))))
   ;; maybe request the list of contacts, automatically refreshed after
   ;; reindexing
   (unless mu4e~contacts (mu4e~request-contacts-maybe)))

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -859,7 +859,7 @@ This is meant to be the exact same data structure as
   "Return the length of longest name of bookmarks and maildirs."
   (cl-loop for b in (append (mu4e-bookmarks)
                             (mu4e~maildirs-with-query))
-           maximize (length (plist-get b :name))))
+           maximize (string-width (plist-get b :name))))
 
 
 ;;; Indexing & Updating

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -837,6 +837,25 @@ When successful, call FUNC (if non-nil) afterwards."
          (kill-buffer))))
    (buffer-list)))
 
+(defun mu4e~maildirs-with-query ()
+  "Return a copy of `mu4e-maildirs-shortcuts' with :query populated.
+
+This is meant to be the exact same data structure as
+`mu4e-bookmarks'."
+  (cl-mapcar
+   (lambda (m)
+     (append
+      ;; we want to change the :maildir key to :name, and add a :query key
+      (list :name (substring (plist-get m :maildir) 1)
+            :query (format "maildir:\"%s\"" (plist-get m :maildir)))
+      ;; next we want to append any other keys to our previous list (e.g. :hide,
+      ;; :key, etc) but skipping :maildir (since it's renamed to :name)
+      (cl-loop for (key value) on m by 'cddr
+               when (not (equal key :maildir))
+               append (list key value))))
+   (mu4e-maildir-shortcuts)))
+
+
 
 ;;; Indexing & Updating
 

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -855,6 +855,11 @@ This is meant to be the exact same data structure as
                append (list key value))))
    (mu4e-maildir-shortcuts)))
 
+(defun mu4e~longest-of-maildirs-and-bookmarks ()
+  "Return the length of longest name of bookmarks and maildirs."
+  (cl-loop for b in (append (mu4e-bookmarks)
+                            (mu4e~maildirs-with-query))
+           maximize (length (plist-get b :name))))
 
 
 ;;; Indexing & Updating


### PR DESCRIPTION
This code could be merged as-is but is mostly a request for comment on this functionality. In a nutshell, this upstreams the functionality of [mu4e-maildirs-extension](https://github.com/agpchil/mu4e-maildirs-extension) using the new query count feature. Displaying maildirs is disabled by default and controlled via `mu4e-main-show-maildirs`.

The last two commits that align both the bookmark and maildir counts is probably overkill but it does look nice.

Missing are documentation, updating the changelog, etc. but I can add those if this feature is deemed worthy to upstream :-)