### PR TITLE
Add missing when parameter to define-obsolete-function-alias

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -1038,7 +1038,7 @@ in the background; otherwise, pop up a window."
       (kill-process proc t))))
 
 (define-obsolete-function-alias 'mu4e-interrupt-update-mail
-  'mu4e-kill-update-mail)
+  'mu4e-kill-update-mail "1.0-alpha0")
 
 
 ;;; Logging / debugging


### PR DESCRIPTION
Emacs 28 is making this 'when' argument mandatory, as the
'make-obsolete' and related functions without a 'when' were marked as
obsolete in Emacs 23.1.

I used 'git tag --contains b6985e13c' to determine the value of
'when'.