### PR TITLE
Fix refs to mu4e~update-buffer which has been renamed to mu4e--update-buffer

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1246,9 +1246,9 @@ docid is not found."
                        'face 'mu4e-modeline-face)
                       " "
                       (if (and mu4e-display-update-status-in-modeline
-                               (buffer-live-p mu4e~update-buffer)
+                               (buffer-live-p mu4e--update-buffer)
                                (process-live-p (get-buffer-process
-                                                mu4e~update-buffer)))
+                                                mu4e--update-buffer)))
                           (propertize " (updating)" 'face 'mu4e-modeline-face)
                         ""))))))
 


### PR DESCRIPTION
On master, `mu4e~update-buffer` has been renamed to `mu4e--update-buffer` but some references haven't been adapted.  When `mu4e-display-update-status-in-modeline` is non-nil, one gets the following error on every search:

``` emacs-lisp
Error during redisplay: (eval (concat (propertize (mu4e-quote-for-modeline "T maildir:\"/Fastmail/INBOX\"") 'face 'mu4e-modeline-face) " " (if (and mu4e-display-update-status-in-modeline (buffer-live-p mu4e~update-buffer) (process-live-p (get-buffer-process mu4e~update-buffer))) (propertize " (updating)" 'face 'mu4e-modeline-face) ""))) signaled (void-variable mu4e~update-buffer)
```

This PR fixes those two leftovers.