### PR TITLE
mu4e: extend mu4e-header-highlight-face to edge of window

### DIFF
--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -661,7 +661,8 @@ I.e. a message with the draft flag set."
   :group 'mu4e-faces)
 
 (defface mu4e-header-highlight-face
-  '((t :inherit hl-line :weight bold :underline t))
+  `((t :inherit hl-line :weight bold :underline t
+       ,@(and (>= emacs-major-version 27) '(:extend t))))
   "Face for the header at point."
   :group 'mu4e-faces)
 


### PR DESCRIPTION
Due to a breaking change we have to request this explicitly in
Emacs 27.  Earlier Emacs versions do the right thing by default.

If the effect of a face does not extend to the edge of the window,
then attributes such as the background color or underline cease to
be used for more that the width of a single character, which is not
appropriate for a face intended to highlight a complete line.

See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=37774.