### PR TITLE
mu4e/mu4e-utils: only set so-long-mode once

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -1009,7 +1009,8 @@ either 'to-server, 'from-server or 'misc. This function is meant for debugging."
       (view-mode)
 
       (when (fboundp 'so-long-mode)
-        (eval '(so-long-mode)))
+        (unless (eq major-mode 'so-long-mode)
+          (eval '(so-long-mode))))
 
       (setq buffer-undo-list t)
       (let* ((inhibit-read-only t)


### PR DESCRIPTION
Ideally we should separate the log buffer creation code so this van be
done a bit more cleanly. For now however only set so-long-mode once
otherwise you end up spamming the messages with constant:

  Changed to so-long-mode (from fundamental-mode) on account of line length.  C-c C-c to revert. [36 times]

As the messages keep rolling in.