### PR TITLE
Fix typo in docstring

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -274,7 +274,7 @@ Must have the same length as `mu4e-headers-thread-connection-prefix'.")
 (defvar mu4e-headers-full-label       '("F" . "∀")
   "Non-fancy and fancy labels for full search in the mode-line.")
 (defvar mu4e-headers-related-label    '("R" . "🤝")
-  "Non-fancy and fancy labels for inclued-related search in the mode-line.")
+  "Non-fancy and fancy labels for include-related search in the mode-line.")
 
 ;;;; Various
 


### PR DESCRIPTION
Found this by accident when debugging something and reading the code. However, the resulting sentence does not make complete sense to me, perhaps it's time to reword it a bit. Maybe I'm missing something, though. Feel free to edit my patch if so :)