### PR TITLE
skip confirmation when executing marks

### DIFF
--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -389,7 +389,7 @@ flow. Therefore, we hide the message, which in practice seems to
 work well.
 
 If NO-CONFIRMATION is non-nil, don't ask user for confirmation."
-  (interactive)
+  (interactive "p")
   (mu4e~mark-in-context
    (let* ((marknum (hash-table-count mu4e~mark-map))
           (prompt (format "Are you sure you want to execute %d mark%s?"


### PR DESCRIPTION
When running `u4e-mark-execute-all` with any prefix-arg you can skip the confirmation-prompt. The potential for accidentally hitting this is quite low.