### PR TITLE
Remove null byte added probably by error

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -553,7 +553,7 @@ add text-properties to VAL."
                      (val (if (= (length vals) 1)
                               (car vals)
                             (truncate-string-to-width (car vals)
-                                                      (- (length (car vals)) 1) 0 nil t)))) 
+                                                      (- (length (car vals)) 1) 0 nil t))))
                 (overlay-put o 'mu4e~view-header-field-folded t)
                 (overlay-put o 'display val))))))))
 


### PR DESCRIPTION
I found a null byte at eol added probably by error in commit 57d38aa7070ad9cb108bfffb1cf17f99f79c1322.
See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=44486 for infos about null bytes in lisp buffers.
Also here the output of shell command `rg mu4e-view-save-attachment-multi` from mu4e directory (file is recognized as binary):

```sh
mu4e-view.el
140:     ("Ssave multi" . mu4e-view-save-attachment-multi)
WARNING: stopped searching binary file mu4e-view.el after match (found "\u{0}" byte around offset 22103)
```