### PR TITLE
Missing space between sig verification and signers

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -637,7 +637,7 @@ add text-properties to VAL."
                                                 (mu4e-view-verify-msg-popup
                                                  (button-get b 'msg))))
                   (buffer-string))))
-         (val (when val (concat val signers " (" btn ")"))))
+         (val (when val (concat val " " signers " (" btn ")"))))
     (mu4e~view-construct-header :signature val t)))
 
 (defun mu4e~view-construct-decryption-header (msg)


### PR DESCRIPTION
Resolution for a tiny annoyance:  adds a space between the verification status of the signature and the signers 