### PR TITLE
Allow generic formatter for thread subjects. 

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -1263,6 +1263,17 @@ string will be shortened to fit if its length exceeds
     (insert (propertize "Loading message..."
                         'face 'mu4e-system-face 'intangible t))))
 
+
+(defun mu4e~stack-push (lst x &optional lvl)
+  "Pushes X to the top of LST. LVL is the level of X."
+  (unless lvl
+    (setq lvl (1+ (length lst))))
+  (while (> (length (symbol-value lst)) lvl)
+    (set lst (cdr (symbol-value lst))))
+  (while (< (length (symbol-value lst)) lvl)
+    (set lst (cons nil (symbol-value lst))))
+  (set lst (cons x (symbol-value lst))))
+
 ;;; _
 (provide 'mu4e-utils)
 ;;; mu4e-utils.el ends here


### PR DESCRIPTION
This commit adds a custom variable `mu4e-headers-thread-subject-format-function` which can be used to customize the way thread subjects are shown. By default it is set to `mu4e~headers-thread-subject-format-default` which simply hides the subject of child messages (like mu4e does). More importantly, one can set

```
(setq mu4e-headers-thread-subject-format-function
      #'mu4e~headers-thread-subject-format-abbrev)
```

(where `mu4e~headers-thread-subject-format-abbrev` is also included in the commit), so that the subject of child messages is not hidden but abbreviated. For example, if the parent message is: `Message Title` and the child message is `Re: Message Title` then the child message is displayed as `Re: ⸗`.

The rationale for this pull request is that hiding messages makes it difficult to distinguish between replies and forwarded messages. Moreover, some people change the subject title in some cases or add to it when replying. Some of my correspondents even reply to emails and change the subject completely as a way of creating a new email (but to the same list of recipients). Always hiding the subject means that I cannot easily pick out those messages.