### PR TITLE
Last updated timestamp in main screen

### DIFF
--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -321,6 +321,7 @@ When REFRESH is non nil refresh infos from server."
 
        "\n"
        (propertize "  Info\n\n" 'face 'mu4e-title-face)
+       (mu4e--key-val "last updated" (current-time-string (plist-get mu4e-index-update-status :tstamp)))
        (mu4e--key-val "database-path" (mu4e-database-path))
        (mu4e--key-val "maildir" (mu4e-root-maildir))
        (mu4e--key-val "in store"


### PR DESCRIPTION
Based on the `:tstamp` key in `mu4e-index-update-status` plist. 

Looks like this:

![example](https://user-images.githubusercontent.com/22022514/163837624-eba219e5-eeb2-4e8e-ae04-c904b3b6d769.png)

