### PR TITLE
Add support for List-Id completion (list:<List-Id>)

### DIFF
--- a/mu4e/mu4e-search.el
+++ b/mu4e/mu4e-search.el
@@ -442,7 +442,11 @@ status, STATUS."
           (match-end 2)
           mu4e--contacts-hash
           :exit-function
-          #'mu4e--search-completion-contacts-action))))
+          #'mu4e--search-completion-contacts-action))
+   ((looking-back "list:\\([a-zA-Z0-9/.@]*\\)" nil)
+    (list (match-beginning 1)
+          (match-end 1)
+          mu4e--lists-hash))))
 
 (define-minor-mode mu4e-search-minor-mode
   "Mode for searching for messages."


### PR DESCRIPTION
As the title suggests, this commit adds completion support for the known List-Id values after the search keyword `list:` just like we already support email address completion after `to:`, `from:`, and friends.