### PR TITLE
~/.mu -> ~/.cache/mu

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -89,7 +89,7 @@
    except when logging may not have been initialized.
 
    The logging system redirects most logging to the log file (typically,
-   ~/.mu/mu.log). g_warning, g_message and g_critical are shown to the user,
+   ~/.cache/mu/mu.log). g_warning, g_message and g_critical are shown to the user,
    except when running with --quiet, in which case g_message is *not* shown.
 
    - ~g_message~ is for non-error messages the user will see (unless running with

--- a/guile/mu-guile.c
+++ b/guile/mu-guile.c
@@ -145,7 +145,7 @@ SCM_DEFINE_PUBLIC (mu_initialize, "mu:initialize", 0, 1, 0,
 		   "Initialize mu - needed before you call any of the other "
 		   "functions. Optionally, you can provide MUHOME which should be an "
 		   "absolute path to your mu home directory "
-		   "-- typically, the default, ~/.mu, should be just fine.")
+		   "-- typically, the default, ~/.cache/mu, should be just fine.")
 #define FUNC_NAME s_mu_initialize
 {
 	char *muhome;

--- a/guile/mu-guile.texi
+++ b/guile/mu-guile.texi
@@ -297,7 +297,7 @@ scheme@(guile-user)> (mu:initialize)
 @end verbatim
 
 This opens the database for reading, using the default location of
-@file{~/.mu}@footnote{If you keep your @t{mu} database in a non-standard
+@file{~/.cache/mu}@footnote{If you keep your @t{mu} database in a non-standard
 place, use @code{(mu:initialize "/path/to/my/mu/")}}
 
 Now, @t{mu-guile} is ready to go. In the next chapter, we go through the

--- a/lib/mu-runtime.h
+++ b/lib/mu-runtime.h
@@ -29,7 +29,7 @@ G_BEGIN_DECLS
  * initialize the mu runtime system; initializes logging and other
  * systems. To uninitialize, use mu_runtime_uninit
  *
- * @param muhome path where to find the mu home directory (typically, ~/.mu)
+ * @param muhome path where to find the mu home directory (typically, ~/.cache/mu)
  * @param name of the main program, ie. 'mu', 'mug' or
  * 'procmule'. this influences the name of the e.g. the logfile
  *

--- a/man/mu-index.1
+++ b/man/mu-index.1
@@ -169,9 +169,9 @@ dominated by operations in the Xapian database now.
 
 .SH FILES
 \fBmu\fR stores logs of its operations and queries in \fI<muhome>/mu.log\fR
-(by default, this is \fI~/.mu/mu.log\fR). Upon startup, \fBmu\fR checks the
+(by default, this is \fI~/.cache/mu/mu.log\fR). Upon startup, \fBmu\fR checks the
 size of this log file. If it exceeds 1 MB, it will be moved to
-\fI~/.mu/mu.log.old\fR, overwriting any existing file of that name, and start
+\fI~/.cache/mu/mu.log.old\fR, overwriting any existing file of that name, and start
 with an empty log file. This scheme allows for continued use of \fBmu\fR
 without the need for any manual maintenance of log files.
 

--- a/man/mu.1
+++ b/man/mu.1
@@ -137,7 +137,7 @@ to \fI~/.mu\fR, which now requires \fI\-\-muhome=~/.mu\fR.
 \fB\-d\fR, \fB\-\-debug\fR
 makes \fBmu\fR generate extra debug information,
 useful for debugging the program itself. By default, debug information goes to
-the log file, \fI~/.mu/log/mu.log\fR. It can safely be deleted when \fBmu\fR is
+the log file, \fI~/.cache/mu/mu.log\fR. It can safely be deleted when \fBmu\fR is
 not running. When running with \fB--debug\fR option, the log file can grow
 rather quickly. See the note on logging below.
 

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -3717,10 +3717,10 @@ We can now run @command{mu} to make sure things work:
 
 @verbatim
 $ mu index
-mu: indexing messages under /home/foo/Maildir [/home/foo/.mu/xapian]
+mu: indexing messages under /home/foo/Maildir [/home/foo/.cache/mu/xapian]
 | processing mail; processed: 520; updated/new: 520, cleaned-up: 0
 mu: elapsed: 3 second(s), ~ 173 msg/s
-mu: cleaning up messages [/home/foo/.mu/xapian]
+mu: cleaning up messages [/home/foo/.cache/mu/xapian]
 / processing mail; processed: 520; updated/new: 0, cleaned-up: 0
 mu: elapsed: 0 second(s)
 @end verbatim


### PR DESCRIPTION
Change man pages so that they honor the new mu config directory.

Question: `mu-script.1` Where are the scripts stored? I guess not in the `.cache` directory. I left `.mu/scripts`.