### PR TITLE
mu4e-search-edit: Fix obsolete alias; update documentation

### DIFF
--- a/mu4e/mu4e-search.el
+++ b/mu4e/mu4e-search.el
@@ -164,7 +164,7 @@ show the message with MSGID."
   (interactive)
   (mu4e-search mu4e--search-last-query nil t))
 
-(define-obsolete-variable-alias 'mu4e-headers-search-edit
+(define-obsolete-function-alias 'mu4e-headers-search-edit
   'mu4e-search-edit "1.7.0")
 
 (defun mu4e-search-bookmark (&optional expr edit)

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -310,7 +310,7 @@ selection."
   (mu4e~view-in-headers-context (mu4e-search-narrow)))
 
 (defun mu4e-view-search-edit ()
-  "Run `mu4e-headers-search-edit' in the headers buffer."
+  "Run `mu4e-search-edit' in the headers buffer."
   (interactive)
   (mu4e~view-in-headers-context (mu4e-search-edit)))
 


### PR DESCRIPTION
Replace obsolete variable alias with obsolete function alias for mu4e-headers-search-edit.
Update docstring for mu4e-view-search-edit to reference the new function.