### PR TITLE
Attachments Saving Improvment

### DIFF
--- a/mu4e/mu4e-view-gnus.el
+++ b/mu4e/mu4e-view-gnus.el
@@ -491,7 +491,10 @@ containing commas."
                    #'completing-read-multiple))
         dir)
     (dolist (part parts)
-      (let ((fname (cdr (assoc 'filename (assoc "attachment" (cdr part))))))
+      (let ((fname (or (cdr (assoc 'filename (assoc "attachment" (cdr part))))
+                       (cl-loop for item in part
+                                for name = (and (listp item) (assoc-default 'name item))
+                                thereis (and (stringp name) name)))))
         (when fname
           (push `(,fname . ,(cdr part)) handles)
           (push fname files))))


### PR DESCRIPTION
Different MIME configurations need a fallback logic. 

Instead of looking for the attachment "fname" in the structure
 ```elisp
("attachment" . (filename "fname"))
```
we find the same file name in the structure
```elisp
("mime-type" . (name . "fname"))
```
by searching, since we don't know the MIME type beforehand.

Should solve #2116 .