### PR TITLE
Default to current open message view, split if non-existent, call fallback function otherwise. 

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -1151,22 +1151,22 @@ and MAXHEIGHT are ignored."
           (insert-image img))))))
 
 
-(defun mu4e-hide-other-mu4e-buffers ()
-  "Bury mu4e-buffers (main, headers, view) (and delete all windows
-displaying it). Do _not_ bury the current buffer, though."
-  (interactive)
-  (unless (eq mu4e-split-view 'single-window)
-    (let ((curbuf (current-buffer)))
+(defun mu4e-hide-other-mu4e-buffers (&optional except)
+    "Bury mu4e-buffers (main, headers, view) (and delete all windows
+displaying it) excluding those in EXCEPT defaults to (selected-window)"
+    (interactive)
+    (unless except
+      (setq except (list (selected-window))))
+    (unless (eq mu4e-split-view 'single-window)
       ;; note: 'walk-windows' does not seem to work correctly when modifying
       ;; windows; therefore, the doloops here
       (dolist (frame (frame-list))
         (dolist (win (window-list frame nil))
-          (with-current-buffer (window-buffer win)
-            (unless (eq curbuf (current-buffer))
+          (unless (member win except)
+            (with-current-buffer (window-buffer win)
               (when (member major-mode '(mu4e-headers-mode mu4e-view-mode))
                 (when (eq t (window-deletable-p win))
-                  (delete-window win))))))) t)))
-
+                  (delete-window win))))))) t))
 
 (defun mu4e-get-time-date (prompt)
   "Determine the emacs time value for the time/date entered by user

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -282,6 +282,10 @@ old format if needed."
           mu4e-bookmarks))
 
 
+(defvar mu4e-fallback-window-func #'selected-window
+  "Function which will be called when a splitting the current window to get a view window
+fails (usually if the current window is too small)")
+
 (defcustom mu4e-split-view 'horizontal
   "How to show messages / headers.
 A symbol which is either:


### PR DESCRIPTION
The changes in this pull request are
- When viewing a message, the previous open view-buffer is used to view the message (before the previous message-view was deleted and a new one was created by splitting).
- When splitting the window fails, a function `mu4e-fallback-window-func` is called instead of `selected-window` (which defaults to `selected-window`). 

This solves a typical problem that I experience. After viewing the headers, if I view a message, the view splits horizontally. While reading the message if I split the message-view manually to view a separate buffer, then try to open a separate message, the old message-view is closed and the (now small) header-view is used instead to view the message.

With the changes of this pull request, the window of the old message-view is used instead.

The pull request also make the fall-back window configurable (instead of using `selected-window`). I personally use it with ace-window to manually select where to view the message.

```
(setq mu4e-fallback-window-func
        (lambda nil (let ((aw-dispatch-always t))
                      (aw-select " Select window for mu4e"))))
```


