### PR TITLE
parser: Deal with dash-separated query values

### DIFF
--- a/lib/mu-parser.cc
+++ b/lib/mu-parser.cc
@@ -366,6 +366,20 @@ Parser::Private::data(Mu::Tokens& tokens, WarningVec& warnings) const
 		if (val[0] == '/' && val[val.length() - 1] == '/')
 			return regex(fields, val, token.pos, warnings);
 
+        // does it look like it contains '-', which xapian treats as word separators
+	const char xapianWordSeparator = '-';
+	auto pos = val.find(xapianWordSeparator);
+	if (pos != std::string::npos) {
+		const std::string wordSeparatorRegexp = "[-]";
+		auto wordSeparatorRegexpLen = wordSeparatorRegexp.length();
+		do {
+			val.replace(pos, sizeof(xapianWordSeparator), wordSeparatorRegexp);
+			pos = val.find(xapianWordSeparator, pos + wordSeparatorRegexpLen);
+		} while (pos != std::string::npos);
+		val = "/" + val + "/";
+		return regex(fields, val, token.pos, warnings);
+	}
+
 	// does it look like a range?
 	const auto dotdot = val.find("..");
 	if (dotdot != std::string::npos)


### PR DESCRIPTION
Xapian uses `-` as a word separator, so a query like `mu find s:kata-containers`
would find no results.

This commit brute-forces it by replacing `-` with a `[-]` regexp and
transparently turning the query into a regexp query when this situation occurs.

Fixes: #2167

Signed-off-by: Christophe de Dinechin <christophe@dinechin.org>