### PR TITLE
Remove unneeded `or` clause in mu4e-view-save-attachments

### DIFF
--- a/mu4e/mu4e-view-gnus.el
+++ b/mu4e/mu4e-view-gnus.el
@@ -490,7 +490,7 @@ containing commas."
          (handles '())
          (files '())
          (helm-comp-read-use-marked t)
-         (compfn (if (or (and (boundp 'helm-mode) helm-mode))
+         (compfn (if (and (boundp 'helm-mode) helm-mode)
                      #'completing-read
                    ;; Fallback to `completing-read-multiple' with poor
                    ;; completion


### PR DESCRIPTION
Was not removed with commit 55d8d20771405465f4d75649eab7b8a462cc4e31.