### PR TITLE
Allow a function as mu4e-split-view value

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1269,16 +1269,16 @@ of `mu4e-split-view', and return a window for the message view."
       (kill-buffer (mu4e-get-view-buffer)))
     ;; get a new view window
     (setq mu4e~headers-view-win
-          (let* ((new-win-func
-                  (cond
-                   ((eq mu4e-split-view 'horizontal) ;; split horizontally
-                    '(split-window-vertically mu4e-headers-visible-lines))
-                   ((eq mu4e-split-view 'vertical) ;; split vertically
-                    '(split-window-horizontally mu4e-headers-visible-columns)))))
-            (cond ((with-demoted-errors "Unable to split window: %S"
-                     (eval new-win-func)))
-                  (t ;; no splitting; just use the currently selected one
-                   (selected-window)))))))
+          (with-demoted-errors "Unable to split window: %S"
+            (cond
+             ((eq mu4e-split-view 'horizontal) ;; split horizontally
+              (split-window-vertically mu4e-headers-visible-lines))
+             ((eq mu4e-split-view 'vertical) ;; split vertically
+              (split-window-horizontally mu4e-headers-visible-columns))
+             ((functionp mu4e-split-view)
+              (funcall mu4e-split-view))
+             (t ;; no splitting; just use the currently selected one
+              (selected-window)))))))
 
 ;;; Search-based marking
 

--- a/mu4e/mu4e-helpers.el
+++ b/mu4e/mu4e-helpers.el
@@ -91,8 +91,10 @@ A symbol which is either:
  * `vertical':      split vertically (headers on the left).
  * `single-window': view and headers in one window (mu4e will try not to
         touch your window layout), main view in minibuffer
+ * a function:      the function is responsible to return some window for
+        the view.
  * anything else:   don't split (show either headers or messages,
-        not both)
+        not both).
 Also see `mu4e-headers-visible-lines'
 and `mu4e-headers-visible-columns'."
   :type '(choice (const :tag "Split horizontally" horizontal)
@@ -515,4 +517,3 @@ Or go to the top level if there is none."
 
 (provide 'mu4e-helpers)
 ;;; mu4e-helpers.el ends here
-


### PR DESCRIPTION
This allows to have a function returning a window as value of
`mu4e-split-view`.  I'm using this patch since quite some time locally with the
following function.

```el
(defun th/mu4e-split-view ()
  (let* ((headers (mu4e-get-headers-buffer))
         (headers-win (and headers (get-buffer-window headers)))
         (view (mu4e-get-view-buffer))
         (view-win (and view (get-buffer-window view))))
    (cond
     ;; There's a view window, just use it.
     (view-win view-win)
     ;; Just one window, split sensibly, i.e., horizontally or
     ;; vertically depending on geometry.
     ((one-window-p) (split-window-sensibly))
     ;; Otherwise, use the tallest window.
     (t (car (sort (delq headers-win (window-list))
                   (lambda (a b)
                     (> (window-height a) (window-height b)))))))))

(setq mu4e-split-view #'th/mu4e-split-view)
```