### PR TITLE
Debugger entered--Lisp error: (error "Selecting deleted buffer") when quitting mu4e

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -856,10 +856,16 @@ When successful, call FUNC (if non-nil) afterwards."
   ;; kill all mu4e buffers
   (mapc
    (lambda (buf)
-     (with-current-buffer buf
-       (when (member major-mode
-                     '(mu4e-headers-mode mu4e-view-mode mu4e-main-mode))
-         (kill-buffer))))
+     ;; When using mu4e-view-use-gnus, the view buffer has the kill-buffer-hook
+     ;; function mu4e~view-kill-buffer-hook-fn which kills the mm-* buffers
+     ;; created by Gnus' article mode.  Those have been returned by
+     ;; `buffer-list' but might already be deleted in case the view buffer has
+     ;; been killed first.  So we need a `buffer-live-p' check here.
+     (when (buffer-live-p buf)
+       (with-current-buffer buf
+         (when (member major-mode
+                       '(mu4e-headers-mode mu4e-view-mode mu4e-main-mode))
+           (kill-buffer)))))
    (buffer-list)))
 
 (defun mu4e~maildirs-with-query ()


### PR DESCRIPTION
Oftentimes I get this error when quitting mu4e by tying `q` in the mu4e buffer.

```
Debugger entered--Lisp error: (error "Selecting deleted buffer")
  #f(compiled-function (buf) #<bytecode -0xd27d395f5e1de6d>)(#<killed buffer>)
  mapc(#f(compiled-function (buf) #<bytecode -0xd27d395f5e1de6d>) (#<killed buffer> #<buffer  *Minibuf-1*> #<killed buffer> #<buffer  *mu4e-loading*> #<buffer *Help*> #<buffer magit: auctex> #<buffer *scratch*> #<killed buffer> #<buffer preview.el.in> #<buffer preview.el> #<buffer *~/tmp/3 output*> #<buffer  *Minibuf-0*> #<buffer *Messages*> #<buffer  *Echo Area 0*> #<buffer  *Echo Area 1*> #<buffer  *code-conversion-work*> #<buffer  *eldoc*> #<buffer *~/tmp/1 output*> #<buffer *TeX Help*> #<buffer 3.log> #<buffer  *mu4e-proc*> #<buffer  *appease-gnus*> #<buffer  *gnus work*> #<buffer  *canonical address*> #<buffer  *extract address components*> #<buffer *Backtrace*> #<buffer *Completions*> #<buffer  *company-posframe-buffer*> #<buffer  *company-posframe-quickhelp-buffer*> #<buffer  *which-key*> #<buffer *rdictcc*> #<buffer *trace of SMTP session to smtp.fastmail.com*> #<killed buffer> #<killed buffer> #<killed buffer>))
  mu4e~stop()
  mu4e-quit()
  funcall-interactively(mu4e-quit)
  call-interactively(mu4e-quit nil nil)
  command-execute(mu4e-quit)
```

The problem is that `mu4e~stop` iterates all buffers in `(buffer-list)` and selects each of them using `with-current-buffer` which fails with above error if it is an already killed buffer.  I think the reason for having killed buffers comes from `mu4e~view-gnus` adding a `kill-buffer-hook` function for the view buffer so that killing that buffer kills other buffers, too, which are also returned by `(buffer-list)`.  So I've added a `buffer-live-p` check.