### PR TITLE
Do not use shell commands to extract version number

### DIFF
--- a/mu4e/mu4e-proc.el
+++ b/mu4e/mu4e-proc.el
@@ -243,9 +243,9 @@ backslashes and double-quotes."
      "Cannot find mu, please set `mu4e-mu-binary' to the mu executable path"))
 
   ;; sanity-check 2
-  (let ((version (shell-command-to-string
-                  (format "%s --version | head -1 | sed 's/.*version //' | tr -d '\n'"
-                          mu4e-mu-binary))))
+  (let ((version (let ((s (shell-command-to-string (concat mu4e-mu-binary " --version"))))
+                   (and (string-match "version \\([.0-9]+\\)" s)
+                        (match-string 1 s)))))
     (unless (string= version mu4e-mu-version)
       (mu4e-error
        (concat


### PR DESCRIPTION
Avoid using 'head', 'sed' or other POSIX commands to extract the version number when Emacs can do it. This allows installing just 'mu', without the extra unix tools in a Windows environment, or run 'mu' from MSYS but do not expose the rest of the MSYS environment (needed if one wants to rely on Windows cmd.exe shell for other tasks, for instance).