### PR TITLE
Allow use of Maildir FAT extension changing the Maildir info separator

### DIFF
--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -396,10 +396,10 @@ You can append flags."
                       (substring sysname
                                  (string-match "^[^.]+" sysname)
                                  (match-end 0))))))
-    (format "%s.%04x%04x%04x%04x.%s:2,%s"
+    (format "%s.%04x%04x%04x%04x.%s%s2,%s"
             (format-time-string "%s" (current-time))
             (random 65535) (random 65535) (random 65535) (random 65535)
-            hostname (or flagstr ""))))
+            hostname mu4e-maildir-info-delimiter (or flagstr ""))))
 
 (defun mu4e~draft-common-construct ()
   "Construct the common headers for each message."

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -619,6 +619,16 @@ NOT be quoted, since mu4e does this for you."
   :version "1.3.9"
   :group 'mu4e-folders)
 
+(defcustom mu4e-maildir-info-delimiter
+  (if (member system-type '(ms-dos windows-nt cygwin))
+      ";" ":")
+  "Separator character between message identifier and flags.
+It defaults to ':' on most platforms, except on Windows,
+where it is not allowed and we use ';' for compatibility
+with mbsync, offlineimap and other programs."
+  :type 'string
+  :group 'mu4e-folders)
+
 
 (defun mu4e-maildir-shortcuts ()
   "Get `mu4e-maildir-shortcuts' in the (new) format, converting


### PR DESCRIPTION
When working on Windows systems, mbsync and other software uses ';' as separator for Maildir flags, because ':' is not allowed in file names. Change the function that creates names for draft and sent emails, so that it depends on a global customizable variable that determines this separator.