### PR TITLE
mu4e: Add support for gemini/gopher in mu4e~view-beginning-of-url-regexp

### DIFF
--- a/mu4e/mu4e-view-common.el
+++ b/mu4e/mu4e-view-common.el
@@ -494,9 +494,10 @@ list."
   "Keymap used for the urls inside the body.")
 
 (defvar mu4e~view-beginning-of-url-regexp
-  "https?\\://\\|mailto:"
-  "Regexp that matches the beginning of http:/https:/mailto:
-URLs; match-string 1 will contain the matched URL, if any.")
+  "\\(?:https?\\|gemini\\|gopher\\|finger\\)://\\|mailto:"
+  "Regexp that matches the beginning of http:/https:/mailto: or
+gemini/gopher/finger URLs; match-string 1 will contain the
+matched URL, if any.")
 
 
 (defun mu4e~view-browse-url-from-binding (&optional url)


### PR DESCRIPTION
This allow such URLs to be clickable and openable through Elpher (for example).

Gemini is a new kind of "Web" built around SSL and a light text markup language (learn more at https://gemini.circumlunar.space/). Gopher is an older internet protocol, still in use by some. Both protocol may be browse with Elpher, the same way than EWW or other web browser.

This commit make it possible to have links to these networks in email clickable again.

However, maybe it could be a better idea in the long term to follow values of `thing-at-point-uri-schemes` (in `thingatpt` package)?