### PR TITLE
mu4e-compose-context-switch for context switching in mu4e:compose buffers

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -446,6 +446,7 @@ removing the In-Reply-To header."
   (setq mu4e-compose-mode-map
         (let ((map (make-sparse-keymap)))
           (define-key map (kbd "C-S-u")   'mu4e-update-mail-and-index)
+          (define-key map (kbd "C-c C-;")   'mu4e-compose-context-switch)
           (define-key map (kbd "C-c C-u") 'mu4e-update-mail-and-index)
           (define-key map (kbd "C-c C-k") 'mu4e-message-kill-buffer)
           (define-key map (kbd "M-q")     'mu4e-fill-paragraph)
@@ -787,6 +788,41 @@ tempfile)."
           (switch-to-buffer (mu4e-get-headers-buffer))
         ;; if all else fails, back to the main view
         (when (fboundp 'mu4e) (mu4e))))))
+
+(defun mu4e-compose-context-switch (&optional force name)
+  "Same as `mu4e-context-switch' but does two things after switching when the buffer
+is a `mu4e-compose-mode':
+- Changes the \"From\" field to the email address of the new context
+- Moves the current message to the draft folder of the new context"
+  (interactive "P")
+  (if (derived-mode-p 'mu4e-compose-mode)
+      (let ((old-context (mu4e-context-current))
+            (has-file (file-exists-p (buffer-file-name))))
+        (unless (and name (not force) (eq old-context name))
+          (when (or (not has-file)
+                    (not (buffer-modified-p))
+                    (y-or-n-p "Draft must be saved before switching context. Save?"))
+            (unless (and (not force) (eq old-context (mu4e-context-switch nil name)))
+              ;; Change From field to user-mail-address
+              (message-replace-header "From" (or (mu4e~draft-from-construct) ""))
+              ;; Move message to mu4e-draft-folder
+              (if has-file
+                  (progn (save-buffer)
+                         (let ((msg-id (message-fetch-field "Message-ID"))
+                               (buf (current-buffer)))
+                           ;; Remove the <>
+                           (when (and msg-id (string-match "<\\(.*\\)>" msg-id))
+                             (save-window-excursion
+                               (mu4e~proc-move (match-string 1 msg-id) mu4e-drafts-folder nil t)
+                               (kill-buffer buf) ;; Kill previous buffer which points to wrong file
+                               ))))
+                ;; No file, just change the buffer file name
+                (setq buffer-file-name
+                      (format "%s/%s/cur/%s"
+                              (mu4e-root-maildir) (mu4e-get-drafts-folder)
+                              (file-name-nondirectory (buffer-file-name)))))))))
+    ;; Just do the standad switchp
+    (mu4e-context-switch force name)))
 
 (defun mu4e-sent-handler (docid path)
   "Handler called with DOCID and PATH for the just-sent message.


### PR DESCRIPTION
Fixes #1772 by implementing context switching in `mu4e-compose` which also changes the `From` and moves the draft to the correct folder.

This mostly works. However, after switching context `mu4e~proc-move` opens a message view even though I pass `t` to `no-view` (I would rather not open the view).  

One also has to press `E` to edit the viewed message. I want to call `mu4e~proc-compose` at the end to open the newly moved message automatically, but I can't find a way to get the doc-id from the message-id.

