### PR TITLE
Ignore existing compiled files when byte-compiling

### DIFF
--- a/mu4e/meson.build
+++ b/mu4e/meson.build
@@ -98,6 +98,7 @@ foreach src : mu4e_all_srcs
 		command: [emacs,
 			  '--no-init-file',
 			  '--batch',
+			  '--eval', '(setq load-prefer-newer t)',
 			  '--eval', target_func,
 			  '--directory', meson.current_build_dir(),
 			  '--directory', meson.current_source_dir(),


### PR DESCRIPTION
In the new build system we call batch-byte-compile manually for incremental compilation. Sadly the default behavior of emacs is to load the byte-compiled version of a source file, even if it refers to an older version. After a git update, this results in emacs loading the existing (old) source when other sources are compiled, which is incorrect.

A warning is emitted though:

```Source file ‘~/src/mu/build/mu4e/mu4e-view.el’ newer than byte-compiled file; using older file```

A simple fix is to use load-prefer-newer in the rule to always avoid loading stale byte-compiled files.