### PR TITLE
Strip properties from mu4e-completing-read-function results.

### DIFF
--- a/mu4e/mu4e-contrib.el
+++ b/mu4e/mu4e-contrib.el
@@ -198,8 +198,9 @@ buffers found, compose a new message and then attach the file."
                 (if (= (length bufs) 1)
                     (get-buffer (car bufs))
                   (let ((prompt (mu4e-format "%s" "Attach to buffer")))
-                    (funcall mu4e-completing-read-function prompt
-                             bufs))))
+                    (substring-no-properties
+                     (funcall mu4e-completing-read-function prompt
+                              bufs)))))
         ;; setup a new mail composition buffer
         (if (y-or-n-p "Compose new mail and attach this file? ")
             (progn (mu4e-compose-new)

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -376,7 +376,8 @@ name. If the special shortcut 'o' (for _o_ther) is used, or if
 all maildirs under `mu4e-maildir'."
   (let ((prompt (mu4e-format "%s" prompt)))
     (if (not (mu4e-maildir-shortcuts))
-        (funcall mu4e-completing-read-function prompt (mu4e-get-maildirs))
+        (substring-no-properties
+         (funcall mu4e-completing-read-function prompt (mu4e-get-maildirs)))
       (let* ((mlist (append (mu4e-maildir-shortcuts)
                             '((:maildir "ther"  :key ?o))))
              (fnames
@@ -391,8 +392,9 @@ all maildirs under `mu4e-maildir'."
                mlist ", "))
              (kar (read-char (concat prompt fnames))))
         (if (member kar '(?/ ?o)) ;; user chose 'other'?
-            (funcall mu4e-completing-read-function prompt
-                     (mu4e-get-maildirs) nil nil "/")
+            (substring-no-properties
+             (funcall mu4e-completing-read-function prompt
+                      (mu4e-get-maildirs) nil nil "/"))
           (or (plist-get
                (cl-find-if (lambda (item) (= kar (plist-get item :key)))
                            (mu4e-maildir-shortcuts)) :maildir)


### PR DESCRIPTION
Some completion engines (like "flx") decorate the strings that they
return.  If MU4E passes such a string down to MU, the "format" call
preserves the text properties in the generated S-expression, producing
an invalid query.  MU4E itself has no interest in those decorations,
so strip them out as early as possible from all prompts that use
mu4e-completing-read-function.