### PR TITLE
Don't declare mu_str_size_s() with the const attribute.

### DIFF
--- a/lib/utils/mu-str.h
+++ b/lib/utils/mu-str.h
@@ -48,7 +48,7 @@ G_BEGIN_DECLS
  * @return a string representation of the size; see above
  * for what to do with it
  */
-const char* mu_str_size_s  (size_t s) G_GNUC_CONST;
+const char* mu_str_size_s  (size_t s);
 char*       mu_str_size    (size_t s) G_GNUC_WARN_UNUSED_RESULT;
 
 


### PR DESCRIPTION
When this function is declared const or pure, clang at -O1 or higher optimizes
away the call to mu_str_size_s() inside mu_str_size(), so that it ignores its
argument and returns whatever is in mu_str_size_s()'s static buffer.

Found when test-mu-str failed while testing an update of mu in OpenBSD's ports tree.