### PR TITLE
Allow ';' as a Maildir flags seperator

### DIFF
--- a/lib/mu-msg-part.c
+++ b/lib/mu-msg-part.c
@@ -263,7 +263,7 @@ cleanup_filename (char *fname)
 	/* replace control characters, slashes, and colons by '-' */
 	for (cur = fname; cur && *cur; cur = g_utf8_next_char (cur)) {
 		uc = g_utf8_get_char (cur);
-		if (g_unichar_iscntrl (uc) || uc == '/' || uc == ':')
+		if (g_unichar_iscntrl (uc) || uc == '/' || uc == ':' || uc == ';')
 			g_string_append_unichar (gstr, '-');
 		else
 			g_string_append_unichar (gstr, uc);

--- a/man/mu-index.1
+++ b/man/mu-index.1
@@ -21,7 +21,7 @@ init\fR to initialize the database.
 \fBindex\fR understands Maildirs as defined by Daniel Bernstein for
 \fBqmail\fR(7). In addition, it understands recursive Maildirs (Maildirs
 within Maildirs), Maildir++. It can also deal with VFAT-based Maildirs
-which use '!' as the separators instead of ':'.
+which use '!' or ';' as the separators instead of ':'.
 
 E-mail messages which are not stored in something resembling a maildir
 leaf-directory (\fIcur\fR and \fInew\fR) are ignored, as are the cache


### PR DESCRIPTION
Isync uses this by default on Windows where ':' is an invalid character
in file names. Also try to preserve the existing separator character
when generating a new file name.