### PR TITLE
seperate Mu::format and Mu::vformat

### DIFF
--- a/lib/mu-store.cc
+++ b/lib/mu-store.cc
@@ -481,7 +481,7 @@ Store::set_dirstamp (const std::string& path, time_t tstamp)
         LOCKED;
 
         std::array<char, 2*sizeof(tstamp)+1> data{};
-        const std::size_t len = g_snprintf (data.data(), data.size(), "%zx", tstamp);
+        const std::size_t len = g_snprintf (data.data(), data.size(), "%zx", (size_t)tstamp);
 
         priv_->writable_db().set_metadata(path, std::string{data.data(), len});
         priv_->dirty();

--- a/lib/utils/mu-error.hh
+++ b/lib/utils/mu-error.hh
@@ -67,7 +67,7 @@ struct Error final: public std::exception {
         Error(Code codearg, const char *frm, ...): code_{codearg} {
                 va_list args;
                 va_start(args, frm);
-                what_ = format(frm, args);
+                what_ = vformat(frm, args);
                 va_end(args);
         }
 
@@ -89,7 +89,7 @@ struct Error final: public std::exception {
 
                 va_list args;
                 va_start(args, frm);
-                what_ = format(frm, args);
+                what_ = vformat(frm, args);
                 va_end(args);
 
                 if (err && *err)

--- a/lib/utils/mu-sexp.cc
+++ b/lib/utils/mu-sexp.cc
@@ -32,7 +32,7 @@ parsing_error(size_t pos, const char* frm, ...)
 {
         va_list args;
         va_start(args, frm);
-        auto msg = format(frm, args);
+        auto msg = vformat(frm, args);
         va_end(args);
 
         if (pos == 0)

--- a/lib/utils/mu-utils.cc
+++ b/lib/utils/mu-utils.cc
@@ -204,14 +204,14 @@ Mu::quote (const std::string& str)
          va_list args;
 
          va_start (args, frm);
-         auto str = format(frm, args);
+         auto str = vformat(frm, args);
          va_end (args);
 
          return str;
  }
 
 std::string
-Mu::format (const char *frm, va_list args)
+Mu::vformat (const char *frm, va_list args)
 {
         char *s{};
         const auto res = g_vasprintf (&s, frm, args);

--- a/lib/utils/mu-utils.hh
+++ b/lib/utils/mu-utils.hh
@@ -104,7 +104,7 @@ std::string format (const char *frm, ...) __attribute__((format(printf, 1, 2)));
  *
  * @return a formatted string
  */
-std::string format (const char *frm, va_list args) __attribute__((format(printf, 1, 0)));
+std::string vformat (const char *frm, va_list args) __attribute__((format(printf, 1, 0)));
 
 
 /**

--- a/lib/utils/test-utils.cc
+++ b/lib/utils/test-utils.cc
@@ -168,6 +168,8 @@ test_clean ()
 static void
 test_format ()
 {
+	g_assert_true (format ("hello %s", "world") ==
+		       "hello world");
 	g_assert_true (format ("hello %s, %u", "world", 123) ==
 		       "hello world, 123");
 }


### PR DESCRIPTION
All the call site that issues a `va_list` in the second argument are converted to use `vformat`.
There is also a unrelated type cast to suppress a compiler warning.  