### PR TITLE
mu4e/view-gnus: Make Gnus email clickable links work

### DIFF
--- a/mu4e/mu4e-view-gnus.el
+++ b/mu4e/mu4e-view-gnus.el
@@ -161,11 +161,27 @@ with no charset."
         (list handle attendee))
   handle-attendee))
 
+
+(defun mu4e~view-mode-p ()
+  (or (eq major-mode 'mu4e-view-mode)
+      (derived-mode-p '(mu4e-view-mode))))
+
 (defun mu4e~view-nop (func &rest args)
   "Do nothing when in mu4e-view-mode. This is useful for advising
 some Gnus-functionality that does not work in mu4e."
-  (unless (or (eq major-mode 'mu4e-view-mode)
-              (derived-mode-p '(mu4e-view-mode)))
+  (unless (mu4e~view-mode-p)
+    (apply func args)))
+
+(defun mu4e~view-button-reply (func &rest args)
+  "Advice to make `gnus-button-reply' links work in mu4e."
+  (if (mu4e~view-mode-p)
+      (mu4e-compose-reply)
+    (apply func args)))
+
+(defun mu4e~view-msg-mail (func &rest args)
+  "Advice to make `gnus-msg-mail' links compose with mu4e."
+  (if (mu4e~view-mode-p)
+      (apply 'mu4e~compose-mail args)
     (apply func args)))
 
 (defvar mu4e-view-mode-map
@@ -363,7 +379,8 @@ Gnus' article-mode."
   (define-key mu4e-view-mode-map (kbd "C-h b") 'describe-bindings)
   ;; ;; turn off gnus modeline changes and menu items
   (advice-add 'gnus-set-mode-line :around #'mu4e~view-nop)
-  (advice-add 'gnus-button-reply :around #'mu4e~view-nop)
+  (advice-add 'gnus-button-reply :around #'mu4e~view-button-reply)
+  (advice-add 'gnus-msg-mail :around #'mu4e~view-msg-mail)
   (mu4e~view-mode-body))
 
 (defun mu4e-view-message-text (msg)


### PR DESCRIPTION
The `From` link triggers _reply_ and the email links launch _mu4e_ (**not** `message-mail`).