### PR TITLE
mu4e-main: fix hide-fully-read semantics; make defcustom

### DIFF
--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -39,9 +39,10 @@
   This also hides the warning if your `user-mail-address' is not
 part of the personal addresses.")
 
-(defvar mu4e-main-hide-fully-read nil
-  "When set to t, do not hide bookmarks or maildirs that have
-no unread messages.")
+(defcustom mu4e-main-hide-fully-read nil
+  "When set to t, hide bookmarks or maildirs that have no unread messages."
+  :type 'boolean
+  :group 'mu4e)
 
 (defvar mu4e-main-mode-map
   (let ((map (make-sparse-keymap)))
@@ -119,6 +120,7 @@ clicked."
 
 
 (defun mu4e~main-bookmarks ()
+  "Return bookmarks string for main view."
   ;; TODO: it's a bit uncool to hard-code the "b" shortcut...
   (cl-loop with bmks = (mu4e-bookmarks)
            with longest = (mu4e~longest-of-maildirs-and-bookmarks)
@@ -135,8 +137,8 @@ clicked."
                                              query)
                                        collect q))
            for unread = (and qcounts (plist-get (car qcounts) :unread))
-           when (not (plist-get bm :hide))
-           when (not (and mu4e-main-hide-fully-read (eq unread 0)))
+           unless (or (plist-get bm :hide)
+                      (and mu4e-main-hide-fully-read (eq unread 0)))
            concat (concat
                    ;; menu entry
                    (mu4e~main-action-str


### PR DESCRIPTION
Reverse the semantics of `mu4e-main-hide-fully-read' so that t hides and nil shows.
The behavior now matches the variable name.
Additionally define the variable with defcustom so users may customize
it through the customization system.