### PR TITLE
mu_maildir_get_new_path() did not use the right flags separator

### DIFF
--- a/lib/mu-maildir.c
+++ b/lib/mu-maildir.c
@@ -779,24 +779,24 @@ get_new_basename (void)
 				g_get_host_name ());
 }
 
-static const char*
-get_path_separator(const char *path)
+static char*
+find_path_separator(const char *path)
 {
-    const char *cur;
-    for (cur = &path[strlen(path)-1]; cur > path; --cur) {
-        if ((*cur == ':' || *cur == '!' || *cur == ';') &&
-            (cur[1] == '2' && cur[2] == ',')) {
-            return cur;
+        const char *cur;
+        for (cur = &path[strlen(path)-1]; cur > path; --cur) {
+                if ((*cur == ':' || *cur == '!' || *cur == ';') &&
+                    (cur[1] == '2' && cur[2] == ',')) {
+                        return (char*)cur;
+                }
         }
-    }
-    return NULL;
+        return NULL;
 }
 
 char*
 mu_maildir_get_new_path (const char *oldpath, const char *new_mdir,
 			 MuFlags newflags, gboolean new_name)
 {
-    char *mfile, *mdir, *custom_flags, *newpath, flags_sep = ':';
+        char *mfile, *mdir, *custom_flags, *cur, *newpath, flags_sep = ':';
 
 	g_return_val_if_fail (oldpath, NULL);
 
@@ -807,30 +807,27 @@ mu_maildir_get_new_path (const char *oldpath, const char *new_mdir,
 	if (!mdir)
 		return NULL;
 
-    /* determine the name of the location of the flag separator */
+        /* determine the name of the location of the flag separator */
 
 	if (new_name) {
-        const char *cur;
 		mfile = get_new_basename ();
-        cur = get_path_separator (oldpath);
-        if (cur) {
-            /* preserve the existing flags separator
-             * in the new file name */
-            flags_sep = *cur;
-        }
-    } else {
-        char *cur;
-        mfile = g_path_get_basename (oldpath);
-        cur = (char*) get_path_separator (mfile);
-        if (cur) {
-            /* get the custom flags (if any) */
-            custom_flags =
-                mu_flags_custom_from_str (cur + 3);
-            /* preserve the existing flags separator
-             * in the new file name */
-            flags_sep = *cur;
-            cur[0] = '\0'; /* strip the flags */
-        }
+                cur = find_path_separator (oldpath);
+                if (cur) {
+                        /* preserve the existing flags separator
+                         * in the new file name */
+                        flags_sep = *cur;
+                }
+        } else {
+                mfile = g_path_get_basename (oldpath);
+                cur = find_path_separator (mfile);
+                if (cur) {
+                        /* get the custom flags (if any) */
+                        custom_flags = mu_flags_custom_from_str (cur + 3);
+                        /* preserve the existing flags separator
+                         * in the new file name */
+                        flags_sep = *cur;
+                        cur[0] = '\0'; /* strip the flags */
+                }
 	}
 
 	newpath = get_new_path (new_mdir ? new_mdir : mdir,

--- a/lib/mu-maildir.c
+++ b/lib/mu-maildir.c
@@ -782,21 +782,21 @@ get_new_basename (void)
 static char*
 find_path_separator(const char *path)
 {
-        const char *cur;
-        for (cur = &path[strlen(path)-1]; cur > path; --cur) {
-                if ((*cur == ':' || *cur == '!' || *cur == ';') &&
-                    (cur[1] == '2' && cur[2] == ',')) {
-                        return (char*)cur;
-                }
-        }
-        return NULL;
+	const char *cur;
+	for (cur = &path[strlen(path)-1]; cur > path; --cur) {
+		if ((*cur == ':' || *cur == '!' || *cur == ';') &&
+		    (cur[1] == '2' && cur[2] == ',')) {
+			return (char*)cur;
+		}
+	}
+	return NULL;
 }
 
 char*
 mu_maildir_get_new_path (const char *oldpath, const char *new_mdir,
 			 MuFlags newflags, gboolean new_name)
 {
-        char *mfile, *mdir, *custom_flags, *cur, *newpath, flags_sep = ':';
+	char *mfile, *mdir, *custom_flags, *cur, *newpath, flags_sep = ':';
 
 	g_return_val_if_fail (oldpath, NULL);
 
@@ -811,23 +811,23 @@ mu_maildir_get_new_path (const char *oldpath, const char *new_mdir,
 
 	if (new_name) {
 		mfile = get_new_basename ();
-                cur = find_path_separator (oldpath);
-                if (cur) {
-                        /* preserve the existing flags separator
-                         * in the new file name */
-                        flags_sep = *cur;
-                }
-        } else {
-                mfile = g_path_get_basename (oldpath);
-                cur = find_path_separator (mfile);
-                if (cur) {
-                        /* get the custom flags (if any) */
-                        custom_flags = mu_flags_custom_from_str (cur + 3);
-                        /* preserve the existing flags separator
-                         * in the new file name */
-                        flags_sep = *cur;
-                        cur[0] = '\0'; /* strip the flags */
-                }
+		cur = find_path_separator (oldpath);
+		if (cur) {
+			/* preserve the existing flags separator
+			 * in the new file name */
+			flags_sep = *cur;
+		}
+	} else {
+		mfile = g_path_get_basename (oldpath);
+		cur = find_path_separator (mfile);
+		if (cur) {
+			/* get the custom flags (if any) */
+			custom_flags = mu_flags_custom_from_str (cur + 3);
+			/* preserve the existing flags separator
+			 * in the new file name */
+			flags_sep = *cur;
+			cur[0] = '\0'; /* strip the flags */
+		}
 	}
 
 	newpath = get_new_path (new_mdir ? new_mdir : mdir,


### PR DESCRIPTION
mu_maildir_get_new_path() is on charge of renaming messages, moving them to different folders. When new_name is 0, it reuses the old name and properly identifies the flags separator. However, when new_name is 1 (which is needed, for instance, for mbsync), it always creates a file name with ':' as flags separator, which is incorrect on MS-DOS based filesystems.