### PR TITLE
Improve support for format=flowed

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -459,6 +459,8 @@ removing the In-Reply-To header."
           (define-key map (kbd "C-c C-u") 'mu4e-update-mail-and-index)
           (define-key map (kbd "C-c C-k") 'mu4e-message-kill-buffer)
           (define-key map (kbd "M-q")     'mu4e-fill-paragraph)
+          (if mu4e-compose-format-flowed
+              (define-key map (kbd "C-c C-c" 'mu4e-fill-send-and-exit)))
           map)))
 
 (defun mu4e-fill-paragraph (&optional region)

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -262,6 +262,18 @@ triggering the soft-wrap behavior of format=flowed."
   (insert " ")
   (widen))
 
+(defun mu4e-fill-send-and-exit ()
+  "Reflow message with `mu4e-fill-buffer-for-flowed' and send it.
+
+With a prefix argument, prompt for a line length to use in place
+of `fill-flowed-encode-column'"
+  (interactive)
+  (let ((fill-flowed-encode-column (if current-prefix-arg
+                                       (read-number "format=flowed line length: " 72)
+                                     fill-flowed-encode-column)))
+    (mu4e-fill-buffer-for-flowed))
+  (message-send-and-exit))
+
 
 ;;; Attachments
 

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -4181,18 +4181,35 @@ setting
 
 @noindent
 in your Emacs init file (@file{~/.emacs} or @file{~/.emacs.d/init.el}).
-The transformation of your message into the proper format is
-done at the time of sending.  For this to happen properly, you should
-write each paragraph of your message of as a long line (i.e. without
-carriage return).  If you introduce unwanted newlines in your paragraph,
-use @kbd{M-q} to reformat it as a single line.
+Optionally, you may also set @code{fill-flowed-encode-column} to control
+length at which your email is wrapped for clients that do not support
+format=flowed.  By default, this is set to 66.
 
-If you want to send the message with paragraphs on single lines but
-without @t{format=flowed} (because, say, the receiver does not
-understand the latter as it is the case for Google or Github), use
-@kbd{M-x use-hard-newlines} (to turn @code{use-hard-newlines} off) or
-uncheck the box @t{format=flowed} in the @t{Text} menu when composing a
-message.
+The transformation of your message into the proper format is
+done at the time of sending by removing the current hard newlines
+from your message and inserting soft newlines at intervals determined
+by @code{fill-flowed-encode-column}.  This means that you can freely use
+@code{auto-fill-mode} to compose your message at a comfortable line
+length and then let your message be rewrapped when you send it.  (This
+represents a change from Mu4e 1.2.0, which required you to write each
+paragraph as a single long line).
+
+If you want to send the message with paragraphs on single lines when
+using @t{format=flowed} (for example, because the receiver does not
+reflow format=flowed emails as it is the case for Google or Github), 
+set @code{fill-flowed-encode-column} to a high value.  With this
+setting, mu4e will format your paragraphs as single lines, which will
+result in good display on clients that fully implement @t{format=flowed}
+and on clients that do not implement @t{format=flowed} but wrap all
+plaintext lines with a narrow width.
+
+This technique is described in more detail at
+@url{https://vxlabs.com/2019/08/25/format-flowed-with-long-lines/}.
+
+Note, however, that this will cause your emails to display poorly on
+clients that do not reflow @t{format=flowed} lines, such as aerc or
+pre-1.3.0 versions of mu4e using the mu4e message viewer (as opposed
+to the then-experimental gnus message viewer).
 
 @subsection How can force images to be shown at the end of my messages, regardless of where I insert them?
 User Marcin Borkowski has a solution:


### PR DESCRIPTION
This PR revises the way mu4e handles format=flowed messages as discussed in #1600.  

This new code removes the previous requirement that users write each paragraph of their code as a single long line, and allows users to use `auto-fill-mode`, `fill-paragraph`, or any other function they might otherwise use to manage line length when writing their messages.

This change also removes the (somewhat confusing) distinction between `mu4e-compose-format-flowed` and `use-hard-newlines`.  Under this code, the user simply sets `mu4e-compose-format-flowed` whenever they want to use the `format=flowed` header and then controls the length of their lines with `fill-flow-encode-column`. 

Please see the individual commit messages for further explanation of implementation details and changes. 