### PR TITLE
Is it :hide-unread or :show-unread

### DIFF
--- a/mu4e/:show-unread t
+++ b/mu4e/:show-unread t
@@ -231,7 +231,7 @@ are plists" "1.3.7")
             :key ?t)
     ( :name "Last 7 days"
             :query "date:7d..now"
-            :show-unread t
+            :hide-unread t
             :key ?w)
     ( :name "Messages with images"
             :query "mime:image/*"


### PR DESCRIPTION
I think the docstring is correct and the variable setting is wrong -- the code elsewhere  (mu4e~start) seems to check hide-unread property.

Once the discrepancy between doc string and code is fixed, the info file will need updating, as this variable is shown verbatim in 7.2 Bookmarks node.