### PR TITLE
Add ivy completion when saving attachments

### DIFF
--- a/mu4e/mu4e-view-gnus.el
+++ b/mu4e/mu4e-view-gnus.el
@@ -444,7 +444,7 @@ containing commas."
          (handles '())
          (files '())
          (helm-comp-read-use-marked t)
-         (compfn (if (and (boundp 'helm-mode) helm-mode)
+         (compfn (if (or (and (boundp 'helm-mode) helm-mode) (and (boundp 'ivy-mode) ivy-mode))
                      #'completing-read
                    ;; Fallback to `completing-read-multiple' with poor
                    ;; completion systems.


### PR DESCRIPTION
[ivy](https://github.com/abo-abo/swiper) is an alternative completion framework to *helm*. I added an extra conditional to use `completing-read` to save attachments (`mu4e-view-save-attachments` in `mu4e-view-gnus.el`) when *ivy* is in use.