### PR TITLE
Merged crypto-policy configuration into one variable

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -656,8 +656,7 @@ See `mu4e-compose-crypto-policy' for more details."
     (cond ((and sign encrypt)
            (mml-secure-message-sign-encrypt))
           (sign (mml-secure-message-sign))
-          (encrypt (mml-secure-message-encrypt))
-          (t (message "Do nothing")))))
+          (encrypt (mml-secure-message-encrypt)))))
 
 (cl-defun mu4e~compose-handler (compose-type &optional original-msg includes)
   "Create a new draft message, or open an existing one.

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -163,7 +163,8 @@ in turn implies `sign-plain-replies'. Adding both to the set, is
 not a contradiction, but a redundant configuration.
 
 All `sign-*' options have a `encrypt-*' analogue."
-  :type '(set (const :tag "Sign all messages" sign-all-messages)
+  :type '(set :greedy t
+	      (const :tag "Sign all messages" sign-all-messages)
               (const :tag "Encrypt all messages" encrypt-all-messages)
               (const :tag "Sign new messages" sign-new-messages)
               (const :tag "Encrypt new messages" encrypt-new-messages)


### PR DESCRIPTION
The current cryptography policy is a bit confusing.  The existence of the two variables `mu4e-compose-crypto-reply-plain-policy` and `mu4e-compose-crypto-reply-encrypted-policy` at first glance implies that you can configure how to respond to encrypted and plain emails, but on closer inspection `mu4e-compose-crypto-reply-plain-policy` reveals itself to also be responsible for forwarding mails, creating new messages, etc.

This changeset suggests merging the two variables into one -- `mu4e-compose-crypto-policy` -- while at the same time expanding it's granularity. So instead of implementing `mu4e-compose-crypto-forward-plain-policy`, `mu4e-compose-crypto-new-policy`, etc. everything regarding encryption and signing is centrally controlled by a customizable set.

To avoid conflicts with older configurations, I have added a translation layer in `mu4e~compose-handler`, that adds the corresponding new symbols to the new policy variable, based on the old the values of the old variables. In case these weren't customized, both should be nil now, meaning that the append has no consing overhead (be it ever so minimal), as `mu4e-compose-crypto-reply-encrypted-policy` has been changed from `sign-and-encrypt` to nil. 

To preserve the current defaults, `mu4e-compose-crypto-policy` only contains the symbols that were implied by `mu4e-compose-crypto-reply-encrypted-policy`. It might be worth considering expanding the default configuration, but I didn't want to make that decision in this pull request.