### PR TITLE
mu4e: change spacing in main view for info section

### DIFF
--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -147,7 +147,7 @@ clicked."
 (defun mu4e~key-val (key val &optional unit)
   "Return a key / value pair."
   (concat
-   "        * "
+   "\t* "
    (propertize (format "%-20s" key) 'face 'mu4e-header-title-face)
    ": "
    (propertize val 'face 'mu4e-header-key-face)


### PR DESCRIPTION
Change the spaces to tab to be consistent with the other entries in the
main view.