### PR TITLE
Guile 3.0 support

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -108,6 +108,10 @@
     - The mu4e <-> mu interaction has been rewritten to communicate using
       s-expressions, with a repl for testing.
 
+*** guile
+
+    - guile 3.0 is now supported; guile 2.2 still works.
+
 *** toys
 
     - Updated the ~mug~ toy UI to use Webkit2/GTK+. Note that this is just a toy

--- a/configure.ac
+++ b/configure.ac
@@ -219,22 +219,22 @@ AM_CONDITIONAL(BUILD_GUI,[test "x$have_webkit" = "xyes" -a "x$have_gtk" = "xyes"
 ###############################################################################
 
 ###############################################################################
-# build with guile2.2 when available and not disabled.
+# build with guile 3.0/2.2 when available and not disabled.
 AC_ARG_ENABLE([guile], AS_HELP_STRING([--disable-guile],[Disable guile]))
 AS_IF([test "x$enable_guile" != "xno"],[
-  PKG_CHECK_MODULES(GUILE22, guile-2.2, [have_guile22=yes],[have_guile22=no])
-  # this is a bit hacky; GUILE_PKG
-  AS_IF([test "x$have_guile22" = "xyes"],[
-    GUILE_PKG([2.2])
+  PKG_CHECK_MODULES(GUILE, [guile-2.2], [have_guile=yes], [have_guile=no])
+  PKG_CHECK_MODULES(GUILE, [guile-3.0], [have_guile=yes])
+  AS_IF([test "x$have_guile" = "xyes"],[
+    GUILE_PKG([3.0 2.2])
     GUILE_PROGS
     GUILE_FLAGS
     AC_DEFINE_UNQUOTED([GUILE_BINARY],"$GUILE",[guile binary])
     AC_DEFINE(BUILD_GUILE,[1], [Do we support Guile?])
     AC_SUBST(GUILE_SNARF, [guile-snarf])
-    guile_version=$($PKG_CONFIG guile-2.2 --modversion)
+    guile_version=$($PKG_CONFIG guile-$GUILE_EFFECTIVE_VERSION --modversion)
   ])
 ])
-AM_CONDITIONAL(BUILD_GUILE,[test "x$have_guile22" = "xyes"])
+AM_CONDITIONAL(BUILD_GUILE,[test "x$have_guile" = "xyes"])
 ###############################################################################
 
 ###############################################################################

--- a/guile/Makefile.am
+++ b/guile/Makefile.am
@@ -68,7 +68,7 @@ SUFFIXES = .x .doc
 
 # FIXME: GUILE_SITEDIR would be better, but that
 # breaks 'make distcheck'
-scmdir=${prefix}/share/guile/site/2.2/
+scmdir=${prefix}/share/guile/site/${GUILE_EFFECTIVE_VERSION}
 scm_DATA=mu.scm
 
 EXTRA_DIST=$(scm_DATA)

--- a/guile/mu/Makefile.am
+++ b/guile/mu/Makefile.am
@@ -16,9 +16,7 @@
 
 include $(top_srcdir)/gtest.mk
 
-# FIXME: GUILE_SITEDIR would be better, but that
-# breaks 'make distcheck'
-scmdir=${prefix}/share/guile/site/2.2/mu/
+scmdir=${prefix}/share/guile/site/${GUILE_EFFECTIVE_VERSION}/mu/
 
 scm_DATA=		\
 	stats.scm	\

--- a/m4/Makefile.am
+++ b/m4/Makefile.am
@@ -41,7 +41,7 @@ EXTRA_DIST=				\
 	ax_lib_readline.m4		\
 	ax_require_defined.m4		\
 	ax_valgrind_check.m4		\
-	guile-2.2.m4			\
+	guile.m4			\
 	lib-ld.m4			\
 	lib-link.m4			\
 	lib-prefix.m4

--- a/m4/guile.m4
+++ b/m4/guile.m4
@@ -47,8 +47,8 @@
 # for an available version of Guile.
 #
 # By default, this macro will search for the latest stable version of
-# Guile (e.g. 2.2), falling back to the previous stable version
-# (e.g. 2.0) if it is available.  If no guile-@var{VERSION}.pc file is
+# Guile (e.g. 3.0), falling back to the previous stable version
+# (e.g. 2.2) if it is available.  If no guile-@var{VERSION}.pc file is
 # found, an error is signalled.  The found version is stored in
 # @var{GUILE_EFFECTIVE_VERSION}.
 #
@@ -60,8 +60,11 @@
 # @code{AC_SUBST}.
 #
 AC_DEFUN([GUILE_PKG],
- [PKG_PROG_PKG_CONFIG
-  _guile_versions_to_search="m4_default([$1], [2.2 2.0 1.8])"
+ [AC_REQUIRE([PKG_PROG_PKG_CONFIG])
+  if test "x$PKG_CONFIG" = x; then
+    AC_MSG_ERROR([pkg-config is missing, please install it])
+  fi
+  _guile_versions_to_search="m4_default([$1], [3.0 2.2 2.0])"
   if test -n "$GUILE_EFFECTIVE_VERSION"; then
     _guile_tmp=""
     for v in $_guile_versions_to_search; do
@@ -221,7 +224,7 @@ AC_DEFUN([GUILE_SITE_DIR],
 # as well.
 #
 # By default, this macro will search for the latest stable version of
-# Guile (e.g. 2.2). x.y or x.y.z versions can be specified. If an older
+# Guile (e.g. 3.0). x.y or x.y.z versions can be specified. If an older
 # version is found, the macro will signal an error.
 #
 # The effective version of the found @code{guile} is set to
@@ -237,7 +240,7 @@ AC_DEFUN([GUILE_SITE_DIR],
 AC_DEFUN([GUILE_PROGS],
  [_guile_required_version="m4_default([$1], [$GUILE_EFFECTIVE_VERSION])"
   if test -z "$_guile_required_version"; then
-    _guile_required_version=2.2
+    _guile_required_version=3.0
   fi
 
   _guile_candidates=guile

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -240,9 +240,9 @@ higher is required, as well as
 Xapian@footnote{@url{https://xapian.org/}} and
 GMime@footnote{@url{http://spruce.sourceforge.net/gmime/}}.
 
-@t{mu} has optional support for the Guile 2.2 (Scheme) programming
-language. There are also some GUI-toys, which require GTK+ 3.x and
-Webkit.
+@t{mu} has optional support for both versions 2.2 and 3.0 of the Guile
+(Scheme) programming language. There are also some GUI-toys, which
+require GTK+ 3.x and Webkit.
 
 If you intend to compile @t{mu} yourself, you need to have the typical
 development tools, such as C and C++ compilers (both @command{gcc} and


### PR DESCRIPTION
Hullo!

GNU Guile released [version 3.0 in January](https://www.gnu.org/software/guile/news/gnu-guile-300-released.html); this patch should allow mu to build with either v2.2 or v3.0 of that language. (The bindings don't seem to have needed any changes, but I hacked the build to be more flexible.)

I'm not the greatest coder, but this builds and passes all the tests on my machine. I use Guix, which uses Guile a lot, and let me switch between building against both versions.

There were a couple of comments in the original code talking about how hacky the solution was for 2.2, and how its path needed to be hard-coded  to avoid a `make distcheck` error.  I didn't see any problems and this new code seems to build okay, so I took out those comments too. 

This patch is for the v1.14.x branch.