### PR TITLE
mu4e-proc: restore rename behaviour in mu4e~proc-move

### DIFF
--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -441,7 +441,7 @@ Returns either (:update ... ) or (:error ) sexp, which are handled my
                   :msgid ,(if (stringp docid-or-msgid) docid-or-msgid nil)
                   :flags ,(or flags nil)
                   :maildir ,(or maildir nil)
-                  :rename ,(if mu4e-change-filenames-when-moving t nil)
+                  :rename ,(and maildir (if mu4e-change-filenames-when-moving t nil))
                   :no-view ,(if no-view t nil))))
 
 (defun mu4e~proc-ping (&optional queries)


### PR DESCRIPTION
This appears to have been inadvertently changed in
a5dccffcdfa3aeb1908832bf467f90db82b7f82c which results in errors as noted
in https://groups.google.com/d/msg/mu-discuss/iLR_9Cw14Ps/EdA2pctoBQAJ