### PR TITLE
Include <functional> for std::invoke

### DIFF
--- a/lib/utils/mu-utils.cc
+++ b/lib/utils/mu-utils.cc
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <iostream>
 #include <algorithm>
+#include <functional>
 
 #include <glib.h>
 #include <glib/gprintf.h>


### PR DESCRIPTION
Fixes a build failure under gcc 12