### PR TITLE
Add new hook `mu4e-processing-finished-hook`.

### DIFF
--- a/mu4e/mu4e-utils.el
+++ b/mu4e/mu4e-utils.el
@@ -620,6 +620,12 @@ messages, it depends on `mu4e-index-updated-hook'. This can be
 used as a simple way to invoke some action when a message
 changed.")
 
+(defvar mu4e-processing-finished-hook nil
+  "Hook run when mu4e has finished processing data from the mu
+server. This can be used as a simple way to be certain something
+is run every single time mu4e finishes processing mu server
+data.")
+
 (make-obsolete-variable 'mu4e-msg-changed-hook
                         'mu4e-message-changed-hook "0.9.19")
 
@@ -653,6 +659,8 @@ process."
           (unless (and (not (string= mu4e~contacts-tstamp "0"))
                        (zerop (plist-get info :updated)))
             (mu4e~request-contacts-maybe))
+          ;; call the processing finished hook.
+          (run-hooks 'mu4e-processing-finished-hook)
           (when (and (buffer-live-p mainbuf) (get-buffer-window mainbuf))
             (save-window-excursion
               (select-window (get-buffer-window mainbuf))


### PR DESCRIPTION
Fix: #2099

Serves as a way to guarantee a function gets ran anytime mu4e finishes
handling data from mu related to index operations, regardless of the
index actually being updated.

An example use case is when making use of goimapnotify to trigger when mu4e does an index by using file watchers. If goimapnotify is watching several boxes (different or same account(s)) it may generate that trigger multiple time (one user used file deletion as a trigger, I use file change and appending a single character as a trigger). Rather than creating hold down timers, what I do is just add a hook to the new hook that will remove itself once it runs, and the code that adds it refuses to add it if it's already present. This means that if goimapnotify triggers multiple times while mu4e is indexing, then mu4e will reindex after indexing, but not attempt to do so during an index. With my configuration this comes in handy as a way to manage indexing without lots of complexity.

I also use this to sync (in my doom config) `+mu4e-personal-addresses` which is used for selecting who you're sending as from a reply. The idea is to filter all contacts for contacts that fit my definition of "who am I" and add them to that list for selection upon reply later (which is an automatic selection).