### PR TITLE
meson: Install mu4e/mu4e-about.org

### DIFF
--- a/mu4e/meson.build
+++ b/mu4e/meson.build
@@ -95,6 +95,9 @@ endforeach
 # also install the sources.
 install_data(mu4e_all_srcs, install_dir: lispdir)
 
+# install mu4e-about.org
+install_data('mu4e-about.org', install_dir : join_paths(datadir, 'doc', 'mu'))
+
 if makeinfo.found()
   custom_target('mu4e_info',
 		input: 'mu4e.texi',


### PR DESCRIPTION
`mu4e` expects this file when activating the [A]bout link in `mu4e-main`
view, but when building the `mu-git` package from the AUR, this file
did not appear in the resulting package.

Now this file is not lost.