### PR TITLE
Assign `list-buffers-directory`

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -805,6 +805,7 @@ true, do *not* update the query history stack."
         (when mu4e--search-last-query
           (mu4e--search-push-query mu4e--search-last-query 'past)))
       (setq mu4e--search-last-query rewritten-expr)
+      (setq list-buffers-directory rewritten-expr)
       (mu4e~headers-update-mode-line))
 
     ;; when the buffer is already visible, select it; otherwise,


### PR DESCRIPTION
for mu4e-header buffers, this displays the search query in
`M-x list-buffers` instead of showing an empty path column.