### PR TITLE
Support maildir shortcuts without keys

### DIFF
--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -169,7 +169,9 @@ clicked."
            with longest = (mu4e~longest-of-maildirs-and-bookmarks)
            with queries = (plist-get mu4e~server-props :queries)
            for m in mds
-           for key = (string (plist-get m :key))
+           for key = (if (plist-get m :key)
+                         (string (plist-get m :key))
+                       " ")
            for name = (plist-get m :name)
            for query = (plist-get m :query)
            for qcounts = (and (stringp query)

--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -364,8 +364,12 @@ all maildirs under `mu4e-maildir'."
     (if (not (mu4e-maildir-shortcuts))
         (substring-no-properties
          (funcall mu4e-completing-read-function prompt (mu4e-get-maildirs)))
-      (let* ((mlist (append (mu4e-maildir-shortcuts)
-                            '((:maildir "ther"  :key ?o))))
+      (let* ((mlist
+              (append (remove nil (mapcar (lambda (item)
+                                            (when (plist-get item :key)
+                                              item))
+                                          mu4e-maildir-shortcuts))
+                      '((:maildir "ther" :key ?o))))
              (fnames
               (mapconcat
                (lambda (item)


### PR DESCRIPTION
This adds support for `mu4e-maildir-shortuct` to include maildirs
without a `:key` for jumping to.

Fixes `mu4e~main-maildirs` to not error upon a maildir shortcut without
a key.

Fixes `mu4e-ask-maildir` to not include maildir shortcuts without keys.

Resolves #2106.

Justification:

Allows one to display more maildir's, their counts (unread/total), in
the mu4e main view. Before this if a user had more maildirs than the
total amount of displayable and usable single key shortcuts they would
have to pick and choose which ones they want displayed be they important
to them or not.