### PR TITLE
Reset `gnus-article-buffer` in mu4e-view (#2139)

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -611,17 +611,18 @@ message."
 (put 'mu4e~gnus-article-mime-handles 'permanent-local t)
 
 (defun mu4e-view (msg)
-    "Display the message MSG in a new buffer, and keep in sync with HDRSBUF.
+  "Display the message MSG in a new buffer, and keep in sync with HDRSBUF.
 'In sync' here means that moving to the next/previous message in
 the the message view affects HDRSBUF, as does marking etc.
 
 As a side-effect, a message that is being viewed loses its 'unread'
 marking if it still had that."
 
-    (mu4e~headers-update-handler msg nil nil);; update headers, if necessary.
+  (mu4e~headers-update-handler msg nil nil) ;; update headers, if necessary.
 
-    (when (bufferp gnus-article-buffer)
+  (when (bufferp gnus-article-buffer)
     (kill-buffer gnus-article-buffer))
+  (setq gnus-article-buffer mu4e-view-buffer-name)
   (with-current-buffer (get-buffer-create gnus-article-buffer)
     (let ((inhibit-read-only t))
       (remove-overlays (point-min)(point-max) 'mu4e-overlay t)


### PR DESCRIPTION
This is needed when gnus is used along mu4e for other purpose like
reading News, in this case gnus rename `gnus-article-buffer` and we
end up with an unrelated buffer-name in mu4e.