### PR TITLE
Use mu4e-query-rewrite-function also for computing bookmark counts

### DIFF
--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -125,7 +125,8 @@ clicked."
            for bm in bmks
            for key = (string (plist-get bm :key))
            for name = (plist-get bm :name)
-           for query = (plist-get bm :query)
+           for query = (funcall (or mu4e-query-rewrite-function #'identity)
+                                (plist-get bm :query))
            for qcounts = (and (stringp query)
                               (cl-loop for q in queries
                                        when (string=

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -826,7 +826,9 @@ When successful, call FUNC (if non-nil) afterwards."
   (setq mu4e-pong-func (lambda (info) (mu4e~pong-handler info func)))
   (mu4e~proc-ping
    (mapcar ;; send it a list of queries we'd like to see read/unread info for
-    (lambda (bm) (plist-get bm :query))
+    (lambda (bm)
+      (funcall (or mu4e-query-rewrite-function #'identity)
+               (plist-get bm :query)))
     ;; exclude bookmarks that are not strings, and with certain flags
     (seq-filter (lambda (bm)
                   (and (stringp (plist-get bm :query))


### PR DESCRIPTION
Until now, the bookmark queries were sent to mu in their original form.  Thus,
if you have `mu4e-query-rewrite-function` set, the numbers shown next to the
bookmarks didn't reflect the actual number of query results you'd get when
opening a bookmark view.

With this commit, the `mu4e-query-rewrite-function` is applied and the result
is sent to mu for evaluation (in `mu4e~start`) and the likewise the rewritten
queries are used to find the matching one in the last query results (in
`mu4e~main-bookmarks`).

* mu4e/mu4e-utils.el (mu4e~start): Send the rewritten queries for evaluation to
mu.
* mu4e/mu4e-main.el (mu4e~main-bookmarks): Compare last mu query results with
rewritten queries.

I think this change makes sense for anyone using a
`mu4e-query-rewrite-function`.

My personal use-case is that I have contexts where I want to restrict the scope
of bookmarks and searches to a certain subset of maildirs.  Therefore, my
contexts set a variable whose value is a regexp matching the maildirs relevant
in this context and my `mu4e-query-rewrite-function` uses it to add a
`maildir:/.../` restriction to queries automatically.  Of course, the numbers
next to the bookmarks should reflect that, e.g., in my FOSS context I'm not
interested in the number of unread messages in all my maildirs but only in
those concerned with my FOSS activity.