### PR TITLE
Use functions instead of lambdas in add-hook calls

### DIFF
--- a/mu4e/mu4e-contrib.el
+++ b/mu4e/mu4e-contrib.el
@@ -59,16 +59,18 @@
 ;;
 ;;  Allow bookmarking a mu4e buffer in regular emacs bookmarks.
 
+(defun mu4e~view-set-bookmark-make-record-fn ()
+  (set (make-local-variable 'bookmark-make-record-function)
+       'mu4e-view-bookmark-make-record))
+
+(defun mu4e~headers-set-bookmark-make-record-fn ()
+  (set (make-local-variable 'bookmark-make-record-function)
+       'mu4e-view-bookmark-make-record))
+
 ;; Probably this can be moved to mu4e-view.el.
-(add-hook 'mu4e-view-mode-hook
-          (lambda ()
-            (set (make-local-variable 'bookmark-make-record-function)
-                 'mu4e-view-bookmark-make-record)))
+(add-hook 'mu4e-view-mode-hook #'mu4e~view-set-bookmark-make-record-fn)
 ;; And this can be moved to mu4e-headers.el.
-(add-hook 'mu4e-headers-mode-hook
-          (lambda ()
-            (set (make-local-variable 'bookmark-make-record-function)
-                 'mu4e-view-bookmark-make-record)))
+(add-hook 'mu4e-headers-mode-hook #'mu4e~headers-set-bookmark-make-record-fn)
 
 (defun mu4e-view-bookmark-make-record ()
   "Make a bookmark entry for a mu4e buffer. Note that this is an

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1136,7 +1136,8 @@ no user-interaction ongoing."
   ;; maybe update the current headers upon indexing changes
   (add-hook 'mu4e-index-updated-hook 'mu4e~headers-maybe-auto-update)
   (add-hook 'mu4e-index-updated-hook
-            (lambda() (run-hooks 'mu4e-message-changed-hook)) t)
+            #'mu4e~headers-index-updated-hook-fn
+            t)
   (setq
    truncate-lines t
    buffer-undo-list t ;; don't record undo information
@@ -1145,6 +1146,9 @@ no user-interaction ongoing."
 
   (mu4e~mark-initialize) ;; initialize the marking subsystem
   (hl-line-mode 1))
+
+(defun mu4e~headers-index-updated-hook-fn ()
+  (run-hooks 'mu4e-message-changed-hook))
 
 ;;; Highlighting
 

--- a/mu4e/mu4e-icalendar.el
+++ b/mu4e/mu4e-icalendar.el
@@ -163,10 +163,12 @@ response in icalendar format."
       ;; also trash the message (thus must be appended to hooks).
       (add-hook
        'message-sent-hook
-       (lambda () (setq mu4e-sent-func
-                   (mu4e~icalendar-trash-message original-msg)))
+       #'mu4e~icalendar-setup-sent-hook-fn
        t t))))
 
+(defun mu4e~icalendar-setup-sent-hook-fn ()
+  (setq mu4e-sent-func
+        (mu4e~icalendar-trash-message original-msg)))
 
 (defun mu4e~icalendar-insert-diary (event reply-status filename)
   "Insert a diary entry for the EVENT in file named FILENAME.

--- a/mu4e/mu4e-speedbar.el
+++ b/mu4e/mu4e-speedbar.el
@@ -55,11 +55,7 @@
 (defun mu4e-speedbar-install-variables ()
   "Install those variables used by speedbar to enhance mu4e."
   (add-hook 'mu4e-context-changed-hook
-            (lambda()
-              (when (buffer-live-p speedbar-buffer)
-                (with-current-buffer speedbar-buffer
-                  (let ((inhibit-read-only t))
-                    (mu4e-speedbar-buttons))))))
+            #'mu4e~speedbar-context-changed-hook-fn)
   (dolist (keymap
            '( mu4e-main-speedbar-key-map
               mu4e-headers-speedbar-key-map
@@ -68,6 +64,12 @@
       (setq keymap (speedbar-make-specialized-keymap))
       (define-key keymap "RET" 'speedbar-edit-line)
       (define-key keymap "e" 'speedbar-edit-line))))
+
+(defun mu4e~speedbar-context-changed-hook-fn ()
+  (when (buffer-live-p speedbar-buffer)
+    (with-current-buffer speedbar-buffer
+      (let ((inhibit-read-only t))
+        (mu4e-speedbar-buttons)))))
 
 ;; Make sure our special speedbar major mode is loaded
 (if (featurep 'speedbar)

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -407,12 +407,14 @@ article-mode."
     (mu4e-view-mode)
     (setq gnus-article-decoded-p gnus-article-decode-hook)
     (set-buffer-modified-p nil)
-    (add-hook 'kill-buffer-hook
-              (lambda() ;; cleanup the mm-* buffers that the view spawns
-                (when mu4e~gnus-article-mime-handles
-                  (mm-destroy-parts mu4e~gnus-article-mime-handles)
-                  (setq mu4e~gnus-article-mime-handles nil))))
+    (add-hook 'kill-buffer-hook #'mu4e~view-kill-buffer-hook-fn)
     (read-only-mode)))
+
+(defun mu4e~view-kill-buffer-hook-fn ()
+  ;; cleanup the mm-* buffers that the view spawns
+  (when mu4e~gnus-article-mime-handles
+    (mm-destroy-parts mu4e~gnus-article-mime-handles)
+    (setq mu4e~gnus-article-mime-handles nil)))
 
 (defun mu4e~view-gnus-display-mime (msg)
   "Same as `gnus-display-mime' but add a mu4e headers to MSG."

--- a/mu4e/org-mu4e.el
+++ b/mu4e/org-mu4e.el
@@ -185,8 +185,7 @@ or org-mode (when in the body)."
        ((and (> (point) sepapoint) (eq major-mode 'mu4e-compose-mode))
         (org-mode)
         (add-hook 'before-save-hook
-                  (lambda ()
-                    (mu4e-error "Switch to mu4e-compose-mode (M-m) before saving"))
+                  #'org~mu4e-error-before-save-hook-fn
                   nil t)
         (org~mu4e-mime-decorate-headers)
         (local-set-key (kbd "M-m")
@@ -202,6 +201,9 @@ or org-mode (when in the body)."
         (add-hook 'message-send-hook 'org~mu4e-mime-convert-to-html-maybe nil t)))
       ;; and add the hook
       (add-hook 'post-command-hook 'org~mu4e-mime-switch-headers-or-body t t))))
+
+(defun org~mu4e-error-before-save-hook-fn ()
+  (mu4e-error "Switch to mu4e-compose-mode (M-m) before saving"))
 
 (defun org-mu4e-compose-org-mode ()
   "Defines a pseudo-minor mode for mu4e-compose-mode.


### PR DESCRIPTION
This is cleaner and help when debugging to use functions in hooks instead of lambdas.