### PR TITLE
refactor: access server properties through generic function

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -313,7 +313,7 @@ If needed, set the Fcc header, and register the handler function."
       `mu4e-sent-messages-behavior'"
                          mu4e-sent-messages-behavior))))
          (fccfile (and mdir
-                       (concat (mu4e-root-maildir) mdir "/cur/"
+                       (concat (mu4e~server-prop :root-maildir) mdir "/cur/"
                                (mu4e~draft-message-filename-construct "S")))))
     ;; if there's an fcc header, add it to the file
     (when fccfile
@@ -326,7 +326,7 @@ If needed, set the Fcc header, and register the handler function."
                   (old-handler message-fcc-handler-function))
               (lambda (file)
                 (setq message-fcc-handler-function old-handler) ;; reset the fcc handler
-                (let ((mdir-path (concat (mu4e-root-maildir) maildir)))
+                (let ((mdir-path (concat (mu4e~server-prop :root-maildir) maildir)))
                   ;; Create the full maildir structure for the sent folder if it doesn't exist.
                   ;; `mu4e~proc-mkdir` runs asynchronously but no matter whether it runs before or after
                   ;; `write-file`, the sent maildir ends up in the correct state.

--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -36,7 +36,7 @@
 
 (defcustom mu4e-compose-dont-reply-to-self nil
   "If non-nil, don't include self.
-\(that is, member of `(mu4e-personal-addresses)') in replies."
+\(that is, member of `(mu4e~server-prop :personal-addresses t)') in replies."
   :type 'boolean
   :group 'mu4e-compose)
 
@@ -185,7 +185,7 @@ of the original, we simple copy the list form the original."
            (cl-member-if
             (lambda (addr)
               (string= (downcase addr) (downcase (cdr to-cell))))
-            (mu4e-personal-addresses)))
+            (mu4e~server-prop :personal-addresses t)))
          reply-to)
       reply-to)))
 
@@ -249,7 +249,7 @@ REPLY-ALL."
                  (cl-member-if
                   (lambda (addr)
                     (string= (downcase addr) (downcase (cdr cc-cell))))
-                  (mu4e-personal-addresses)))
+                  (mu4e~server-prop :personal-addresses t)))
                cc-lst))))
       cc-lst)))
 
@@ -538,7 +538,7 @@ This is based on `mu4e-drafts-folder', which is evaluated once.")
 (defun mu4e~draft-determine-path (draft-dir)
   "Determines the path for a new draft file in DRAFT-DIR."
   (format "%s/%s/cur/%s"
-          (mu4e-root-maildir) draft-dir (mu4e~draft-message-filename-construct "DS")))
+          (mu4e~server-prop :root-maildir) draft-dir (mu4e~draft-message-filename-construct "DS")))
 
 
 (defun mu4e-draft-open (compose-type &optional msg)
@@ -548,7 +548,7 @@ In case of a new message (when COMPOSE-TYPE is `reply', `forward'
  or re-send an existing message (when COMPOSE-TYPE is `resend').
 
 The name of the draft folder is constructed from the
-concatenation of `(mu4e-root-maildir)' and `mu4e-drafts-folder' (the
+concatenation of `(mu4e~server-prop :root-maildir)' and `mu4e-drafts-folder' (the
 latter will be evaluated). The message file name is a unique name
 determined by `mu4e-send-draft-file-name'. The initial contents
 will be created from either `mu4e~draft-reply-construct', or

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -598,7 +598,7 @@ cdr element the To: prefix.")
 
 (defun mu4e~headers-from-or-to (msg)
   "When the from address for message MSG is one of the the user's addresses,
-\(as per `mu4e-personal-addresses'), show the To address;
+\(as per `mu4e~server-prop :personal-addresses t'), show the To address;
 otherwise ; show the from address; prefixed with the appropriate
 `mu4e-headers-from-or-to-prefix'."
   (let ((addr (cdr-safe (car-safe (mu4e-message-field msg :from)))))

--- a/mu4e/mu4e-icalendar.el
+++ b/mu4e/mu4e-icalendar.el
@@ -76,7 +76,7 @@
   (let* ((handle (car data))
          (status (cadr data))
          (event (caddr data))
-         (gnus-icalendar-additional-identities (mu4e-personal-addresses))
+         (gnus-icalendar-additional-identities (mu4e~server-prop :personal-addresses t))
          (reply (gnus-icalendar-with-decoded-handle
                  handle
                  (let ((gnus-icalendar-find-if (lambda(pred seq) nil)))

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -226,7 +226,7 @@ When REFRESH is non nil refresh infos from server."
   (with-current-buffer mu4e-main-buffer-name
     (let ((inhibit-read-only t)
           (pos (point))
-          (addrs (mu4e-personal-addresses)))
+          (addrs (mu4e~server-prop :personal-addresses t)))
       (erase-buffer)
       (insert
        "* "
@@ -267,8 +267,8 @@ When REFRESH is non nil refresh infos from server."
 
        "\n"
        (propertize "  Info\n\n" 'face 'mu4e-title-face)
-       (mu4e~key-val "database-path" (mu4e-database-path))
-       (mu4e~key-val "maildir" (mu4e-root-maildir))
+       (mu4e~key-val "database-path" (mu4e~server-prop :database-path))
+       (mu4e~key-val "maildir" (mu4e~server-prop :root-maildir))
        (mu4e~key-val "in store"
                      (format "%d" (plist-get mu4e~server-props :doccount)) "messages")
        (if mu4e-main-buffer-hide-personal-addresses ""

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -292,7 +292,7 @@ The following marks are available, and the corresponding props:
          (target (if (string= (substring target 0 1) "/")
                      target
                    (concat "/" target)))
-         (fulltarget (concat (mu4e-root-maildir) target)))
+         (fulltarget (concat (mu4e~server-prop :root-maildir) target)))
     (when (or (file-directory-p fulltarget)
               (and (yes-or-no-p
                     (format "%s does not exist.  Create now?" fulltarget))
@@ -372,7 +372,7 @@ user which one)."
 
 (defun mu4e~mark-check-target (target)
   "Check if TARGET exists; if not, offer to create it."
-  (let ((fulltarget (concat (mu4e-root-maildir) target)))
+  (let ((fulltarget (concat (mu4e~server-prop :root-maildir) target)))
     (if (not (mu4e-create-maildir-maybe fulltarget))
         (mu4e-error "Target dir %s does not exist " fulltarget)
       target)))

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -279,14 +279,14 @@ expressions, in which case any of those are tried for a match."
 Checks whether any of the of the contacts in field
 CFIELD (either :to, :from, :cc or :bcc) of msg MSG matches *me*,
 that is, any of the e-mail address in
-`(mu4e-personal-addresses)'. Returns the contact cell that
+`(mu4e~server-prop :personal-addresses t)'. Returns the contact cell that
 matched, or nil."
   (cl-find-if
    (lambda (cc-cell)
      (cl-member-if
       (lambda (addr)
         (string= (downcase addr) (downcase (cdr cc-cell))))
-      (mu4e-personal-addresses)))
+      (mu4e~server-prop :personal-addresses t)))
    (mu4e-message-field msg cfield)))
 
 (defsubst mu4e-message-part-field  (msgpart field)

--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -438,7 +438,7 @@ Returns either (:update ... ) or (:error ) sexp, which are handled my
   (unless (or maildir flags)
     (mu4e-error "At least one of maildir and flags must be specified"))
   (unless (or (not maildir)
-              (file-exists-p (concat (mu4e-root-maildir) "/" maildir "/")))
+              (file-exists-p (concat (mu4e~server-prop :root-maildir) "/" maildir "/")))
     (mu4e-error "Target dir does not exist"))
   (mu4e~call-mu `(move
                   :docid ,(if (stringp docid-or-msgid) nil docid-or-msgid)

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -58,7 +58,7 @@ Setting this to t increases the amount of information in the log."
   :group 'mu4e)
 
 (make-obsolete-variable 'mu4e-maildir
-                        "determined by server; see `mu4e-root-maildir'." "1.3.8")
+                        "determined by server; see `mu4e~server-prop'." "1.3.8")
 
 (defcustom mu4e-org-support t
   "Support org-mode links."
@@ -192,7 +192,7 @@ mime-type are nill."
 (make-obsolete-variable 'mu4e-my-email-addresses
                         'mu4e-user-mail-address-list "0.9.9.x")
 (make-obsolete-variable 'mu4e-user-mail-address-list
-                        "determined by server; see `mu4e-personal-addresses'." "1.3.8")
+                        "determined by server; see `mu4e~server-prop'." "1.3.8")
 
 (defcustom mu4e-use-fancy-chars nil
   "When set, allow fancy (Unicode) characters for marks/threads.
@@ -230,18 +230,18 @@ are plists" "1.3.7")
 
 (defcustom mu4e-bookmarks
   '(( :name  "Unread messages"
-             :query "flag:unread AND NOT flag:trashed"
-             :key ?u)
+      :query "flag:unread AND NOT flag:trashed"
+      :key ?u)
     ( :name "Today's messages"
-            :query "date:today..now"
-            :key ?t)
+      :query "date:today..now"
+      :key ?t)
     ( :name "Last 7 days"
-            :query "date:7d..now"
-            :hide-unread t
-            :key ?w)
+      :query "date:7d..now"
+      :hide-unread t
+      :key ?w)
     ( :name "Messages with images"
-            :query "mime:image/*"
-            :key ?p))
+      :query "mime:image/*"
+      :key ?p))
   "List of pre-defined queries that are shown on the main screen.
 
 Each of the list elements is a plist with at least:
@@ -829,7 +829,7 @@ mu4e-compose-mode."
   :group 'mu4e-faces)
 
 (defface mu4e-region-code
-    '((t (:background "DarkSlateGray")))
+  '((t (:background "DarkSlateGray")))
   "Face for highlighting marked region in mu4e-view buffer."
   :group 'mu4e-faces)
 
@@ -838,120 +838,120 @@ mu4e-compose-mode."
 (defconst mu4e-header-info
   '((:attachments
      . (:name "Attachments"
-        :shortname "Atts"
-        :help "Message attachments"
-        :require-full t
-        :sortable nil))
+              :shortname "Atts"
+              :help "Message attachments"
+              :require-full t
+              :sortable nil))
     (:bcc
      . (:name "Bcc"
-        :shortname "Bcc"
-        :help "Blind Carbon-Copy recipients for the message"
-        :sortable t))
+              :shortname "Bcc"
+              :help "Blind Carbon-Copy recipients for the message"
+              :sortable t))
     (:cc
      . (:name "Cc"
-        :shortname "Cc"
-        :help "Carbon-Copy recipients for the message"
-        :sortable t))
+              :shortname "Cc"
+              :help "Carbon-Copy recipients for the message"
+              :sortable t))
     (:date
      . (:name "Date"
-        :shortname "Date"
-        :help "Date/time when the message was written"
-        :sortable t))
+              :shortname "Date"
+              :help "Date/time when the message was written"
+              :sortable t))
     (:human-date
      . (:name "Date"
-        :shortname "Date"
-        :help "Date/time when the message was written."
-        :sortable :date))
+              :shortname "Date"
+              :help "Date/time when the message was written."
+              :sortable :date))
     (:flags
      . (:name "Flags"
-        :shortname "Flgs"
-        :help "Flags for the message"
-        :sortable nil))
+              :shortname "Flgs"
+              :help "Flags for the message"
+              :sortable nil))
     (:from
      . (:name "From"
-        :shortname "From"
-        :help "The sender of the message"
-        :sortable t))
+              :shortname "From"
+              :help "The sender of the message"
+              :sortable t))
     (:from-or-to
      . (:name "From/To"
-        :shortname "From/To"
-        :help "Sender of the message if it's not me; otherwise the recipient"
-        :sortable nil))
+              :shortname "From/To"
+              :help "Sender of the message if it's not me; otherwise the recipient"
+              :sortable nil))
     (:maildir
      . (:name "Maildir"
-        :shortname "Maildir"
-        :help "Maildir for this message"
-        :sortable t))
+              :shortname "Maildir"
+              :help "Maildir for this message"
+              :sortable t))
     (:list
      . (:name "List-Id"
-        :shortname "List"
-        :help "Mailing list id for this message"
-        :sortable t))
+              :shortname "List"
+              :help "Mailing list id for this message"
+              :sortable t))
     (:mailing-list
      . (:name "List"
-        :shortname "List"
-        :help "Mailing list friendly name for this message"
-        :sortable :list))
+              :shortname "List"
+              :help "Mailing list friendly name for this message"
+              :sortable :list))
     (:message-id
      . (:name "Message-Id"
-        :shortname "MsgID"
-        :help "Message-Id for this message"
-        :sortable nil))
+              :shortname "MsgID"
+              :help "Message-Id for this message"
+              :sortable nil))
     (:path
      . (:name "Path"
-        :shortname "Path"
-        :help "Full filesystem path to the message"
-        :sortable t))
+              :shortname "Path"
+              :help "Full filesystem path to the message"
+              :sortable t))
     (:signature
      . (:name "Signature"
-        :shortname "Sgn"
-        :help "Check for the cryptographic signature"
-        :require-full t
-        :sortable nil))
+              :shortname "Sgn"
+              :help "Check for the cryptographic signature"
+              :require-full t
+              :sortable nil))
     (:decryption
      . (:name "Decryption"
-        :shortname "Dec"
-        :help "Check the cryptographic decryption status"
-        :require-full t
-        :sortable nil))
+              :shortname "Dec"
+              :help "Check the cryptographic decryption status"
+              :require-full t
+              :sortable nil))
     (:size
      . (:name "Size"
-        :shortname "Size"
-        :help "Size of the message"
-        :sortable t))
+              :shortname "Size"
+              :help "Size of the message"
+              :sortable t))
     (:subject
      . (:name "Subject"
-        :shortname "Subject"
-        :help "Subject of the message"
-        :sortable t))
+              :shortname "Subject"
+              :help "Subject of the message"
+              :sortable t))
     (:tags
      . (:name "Tags"
-        :shortname "Tags"
-        :help "Tags for the message"
-        :sortable nil))
+              :shortname "Tags"
+              :help "Tags for the message"
+              :sortable nil))
     (:thread-subject
      . (:name "Subject"
-        :shortname "Subject"
-        :help "Subject of the thread"
-        :sortable :subject))
+              :shortname "Subject"
+              :help "Subject of the thread"
+              :sortable :subject))
     (:to
      . (:name "To"
-        :shortname "To"
-        :help "Recipient of the message"
-        :sortable t))
+              :shortname "To"
+              :help "Recipient of the message"
+              :sortable t))
     (:user-agent
      . (:name "User-Agent"
-        :shortname "UA"
-        :help "Program used for writing this message"
-        :require-full t
-        :sortable t)))
+              :shortname "UA"
+              :help "Program used for writing this message"
+              :require-full t
+              :sortable t)))
   "An alist of all possible header fields and information about them.
 This is used in the user-interface (the column headers in the header list, and
 the fields the message view).
 
 Most fields should be self-explanatory. A special one is
 `:from-or-to', which is equal to `:from' unless `:from' matches
