### PR TITLE
NEWS.org, mu4e-vars.e.: fix spelling mu4e-contact-rewrite-function

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -100,7 +100,7 @@
       get the contacts that have changed since the last round.
 
       We also moved sorting the contacts to the mu-side, which speeds things up
-      further. However, as a side-effect of this, ~mu4e-contacts-rewrite-function~
+      further. However, as a side-effect of this, ~mu4e-contact-rewrite-function~
       and ~mu4e-compose-complete-ignore-address-regexp~ have been obsoleted; users
       of those should migrate to ~mu4e-contact-process-function~; see its
       docstring for details.

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -443,7 +443,7 @@ their canonical counterpart; useful as an example."
         (mail (plist-get contact :mail)))
     (list :name name :mail mail)))
 
-(make-obsolete-variable 'mu4e-contacts-rewrite-function
+(make-obsolete-variable 'mu4e-contact-rewrite-function
                         "mu4e-contact-process-function (see docstring)" "mu4e 1.3.2")
 (make-obsolete-variable 'mu4e-compose-complete-ignore-address-regexp
                         "mu4e-contact-process-function (see docstring)" "mu4e 1.3.2")


### PR DESCRIPTION
mu4e-contact-rewrite-function was obsoleted in 1.4, but the entry in
NEWS.org entry, and the make-obsolete-variable call, referred to it as
mu4e-contacts-rewrite-function. (Should be "contact", not "contacts".)