### PR TITLE
Make order relation on contacts antisymmetric

### DIFF
--- a/lib/mu-contacts.cc
+++ b/lib/mu-contacts.cc
@@ -87,7 +87,7 @@ struct ContactInfoLessThan {
                 if (ci1.personal != ci2.personal)
                         return ci1.personal; // personal comes first
 
-                if (ci1.last_seen > recently_)
+                if ((ci1.last_seen > recently_) != (ci2.last_seen > recently_))
                         return ci1.last_seen > ci2.last_seen;
 
                 if (ci1.freq != ci2.freq) // more frequent comes first


### PR DESCRIPTION
The behaviour suggested in #1857 (and the old behaviour of mu4e when that did the sorting) is that if exactly one of ci1 or ci2 was seen in the last 15 days, then that should be selected as first in the order by ContactInfoLessThan. As it stands, we return the most recent of ci1 and ci2 as least in the order only when ci1 was seen in the last 15 days. So if ci2 was seen in the last 15 days, but ci1 was not, it will fall through to a comparison on frequency; while if ci1 was seen in the last 15 days, but ci2 was not, it will always return ci1 as least. This is not antisymmetric in ci1 and ci2.