-one of the addresses in `(mu4e-personal-addresses)', in which
+one of the addresses in `(mu4e~server-prop :personal-addresses t)', in which
 case it will be equal to `:to'.
 
 Furthermore, the property `:sortable' determines whether we can
@@ -969,13 +969,13 @@ Note, `:sortable' is not supported for custom header fields.")
 (defvar mu4e-header-info-custom
   '( (:recipnum .
                 ( :name "Number of recipients"
-                        :shortname "Recip#"
-                        :help "Number of recipients for this message"
-                        :function
-                        (lambda (msg)
-                          (format "%d"
-                                  (+ (length (mu4e-message-field msg :to))
-                                     (length (mu4e-message-field msg :cc))))))))
+                  :shortname "Recip#"
+                  :help "Number of recipients for this message"
+                  :function
+                  (lambda (msg)
+                    (format "%d"
+                            (+ (length (mu4e-message-field msg :to))
+                               (length (mu4e-message-field msg :cc))))))))
   "A list of custom (user-defined) headers.
 The format is similar to `mu4e-header-info', but adds a :function
 property, which should point to a function that takes a message
@@ -1023,33 +1023,15 @@ mu4e-compose.")
 (defvar mu4e~server-props nil
   "Information  we receive from the mu4e server process \(in the 'pong-handler').")
 
