### PR TITLE
Check for nil before calling mu4e-user-mail-address-p

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -608,7 +608,7 @@ cdr element the To: prefix.")
 otherwise ; show the from address; prefixed with the appropriate
 `mu4e-headers-from-or-to-prefix'."
   (let ((addr (cdr-safe (car-safe (mu4e-message-field msg :from)))))
-    (if (mu4e-user-mail-address-p addr)
+    (if (and addr (mu4e-user-mail-address-p addr))
         (concat (cdr mu4e-headers-from-or-to-prefix)
                 (mu4e~headers-contact-str (mu4e-message-field msg :to)))
       (concat (car mu4e-headers-from-or-to-prefix)


### PR DESCRIPTION
Got a few errors in `*mu4e-headers*` while skimming through a junk folder due to a nil :from address.
I'd rather have mu4e-user-mail-address-p not called in such cases, so we filter it earlier.

There's a similar second instance in mu4e-view.el:272 , when constructing "from-to", but I'm not sure if that's applicable? (I couldn't select a message that would trigger it).