### PR TITLE
Disable `mm-verify-option` let-bounded in `mu4e~view-gnus`

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -380,8 +380,6 @@ article-mode."
   (require 'gnus-art)
   (let ((path (mu4e-message-field msg :path))
         (inhibit-read-only t)
-        ;; support signature verification
-        (mm-verify-option 'known)
         (mm-decrypt-option 'known)
         (gnus-article-emulate-mime t)
         (gnus-buttonized-mime-types (append (list "multipart/signed"


### PR DESCRIPTION
When this option is set to 'known and the needed key is not yet in the user's
keyring, mu4e may hangs forever unable to verify email so lets user set this
variable globally to 'never to prevent this issue.