-(defun mu4e-root-maildir()
-  "Get the root maildir."
-  (let ((root-maildir (and mu4e~server-props
-                           (plist-get mu4e~server-props :root-maildir))))
-    (unless root-maildir
-      (mu4e-error "root maildir unknown; did you start mu4e?"))
-    root-maildir))
-
-(defun mu4e-database-path()
-  "Get the mu4e database path"
-  (let ((path (and mu4e~server-props
-                   (plist-get mu4e~server-props :database-path))))
-    (unless path
-      (mu4e-error "database-path unknown; did you start mu4e?"))
-    path))
-
-(defun mu4e-personal-addresses()
-  "Get the user's personal addresses, if any."
-  (when mu4e~server-props (plist-get mu4e~server-props :personal-addresses)))
-
-(defun mu4e-server-version()
-  "Get the server version, which should match mu4e's."
-  (let ((version (and mu4e~server-props (plist-get mu4e~server-props :version))))
-    (unless version
-      (mu4e-error "version unknown; did you start mu4e?"))
-    version))
-
+(defun mu4e~server-prop (property &optional noerror)
+  "Return PROPERTY from `mu4e~server-props'.
+If PROPERTY is nil an error is signaled unless NOERROR is non-nil."
+  (or (plist-get mu4e~server-props property)
+      (unless noerror
+        (mu4e-error
+         (concat "Uknown "
+                 (replace-regexp-in-string "-" " " (substring (symbol-name property) 1))
+                 ". Did you start mu4e?")))))
 
 
 ;;; Handler functions

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -399,7 +399,7 @@ article-mode."
           (gnus-blocked-images ".") ;; don't load external images.
           ;; Possibly add headers (before "Attachments")
           (gnus-display-mime-function (mu4e~view-gnus-display-mime msg))
