### PR TITLE
[mu4e bug] (1.6.0) - messages in old view are shown without line break

### DIFF
--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -245,8 +245,7 @@ replace with."
   (with-temp-buffer
     (insert body)
     (goto-char (point-min))
-    (while (re-search-forward "[
- ]" nil t)
+    (while (re-search-forward "\015 ]" nil t)
       (replace-match
        (cond
         ((string= (match-string 0) "") "'")


### PR DESCRIPTION
**Describe the bug**
When using `mu4e-view-use-old`, then messages are shown without linebreak.

**To Reproduce**
Use the "old" view and open an email with multiple lines or reply to an email (also affects cited email).

This is caused by `mu4e-message-outlook-cleanup`. Where linefeed instead of carriage return is replaced. Looks like this was introduced in commit `539a946a` and was correct before. 

**Environment**
happens on both linux and Mac OS X

**Checklist**
- [X] you are running vanilla emacs (i.e. without Doom, Evil, Spacemacs etc.) (otherwise, please try to reproduce without those
- [X] you are running mu4e without any third-party extensions (otherwise, please try to reproduce without those)
- [X] you are running either the latest 1.4.x release, or a 1.5.11+ development release (otherwise, please upgrade).
