### PR TITLE
Remove configuration check for timegm()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,7 +122,8 @@ AS_IF([test "x$ac_cv_member_struct_dirent_d_ino" != "xyes"],
 
 AC_CHECK_FUNCS([memset memcpy realpath setlocale strerror getpass setsid])
 AC_CHECK_FUNCS([vasprintf strptime])
-AC_CHECK_FUNC(timegm,[],AC_MSG_ERROR([missing required function timegm]))
+# timegm is no longer used in the source
+# AC_CHECK_FUNC(timegm,[],AC_MSG_ERROR([missing required function timegm]))
 
 # require pkg-config >= 0.28 (release in 2013; should be old enough...)
 # with that version, we don't need the AC_SUBST stuff after PKG_CHECK.

--- a/lib/utils/mu-logger.cc
+++ b/lib/utils/mu-logger.cc
@@ -65,7 +65,7 @@ maybe_rotate_logfile ()
                 return true;
 
         GStatBuf statbuf;
-        if (::stat (MuLogPath.c_str(), &statbuf) == -1 ||
+        if (g_stat(MuLogPath.c_str(), &statbuf) == -1 ||
             statbuf.st_size <= MaxLogFileSize)
                 return true;
 


### PR DESCRIPTION
timegm() is no longer used in the mu source base. I am trying to find what are the minimal changes to allow configuring this code in mingw/msys (which is my preferred basis for compiling Emacs itself).