### PR TITLE
Remove unnecessary faces

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -316,23 +316,7 @@ Our parent `message-mode' uses font-locking for the compose
 buffers; lets remap its faces so it uses the ones for mu4e."
   ;; normal headers
   (face-remap-add-relative 'message-header-name
-                           '((:inherit mu4e-header-key-face)))
-  (face-remap-add-relative 'message-header-other
-                           '((:inherit mu4e-header-value-face)))
-  ;; special headers
-  (face-remap-add-relative 'message-header-from
-                           '((:inherit mu4e-contact-face)))
-  (face-remap-add-relative 'message-header-to
-                           '((:inherit mu4e-contact-face)))
-  (face-remap-add-relative 'message-header-cc
-                           '((:inherit mu4e-contact-face)))
-  (face-remap-add-relative 'message-header-bcc
-                           '((:inherit mu4e-contact-face)))
-  (face-remap-add-relative 'message-header-subject
-                           '((:inherit mu4e-special-header-value-face)))
-  ;; citation
-  (face-remap-add-relative 'message-cited-text
-                           '((:inherit mu4e-cited-1-face))))
+                           '(:inherit mu4e-header-key-face)))
 
 (define-derived-mode mu4e-compose-mode message-mode "mu4e:compose"
   "Major mode for the mu4e message composition, derived from `message-mode'.

--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -294,11 +294,7 @@ its settings apply."
 (defun mu4e~draft-header (hdr val)
   "Return a header line of the form \"HDR: VAL\".
 If VAL is nil, return nil."
-  ;; note: the propertize here is currently useless, since gnus sets its own
-  ;; later.
-  (when val (format "%s: %s\n"
-                    (propertize hdr 'face 'mu4e-header-key-face)
-                    (propertize val 'face 'mu4e-header-value-face))))
+  (when val (format "%s: %s\n" hdr val)))
 
 (defconst mu4e~max-reference-num 21
   "Specifies the maximum number of References:.

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -126,23 +126,8 @@ I.e. a message with the draft flag set."
   "Face for a header key (such as \"Foo\" in \"Subject:\ Foo\")."
   :group 'mu4e-faces)
 
-(defface mu4e-header-value-face
-  '((t :inherit font-lock-type-face))
-  "Face for a header value (such as \"Re: Hello!\")."
-  :group 'mu4e-faces)
-
-(defface mu4e-special-header-value-face
-  '((t :inherit font-lock-builtin-face))
-  "Face for special header values."
-  :group 'mu4e-faces)
-
 (defface mu4e-link-face
   '((t :inherit link))
-  "Face for showing URLs and attachments in the message view."
-  :group 'mu4e-faces)
-
-(defface mu4e-contact-face
-  '((t :inherit font-lock-variable-name-face))
   "Face for showing URLs and attachments in the message view."
   :group 'mu4e-faces)
 


### PR DESCRIPTION
With the removal of the old mu4e-view, most of these faces were only used in compose, where it seems more reasonable to not remap the faces from message-mode (which can be suitably customized by users in any case).

The only face that was actually used in more places was `mu4e-header-key-face` which perhaps could be removed as well, but I didn’t do that for this initial suggestion.