### PR TITLE
mu4e-jump-to-maildir: offer editing the query when a prefix arg is given

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -2157,7 +2157,8 @@ with the difference being that the target is always a maildir --- maildir
 queries provide a `traditional' folder-like interface to a search-based e-mail
 client. By default, maildir searches are available in the @ref{Main view},
 @ref{Headers view}, and @ref{Message view}, with the key @key{j}
-(@code{mu4e-jump-to-maildir}).
+(@code{mu4e-jump-to-maildir}). If a prefix argument is given, the maildir
+query can be refined before execution.
 
 @subsection Setting up maildir shortcuts
 


### PR DESCRIPTION
I have many maildirs (because I also use other clients, like a mobile one, which haven't the searching super-powers of mu) and configured shortcuts for them.  Frequently, I want to read such a maildir but do not want to see all messages but just unread messages or messages with attachments.  For such purposes, I've added an optional prefix arg to `mu4e-jump-to-maildir` which allows the `maildir:"/foo/bar"` query to be refined/extended before execution.  So it's basically the same as for bookmarks, i.e., `B` instead of `b`.

If you want, I can also add a new command bound to `J` which calls `mu4e-jump-to-maildir` with non-nil prefix arg so that `j` and `J` are really analogous to `b` and `B`.

I've adapted docstring and texi docs accordingly.

I also refactored the now two usages of the "read a query with completion" feature into a new separate function `mu4e-read-query`.