### PR TITLE
Fix bug with helm completing-read when saving attachments

### DIFF
--- a/mu4e/mu4e-view-gnus.el
+++ b/mu4e/mu4e-view-gnus.el
@@ -476,7 +476,6 @@ containing commas."
   (let* ((parts (mu4e~view-gather-mime-parts))
          (handles '())
          (files '())
-         (helm-comp-read-use-marked t)
          (compfn (if (and (boundp 'helm-mode) helm-mode)
                      #'completing-read
                    ;; Fallback to `completing-read-multiple' with poor
@@ -490,7 +489,8 @@ containing commas."
           (push fname files))))
     (if files
         (progn
-          (setq files (funcall compfn "Save part(s): " files)
+          (setq files (let ((helm-comp-read-use-marked t))
+                        (funcall compfn "Save part(s): " files))
                 dir (if arg (read-directory-name "Save to directory: ") mu4e-attachment-dir))
           (cl-loop for (f . h) in handles
                    when (member f files)


### PR DESCRIPTION
Previously helm-comp-read-use-marked was bound also when completing on
a directory for saving attachments (when using a prefix argument). This
returned a list with the selected directory, which caused an error.