### PR TITLE
Fix mu-init manpage markup

### DIFF
--- a/man/mu-init.1
+++ b/man/mu-init.1
@@ -44,7 +44,7 @@ which were merely seen in mailing list messages.
 
 \fI<my-email-address>\fR can be either a plain e-mail address (such as
 \fBfoo@example.com\fR), or a regular-expression (of the 'Basic POSIX'
-flavor), wrapped in \B/\fR (such as \B/foo-.*@example\\.com\fR).
+flavor), wrapped in \fB/\fR (such as \fB/foo-.*@example\\.com/\fR).
 
 .SH ENVIRONMENT
 


### PR DESCRIPTION
Hi,

The manpage markup in `mu-init` is broken and renders like this when escape sequences are enabled:

```
<my-email-address> can be either a plain e-mail address (such as
foo@example.com), or a regular-expression (of the 'Basic POSIX'
flavor), wrapped in 0
```

This PR fixes the markup to what I *think* was meant. Also, I think the second '/' was missing in the wrapped regex email address notation.

With this fix, it reads like:
```
<my-email-address> can be either a plain e-mail address (such as
foo@example.com), or a regular-expression (of the 'Basic POSIX'
flavor), wrapped in / (such as /foo-.*@example\.com/).
```
The '/' as well as '/foo-.*@example\.com/' are bold.