### PR TITLE
Make URLs clickable again

### DIFF
--- a/mu4e/mu4e-view-common.el
+++ b/mu4e/mu4e-view-common.el
@@ -480,6 +480,7 @@ list."
 
 (defvar mu4e-view-active-urls-keymap
   (let ((map (make-sparse-keymap)))
+    (define-key map [down-mouse-1] 'mu4e~view-browse-url-from-binding)
     (define-key map [mouse-1] 'mu4e~view-browse-url-from-binding)
     (define-key map (kbd "M-<return>") 'mu4e~view-browse-url-from-binding)
     map)

--- a/mu4e/mu4e-view-gnus.el
+++ b/mu4e/mu4e-view-gnus.el
@@ -45,7 +45,7 @@
 (put 'mu4e~gnus-article-mime-handles 'permanent-local t)
 
 (defun mu4e~view-gnus (msg)
-  "View MSG using Gnus' article mode. Experimental."
+  "View MSG using Gnus' article mode."
   (let ((path (mu4e-message-field msg :path))
         (inhibit-read-only t)
         (mm-decrypt-option 'known)


### PR DESCRIPTION
Without this, the clicking on the URL just show `insert-for-yank: Buffer is read-only: #<buffer *Article*>` but no action is taken.  <kbd>C-h k</kbd> and then clicking reports:
```
There were several key-sequences:

  <down-mouse-1> at that spot runs the command mouse-drag-region
  <mouse-2> (translated from <mouse-1>) at that spot runs the command mouse-yank-primary

Those are influenced by `mouse-1-click-follows-link'

They're all described below.

<down-mouse-1> at that spot runs the command mouse-drag-region (found
in global-map),
...
<mouse-2> (translated from <mouse-1>) at that spot runs the command
mouse-yank-primary (found in global-map),
...
```
After, I get
```
There were several key-sequences:

  <down-mouse-1> at that spot runs the command mu4e~view-browse-url-from-binding
  <mouse-2> (translated from <mouse-1>) at that spot runs the command mouse-yank-primary
...
<down-mouse-1> at that spot runs the command
mu4e~view-browse-url-from-binding (found in
mu4e-view-active-urls-keymap), which is an interactive Lisp closure in
‘mu4e-view-common.el’.
...
```