### PR TITLE
mu4e-headers: Add mu4e-headers-thread-mark-as-orphan option

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -207,6 +207,11 @@ chronologically (`:date') by the newest message in the thread.")
 
 ;;;; Graph drawing
 
+(defvar mu4e-headers-thread-mark-as-orphan 'all
+  "Define which messages should be prefixed with the orphan mark.
+`all' marks all the messages without a parent as orphan, `first' only
+marks the first message in the thread.")
+
 (defvar mu4e-headers-thread-root-prefix '("* " . "□ ")
   "Prefix for root messages.")
 (defvar mu4e-headers-thread-child-prefix '("|>" . "│ ")
@@ -451,7 +456,10 @@ with DOCID which must be present in the headers buffer."
                    ;; Current entry.
                    (mu4e~headers-thread-prefix-map
                     (if single-orphan 'single-orphan
-                      (if orphan 'orphan
+                      (if (and orphan
+			       (or first-child
+				   (not (eq mu4e-headers-thread-mark-as-orphan 'first))))
+			       'orphan
                         (if last-child 'last-child
                           (if first-child 'first-child
                             'child)))))))))


### PR DESCRIPTION
To mark only the first message in the thread as orphan, allowing to
replicate the thread structure used by mutt and other clients.

This way it might be possible to replicate the same threading style from mutt. For example, with this configuration:

```elisp
  (setq mu4e-headers-thread-mark-as-orphan 'first
	mu4e-headers-thread-child-prefix '("├>" . "├▸ ")
	mu4e-headers-thread-first-child-prefix '("├>" . "├▸ ")
        mu4e-headers-thread-last-child-prefix '("└>" . "└▸ ")
        mu4e-headers-thread-connection-prefix '("│" . "│ ")
	mu4e-headers-thread-single-orphan-prefix '("─>" . "─▸")
	mu4e-headers-thread-orphan-prefix '("┬>" . "┬▸"))
```

I can have something like that:

```
  12/17/21   Sa   John    ┬>Some orphan thread..
  14:08:36   Nau  John    ├>
  15:13:33   Nau  John    └>
  12:27:12   S    Anne    A regular thread
  13:24:43   u    Ben     ├>
  13:26:43   u    Sandra  └>
  13:34:38   u    Anne     └>
```

