### PR TITLE
Add Emacs v29 support for enabling mu4e

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,7 +97,7 @@ AS_IF([test "x$enable_mu4e" != "xno"], [
   ])
   AS_CASE([$emacs_version],
     [*25.3*],[build_mu4e=yes],
-    [*26*|*27*|*28*],[build_mu4e=yes],
+    [*26*|*27*|*28*|*29*],[build_mu4e=yes],
     [AC_WARN([emacs is too old to build mu4e (need emacs >= 25.3)])])
 ])
 AM_CONDITIONAL(BUILD_MU4E, test "x$build_mu4e" = "xyes")


### PR DESCRIPTION
Current version checks for enabling mu4e don't include checking for Emacs 29, as such installing mu when using Emacs 29 does not appear to install mu4e. This suggestion changes that behavior.