### PR TITLE
mu-store: enlarge buffer for strftime

### DIFF
--- a/lib/mu-store.cc
+++ b/lib/mu-store.cc
@@ -1408,7 +1408,7 @@ mu_store_print_info  (const MuStore *store, gboolean nocolor)
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-y2k"
-        char tbuf[32];
+        char tbuf[64];
 	strftime (tbuf, sizeof(tbuf), "%c", tstamp);
 #pragma GCC diagnostic pop
 


### PR DESCRIPTION
On Debian 9 random memory was printed with the original buffer size
and valgrind complained about the use of uninitialized memory.