### PR TITLE
mu4e/mu4e-utils: save our position before deleting old data

### DIFF
--- a/lib/index/mu-indexer.cc
+++ b/lib/index/mu-indexer.cc
@@ -270,6 +270,9 @@ Indexer::Private::start(const Indexer::Config& conf)
                         cleanup();
                         clean_done_ = true;
                         g_debug ("cleanup finished");
+                } else {
+                        clean_done_ = true;
+                        g_debug ("cleanup skipped");
                 }
 
                 store_.commit();

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -1000,11 +1000,10 @@ in the background; otherwise, pop up a window."
   "Max number of characters to keep around in the log buffer.")
 (defconst mu4e~log-buffer-name "*mu4e-log*"
   "*internal* Name of the logging buffer.")
-(defun mu4e-log (type frm &rest args)
-  "Write a message of TYPE with format-string FRM and ARGS in
-*mu4e-log* buffer, if the variable mu4e-debug is non-nil. Type is
-either 'to-server, 'from-server or 'misc. This function is meant for debugging."
-  (when mu4e-debug
+
+(defun mu4e~get-log-buffer ()
+  "Fetch (and maybe create) the log buffer."
+  (unless (get-buffer mu4e~log-buffer-name)
     (with-current-buffer (get-buffer-create mu4e~log-buffer-name)
       (view-mode)
 
@@ -1012,7 +1011,15 @@ either 'to-server, 'from-server or 'misc. This function is meant for debugging."
         (unless (eq major-mode 'so-long-mode)
           (eval '(so-long-mode))))
 
-      (setq buffer-undo-list t)
+      (setq buffer-undo-list t)))
+  mu4e~log-buffer-name)
+
+(defun mu4e-log (type frm &rest args)
+  "Write a message of TYPE with format-string FRM and ARGS in
+*mu4e-log* buffer, if the variable mu4e-debug is non-nil. Type is
+either 'to-server, 'from-server or 'misc. This function is meant for debugging."
+  (when mu4e-debug
+    (with-current-buffer (mu4e~get-log-buffer)
       (let* ((inhibit-read-only t)
              (tstamp (propertize (format-time-string "%Y-%m-%d %T.%3N"
                                                      (current-time))

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -1032,21 +1032,22 @@ either 'to-server, 'from-server or 'misc. This function is meant for debugging."
                 (error       'font-lock-warning-face)
                 (otherwise   (mu4e-error "Unsupported log type"))))
              (msg (propertize (apply 'format frm args) 'face msg-face)))
-        (goto-char (point-max))
-        (insert tstamp
-                (cl-case type
-                  (from-server " <- ")
-                  (to-server   " -> ")
-                  (error       " !! ")
-                  (otherwise   " "))
-                msg "\n")
+        (save-excursion
+          (goto-char (point-max))
+          (insert tstamp
+                  (cl-case type
+                    (from-server " <- ")
+                    (to-server   " -> ")
+                    (error       " !! ")
+                    (otherwise   " "))
+                  msg "\n")
 
-        ;; if `mu4e-log-max-lines is specified and exceeded, clearest the oldest
-        ;; lines
-        (when (> (buffer-size) mu4e~log-max-size)
-          (goto-char (- (buffer-size) mu4e~log-max-size))
-          (beginning-of-line)
-          (delete-region (point-min) (point)))))))
+          ;; if `mu4e-log-max-lines is specified and exceeded, clearest the oldest
+          ;; lines
+          (when (> (buffer-size) mu4e~log-max-size)
+            (goto-char (- (buffer-size) mu4e~log-max-size))
+            (beginning-of-line)
+            (delete-region (point-min) (point))))))))
 
 (defun mu4e-toggle-logging ()
   "Toggle between enabling/disabling debug-mode (in debug-mode,


### PR DESCRIPTION
Once your log buffer has filled up every new entry causes you to jump
back to the top of the log. Stop this happening by wrapping the
clean-up in save-excursion.