### PR TITLE
fix: mu4e-view-save-attachments void variable

### DIFF
--- a/mu4e/mu4e-view-gnus.el
+++ b/mu4e/mu4e-view-gnus.el
@@ -465,7 +465,7 @@ The alist uniquely maps the number to the gnus-part."
     parts))
 
 
-(defun mu4e-view-save-attachments (&optional _arg)
+(defun mu4e-view-save-attachments (&optional arg)
   "Save mime parts from current mu4e gnus view buffer.
 
 When helm-mode is enabled provide completion on attachments and


### PR DESCRIPTION
This `_` looks like typo (correct me if I'm mistaken 😅).
`_arg` instead of `arg` here caused `Symbol’s value as variable is void: arg` for me when invoking `mu4e-view-save-attachments` .