### PR TITLE
Fix declare-function statements referencing the now-gone mu4e-utils

### DIFF
--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -31,21 +31,21 @@
 (require 'flow-fill)
 (require 'shr)
 
-(declare-function mu4e-error "mu4e-utils")
-(declare-function mu4e-warn  "mu4e-utils")
-(declare-function mu4e-personal-address-p "mu4e-utils")
-(declare-function mu4e-make-temp-file  "mu4e-utils")
+(declare-function mu4e-error "mu4e-helpers")
+(declare-function mu4e-warn  "mu4e-helpers")
+(declare-function mu4e-personal-address-p "mu4e-contacts")
+(declare-function mu4e-make-temp-file  "mu4e-helpers")
 
 (defvar mu4e~view-message)
 (defvar shr-inhibit-images)
- 
+
 (make-obsolete-variable 'mu4e-html2text-command "No longer in use" "1.7.0")
 (make-obsolete-variable 'mu4e-view-prefer-html "No longer in use" "1.7.0")
 (make-obsolete-variable 'mu4e-view-html-plaintext-ratio-heuristic
 			"No longer in use" "1.7.0")
 (make-obsolete-variable 'mu4e-message-body-rewrite-functions
 			"No longer in use" "1.7.0")
- 
+
 ;;; Message fields
 
 (defsubst mu4e-message-field-raw (msg field)
@@ -135,7 +135,7 @@ This is equivalent to:
   "Get the body in text form for message MSG."
   "" ;; not implemented for Gnus mode.
 )
-  
+
 
 (defun mu4e-message-contact-field-matches (msg cfield rx)
   "Does MSG's contact-field CFIELD match rx?

--- a/mu4e/obsolete/org-mu4e.el
+++ b/mu4e/obsolete/org-mu4e.el
@@ -40,7 +40,7 @@
 (declare-function mu4e-message-at-point             "mu4e-message")
 (declare-function mu4e-view-message-with-message-id "mu4e-view")
 (declare-function mu4e-headers-search               "mu4e-headers")
-(declare-function mu4e-error                        "mu4e-utils")
+(declare-function mu4e-error                        "mu4e-helpers")
 (declare-function mu4e-message                      "mu4e-message")
 (declare-function mu4e-compose-mode                 "mu4e-compose")
 


### PR DESCRIPTION
This fixes some `declare-function` statements referencing the now-gone `mu4e-utils.el`.

BTW, I've already sent you this patch by mail on August, 31st, but never got a response.  Did your spam filter classify my mails as spam, or is `git send-email` simply a way to contribute that you are not interested in, or is that fine but should go to the mailinglist rather than your private mail address to allow for broader discussion?