### PR TITLE
Misc fixes

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -314,8 +314,8 @@ Message-ID."
                 (mu4e~compose-set-friendly-buffer-name)
                 (mu4e~draft-insert-mail-header-separator)
                 ;; hide some headers again
-                (mu4e~compose-hide-headers)
                 (widen)
+                (mu4e~compose-hide-headers)
                 (set-buffer-modified-p nil)
                 (mu4e-message "Saved (%d lines)" (count-lines (point-min) (point-max)))
                 ;; update the file on disk -- ie., without the separator

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -655,8 +655,9 @@ process."
                        (zerop (plist-get info :updated)))
             (mu4e~request-contacts-maybe))
           (when (and (buffer-live-p mainbuf) (get-buffer-window mainbuf))
-            (select-window (get-buffer-window mainbuf))
-            (mu4e~main-view 'refresh)))))
+            (save-window-excursion
+              (select-window (get-buffer-window mainbuf))
+              (mu4e~main-view 'refresh))))))
      ((plist-get info :message)
       (mu4e-index-message "%s" (plist-get info :message))))))
 


### PR DESCRIPTION
This fixes what I believe to be two bugs:

- The first is in `mu4e-info-handler` where `save-window-excursion` is now called instead of just selecting the `mainbuf` window. Previously, the main-mu4e window was selected (if visible) after `mu4e-update-index` is called (directly or through the update timer). The result was that the pointer would jump away from a currently selected window. 

- The second is in `mu4e-compose.el`. Previously, `(widen)` was called right after `(mu4e~compose-hide-headers)`. There were two problems: First the headers that were just hidden are immediately shown. Second if some headers were previously hidden before that hook is executed, some header fields were corrupted.