### PR TITLE
[MSYS2] Added missing include files

### DIFF
--- a/lib/index/mu-scanner.cc
+++ b/lib/index/mu-scanner.cc
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <atomic>
 #include <thread>
+#include <cstring>
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/lib/utils/mu-logger.cc
+++ b/lib/utils/mu-logger.cc
@@ -26,6 +26,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <cstring>
 
 #include "mu-logger.hh"
 


### PR DESCRIPTION
The latest code cannot be successfully compiled on windows:
```sh
mu-logger.cc:81:40: error: 鈥▒::strerror鈥▒ has not been declared; did you mean 鈥▒g_strerror鈥▒?
81 |                           << ": " << ::strerror(errno) << std::endl;
mu-scanner.cc:167:70: error: 鈥▒strerror鈥▒ was not declared in this scope; did you mean 鈥▒g_strerror鈥▒?
167 |                 g_warning("'%s' is not stat'able: %s", path.c_str(), strerror (errno));
```
The cause of this error is that the header file required by `strerror` does not explicitly contain: `cstring.h`.
This PR fixed it.