### PR TITLE
add CI: run test suite with GitHub actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,39 @@
+name: Build & run tests
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - if: contains(matrix.os, 'ubuntu')
+        name: ubuntu-deps
+        run: |
+          sudo apt update
+          sudo apt-get install automake autoconf-archive autotools-dev libglib2.0-dev libxapian-dev libgmime-3.0-dev m4 make libtool pkg-config
+
+      - if: contains(matrix.os, 'macos')
+        name: macos-deps
+        run: |
+          brew install autoconf automake libgpg-error libtool pkg-config gettext glib gmime xapian
+
+      - name: configure
+        run: ./autogen.sh
+
+      - name: build
+        run: make
+
+      - name: test
+        run: make test


### PR DESCRIPTION
currently this runs tests on the latest Ubuntu LTS and the latest macOS

should be straightforward to run tests on any of the other [supported
environments](https://github.com/actions/virtual-environments) or in a Docker
container

as discussed in #1723 