### PR TITLE
mu4e/gnus: Switch to the buffer before rendering the message

### DIFF
--- a/mu4e/mu4e-view-gnus.el
+++ b/mu4e/mu4e-view-gnus.el
@@ -52,14 +52,13 @@
   "View MSG using Gnus' article mode."
   (when (bufferp gnus-article-buffer)
     (kill-buffer gnus-article-buffer))
-  (with-current-buffer (get-buffer-create gnus-article-buffer)
-    (let ((inhibit-read-only t))
-      (erase-buffer)
-      (insert-file-contents-literally
-       (mu4e-message-field msg :path) nil nil nil t)
-      (setq mu4e~view-message msg)
-      (mu4e~view-render-buffer msg)))
-  (switch-to-buffer gnus-article-buffer))
+  (switch-to-buffer (get-buffer-create gnus-article-buffer))
+  (let ((inhibit-read-only t))
+    (erase-buffer)
+    (insert-file-contents-literally
+     (mu4e-message-field msg :path) nil nil nil t)
+    (setq mu4e~view-message msg)
+    (mu4e~view-render-buffer msg)))
 
 (defun mu4e-view-message-text (msg)
   "Return the pristine message as a string, for replying/forwarding


### PR DESCRIPTION
This is necessary for `shr' to know the size of the window and dimension the line width and images properly.

Fixes https://github.com/djcb/mu/issues/1998