### PR TITLE
Use file timestamp for indexing non-RFC-822-compliant messages where the Date: field is missing

### DIFF
--- a/lib/mu-msg-file.cc
+++ b/lib/mu-msg-file.cc
@@ -752,7 +752,7 @@ Mu::mu_msg_file_get_num_field(MuMsgFile* self, const MuMsgFieldId mfid)
 	case MU_MSG_FIELD_ID_DATE: {
 		GDateTime* dt;
 		dt = g_mime_message_get_date(self->_mime_msg);
-		return dt ? g_date_time_to_unix(dt) : 0;
+		return dt ? g_date_time_to_unix(dt) : self->_timestamp;
 	}
 
 	case MU_MSG_FIELD_ID_FLAGS: return (gint64)get_flags(self);


### PR DESCRIPTION
This is a proposed fix for the closed issue : https://github.com/djcb/mu/issues/1083
