### PR TITLE
mu4e-view: remove <home> and <end> bindings

### DIFF
--- a/mu4e/mu4e-view-gnus.el
+++ b/mu4e/mu4e-view-gnus.el
@@ -283,8 +283,6 @@ some Gnus-functionality that does not work in mu4e."
 
     ;; intra-message navigation
     (define-key map (kbd "SPC") #'mu4e-view-scroll-up-or-next)
-    (define-key map (kbd "<home>") 'beginning-of-buffer)
-    (define-key map (kbd "<end>") 'end-of-buffer)
     (define-key map (kbd "RET")  #'mu4e-scroll-up)
     (define-key map (kbd "<backspace>") #'mu4e-scroll-down)
 

--- a/mu4e/mu4e-view-old.el
+++ b/mu4e/mu4e-view-old.el
@@ -496,8 +496,6 @@ FUNC should be a function taking two arguments:
 
           ;; intra-message navigation
           (define-key map (kbd "SPC") 'mu4e-view-scroll-up-or-next)
-          (define-key map (kbd "<home>") 'beginning-of-buffer)
-          (define-key map (kbd "<end>") 'end-of-buffer)
           (define-key map (kbd "RET") 'mu4e-scroll-up)
           (define-key map (kbd "<backspace>") 'mu4e-scroll-down)
 


### PR DESCRIPTION
Users usually have `<home>` and `<end>` bound in their configuration,
for Spacemacs the default is “move-beginning-of-line” and “move-end-of-line”.

The mu4e view mode should not rebind basic navigation keys like these.