### PR TITLE
Only remove mark overlays in `mu4e-mark-at-point`

### DIFF
--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -267,7 +267,7 @@ The following marks are available, and the corresponding props:
         ;; stuff, unless we're unmarking
         (remhash docid mu4e~mark-map)
         ;; remove possible mark overlays
-        (remove-overlays (line-beginning-position) (line-end-position) 'mmark t)
+        (remove-overlays (line-beginning-position) (line-end-position) 'mu4e-mark t)
         ;; now, let's set a mark (unless we were unmarking)
         (unless (eql mark 'unmark)
           (puthash docid (cons mark target) mu4e~mark-map)
@@ -282,7 +282,7 @@ The following marks are available, and the corresponding props:
                              (mu4e~headers-goto-docid docid t)))
                    (overlay (make-overlay start (+ start (length targetstr)))))
               (overlay-put overlay 'display targetstr)
-              (overlay-put overlay 'mmark t)
+              (overlay-put overlay 'mu4e-mark t)
               (overlay-put overlay 'evaporate t)
               docid)))))))
 

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -266,8 +266,8 @@ The following marks are available, and the corresponding props:
         ;; update the hash -- remove everything current, and if add the new
         ;; stuff, unless we're unmarking
         (remhash docid mu4e~mark-map)
-        ;; remove possible overlays
-        (remove-overlays (line-beginning-position) (line-end-position))
+        ;; remove possible mark overlays
+        (remove-overlays (line-beginning-position) (line-end-position) 'mmark t)
         ;; now, let's set a mark (unless we were unmarking)
         (unless (eql mark 'unmark)
           (puthash docid (cons mark target) mu4e~mark-map)
@@ -282,6 +282,8 @@ The following marks are available, and the corresponding props:
                              (mu4e~headers-goto-docid docid t)))
                    (overlay (make-overlay start (+ start (length targetstr)))))
               (overlay-put overlay 'display targetstr)
+              (overlay-put overlay 'mmark t)
+              (overlay-put overlay 'evaporate t)
               docid)))))))
 
 (defun mu4e~mark-get-move-target ()


### PR DESCRIPTION
This prevent deleting overlays added by third party packages working as well
with overlays in mu4e-headers e.g. thread-folding , and probably in mu4e
itself as well with future features.  Also having a named overlay allows in
future features to modify any other overlays but these ones.

As it is this patch doesn't modify the actual behavior.