### PR TITLE
Documented icalendar capture template

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -3425,7 +3425,8 @@ The full default capture template is:
 
 @lisp
 ("#" "used by gnus-icalendar-org" entry
-   (file+olp ,gnus-icalendar-org-capture-file ,gnus-icalendar-org-capture-headline)
+   (file+olp ,gnus-icalendar-org-capture-file
+             ,gnus-icalendar-org-capture-headline)
    "%i" :immediate-finish t)
 @end lisp
 
@@ -3442,6 +3443,26 @@ prompting for the date, you could use the following:
    "%i" :immediate-finish t :time-prompt t)
 @end lisp
 
+Note that the default behaviour for @code{datetree} targets in this situation
+is to store the event at the date that you capture it, not at the date
+that it is scheduled. That's why I've suggested using the
+@code{:timeprompt t} argument. This gives you an opportunity to set the
+time to the correct value yourself.
+
+You can extract the event time directly, and have the @code{org-capture}
+functions use that to set the @code{datetree} location:
+
+@lisp
+(defun my-catch-event-time (event reply-status)
+  "Set org-overriding-default-time to the start time of the capture event"
+  (setq org-overriding-default-time
+        (date-to-time (gnus-icalendar-event:start event))))
+
+(advice-add 'gnus-icalendar:org-event-save :before #'my-catch-event-time)
+@end lisp
+
+If you do this, you'll want to omit the @code{:timeprompt t} setting
+from your capture template.
 
 @node Sauron
 @section Sauron

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -3453,12 +3453,13 @@ You can extract the event time directly, and have the @code{org-capture}
 functions use that to set the @code{datetree} location:
 
 @lisp
-(defun my-catch-event-time (event reply-status)
+(defun my-catch-event-time (orig-fun &rest args)
   "Set org-overriding-default-time to the start time of the capture event"
-  (setq org-overriding-default-time
-        (date-to-time (gnus-icalendar-event:start event))))
+  (let ((org-overriding-default-time (date-to-time
+                                      (gnus-icalendar-event:start (car args)))))
+    (apply orig-fun args)))
 
-(advice-add 'gnus-icalendar:org-event-save :before #'my-catch-event-time)
+(advice-add 'gnus-icalendar:org-event-save :around #'my-catch-event-time)
 @end lisp
 
 If you do this, you'll want to omit the @code{:timeprompt t} setting

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -3414,6 +3414,34 @@ To enable optional iCalendar→Org sync functionality, add the following:
 
 Both the capture file and the headline(s) inside it must already exist.
 
+By default, @code{gnus-icalendar-org-setup} adds a temporary capture
+template to the variable @code{org-capture-templates}, with the
+description ``used by gnus-icalendar-org'', and the shortcut key ``#''.
+If you want to use your own template, create it using the same key
+and description. This will prevent the temporary one from being
+installed next time you @code{gnus-icalendar-org-setup} is called.
+
+The full default capture template is:
+
+@lisp
+("#" "used by gnus-icalendar-org" entry
+   (file+olp ,gnus-icalendar-org-capture-file ,gnus-icalendar-org-capture-headline)
+   "%i" :immediate-finish t)
+@end lisp
+
+where the values of the variables @code{gnus-icalendar-org-capture-file}
+and @code{gnus-icalendar-org-capture-headline} are inserted via macro
+expansion.
+
+If, for example, you wanted to store ical events in a date tree,
+prompting for the date, you could use the following:
+
+@lisp
+("#" "used by gnus-icalendar-org" entry
+   (file+olp+datetree path-to-capture-file)
+   "%i" :immediate-finish t :time-prompt t)
+@end lisp
+
 
 @node Sauron
 @section Sauron


### PR DESCRIPTION
It's not documented in gnus-icalendar, so the explanation comes straight from my reading of the code.

Being able to customize the capture template partially addresses the issue I raised in #1912. gnus-icalendar supports this, in an undocumented way, and the code comments suggest the details may change eventually.