### PR TITLE
Fix #2044: broken header movement with visual-line-mode

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1846,7 +1846,8 @@ docid. Otherwise, return nil."
   (cl-flet ((goto-next-line
              (arg)
              (condition-case _err
-                 (and (line-move arg) 0)
+                 (and (let (line-move-visual)
+                        (line-move arg)) 0)
                ((beginning-of-buffer end-of-buffer)
                 1))))
     (let* ((_succeeded (zerop (goto-next-line lines)))


### PR DESCRIPTION
This fixes the issue introduced by 50f6f539 where header navigation
would break when `visual-line-mode` was enabled. Previously,
`forward-line` was used in `mu4e-view-headers-next`, which disregarded
visual lines and moved by logical lines, but this was changed to
`line-move`, which moves by visual lines when `line-move-visual` is
non-nil (the default when `visual-line-mode` is enabled). Thus, when
the current header line was wrapped and a message was open in the
split view, `mu4e-view-headers-next` would move to the next visual
line in the headers buffer (the same message), and then jump back to
the start of the previous line, preventing switching to the next
message.

This would also throw off navigation when `mu4e-view-headers-next` was
used with a prefix argument, since it would move by visual lines and
not headers.

`line-move-visual` is therefore set to nil before using `line-move' to
prevent these issues.