### PR TITLE
mu4e: Delay the execution of workaround for desktop.el

### DIFF
--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -42,8 +42,8 @@
 
 ;; We can't properly use compose buffers that are revived using
 ;; desktop-save-mode; so let's turn that off.
-(require 'desktop)
-(add-to-list 'desktop-modes-not-to-save 'mu4e-compose-mode)
+(with-eval-after-load 'desktop
+  (eval '(add-to-list 'desktop-modes-not-to-save 'mu4e-compose-mode)))
 
 
 ;;;###autoload


### PR DESCRIPTION
Some Emacs user may never use desktop.el, We don't need to require desktop.el
for them.