### PR TITLE
fix `mu4e-main-buffer-hide-personal-addresses'

### DIFF
--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -221,10 +221,10 @@ When REFRESH is non nil refresh infos from server."
        (mu4e~key-val "maildir" (mu4e-root-maildir))
        (mu4e~key-val "in store"
                      (format "%d" (plist-get mu4e~server-props :doccount)) "messages")
-       (unless mu4e-main-buffer-hide-personal-addresses
+       (if mu4e-main-buffer-hide-personal-addresses ""
          (mu4e~key-val "personal addresses" (if addrs (mapconcat #'identity addrs ", "  ) "none"))))
 
-      (unless mu4e-main-buffer-hide-personal-addresses
+      (if mu4e-main-buffer-hide-personal-addresses ""
         (when (and addrs user-mail-address (not (member user-mail-address addrs)))
           (mu4e-message (concat
                          "Note: `user-mail-address' ('%s') is not part "


### PR DESCRIPTION
Ran into this small bug when trying to hide the display of personal messages in the main view. "insert" expects a string, this fix returns an empty string when `mu4e-main-buffer-hide-personal-addresses' is set.