-          (gnus-icalendar-additional-identities (mu4e-personal-addresses)))
+          (gnus-icalendar-additional-identities (mu4e~server-prop :personal-addresses t)))
       (gnus-article-prepare-display))
     (setq mu4e~view-message msg)
     (mu4e-view-mode)

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -2780,7 +2780,7 @@ message. An example should clarify this:
       ((find-if
 	 (lambda (addr)
 	   (mu4e-message-contact-field-matches msg :from addr))
-	 (mu4e-personal-addresses))
+	 (mu4e~server-prop :personal-addresses t))
 	mu4e-sent-folder)
       ;; everything else goes to /archive
       ;; important to have a catch-all at the end!
@@ -3187,7 +3187,7 @@ maildirs.
 @item @code{mu4e-running-p}: return @code{t} if the @t{mu4e} process is
 running, @code{nil} otherwise.
 @item @code{(mu4e-user-mail-address-p addr)}: return @code{t} if @var{addr} is
-one of the user's e-mail addresses (as per @code{(mu4e-personal-addresses)}).
+one of the user's e-mail addresses (as per @code{(mu4e~server-prop :personal-addresses t)}).
 @item @code{mu4e-log} logs to the @t{mu4e} debugging log if it is enabled;
 see @code{mu4e-toggle-logging}.
 @item @code{mu4e-message}, @code{mu4e-warning}, @code{mu4e-error} are the


### PR DESCRIPTION
New function, `mu4e~server-prop', allows accessing server properties
generically, rather than defining a function per property.

This should scale better as it doesn't repeat any logic per property.
If necessary, a property-specific function could easily be defined via `apply-partially'.