### PR TITLE
query: fix include-related.

### DIFF
--- a/lib/mu-server.cc
+++ b/lib/mu-server.cc
@@ -86,7 +86,7 @@ struct Server::Private {
         void output_sexp(Sexp::List&& lst) const {
                 output_sexp(Sexp::make_list(std::move(lst)));
         }
-        size_t output_sexp (const QueryResults& qres, unsigned maxnum);
+        size_t output_sexp (const QueryResults& qres);
 
         //
         // handlers for various commands.
@@ -731,13 +731,10 @@ determine_docids (const Query& q, const Parameters& params)
 
 
 size_t
-Server::Private::output_sexp (const QueryResults& qres, unsigned maxnum)
+Server::Private::output_sexp (const QueryResults& qres)
 {
         size_t n{};
         for (auto&& mi: qres) {
-
-                if (n >= maxnum)
-                        break;
                 ++n;
                 auto msg{mi.floating_msg()};
                 if (!msg)
@@ -745,7 +742,7 @@ Server::Private::output_sexp (const QueryResults& qres, unsigned maxnum)
 
                 auto qm{mi.query_match()};
                 output_sexp(build_message_sexp(msg, mi.doc_id(),
-                                       qm, MU_MSG_OPTION_HEADERS_ONLY));
+                                               qm, MU_MSG_OPTION_HEADERS_ONLY));
         }
 
         return n;
@@ -796,7 +793,7 @@ Server::Private::find_handler (const Parameters& params)
         }
 
         {
-                const auto foundnum{output_sexp (*qres, maxnum)};
+                const auto foundnum{output_sexp (*qres)};
                 Sexp::List lst;
                 lst.add_prop(":found", Sexp::make_number(foundnum));
                 output_sexp(std::move(lst));


### PR DESCRIPTION
mu-query.cc:
- make_related_enquire: don't include first query in qvec, we already have all
  thread IDs we need to query in thread_ids.
- run_related: always sort first query by date, as explained in the code
  comment.
- run_related: include qflags (in particular ascending vs descending) in
  leader_qflags.
- run_threaded: don't limit results to maxnum, that results in threads
  potentially being cut off.

mu-server.cc:
- output_sexp: don't limit results to maxnum so as to match the behaviour of
  mu find (and avoid cutting off threads).

Fixes #1924 and #1911.