### PR TITLE
mu4e/mu4e-headers: remove excess message output

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1474,7 +1474,6 @@ descendants."
      (lambda (cur-msg)
        (let ((cur-thread-id   (mu4e~headers-get-thread-info cur-msg 'thread-id))
              (cur-thread-path (mu4e~headers-get-thread-info cur-msg 'path)))
-         (message "### %S %S %S" path match-path cur-thread-path)
          (if subthread
              ;; subthread matching; mymsg's thread path should have path as its
              ;; prefix


### PR DESCRIPTION
When marking threads as read things are slowed down by echoing the
thread path to the mini-buffer. I assume this is left over debug but
if needed for something else should probably be a log call.