### PR TITLE
Fixed typo in mu4e.texi

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -3744,7 +3744,7 @@ answers.
 @node General
 @section General
 
-@subsection Results from @t {mu} and @t{mu4e} differ - why?
+@subsection Results from @t{mu} and @t{mu4e} differ - why?
 @anchor{mu-mu4e-differ} In general, the same queries for @command{mu}
 and @t{mu4e} should yield the same results. If they differ, this is
 usually because one of the following reasons:


### PR DESCRIPTION
This typo prevented the build:

```
[...]

[98/121] Generating mu4e/mu4e_info with a custom command
FAILED: mu4e/mu4e.info
/usr/bin/makeinfo -o /Users/fintel/Repos/notmine/mu/build/mu4e/mu4e.info /Users/fintel/Repos/notmine/mu/mu4e/mu4e.texi -I /Users/fintel/Repos/notmine/mu/build/mu4e/..
/Users/fintel/Repos/notmine/mu/mu4e/mu4e.texi:55: warning: undefined flag: VERSION.
/Users/fintel/Repos/notmine/mu/mu4e/mu4e.texi:3748: @t expected braces.
/Users/fintel/Repos/notmine/mu/mu4e/mu4e.texi:3748: Misplaced {.
/Users/fintel/Repos/notmine/mu/mu4e/mu4e.texi:3748: Misplaced }.
/Users/fintel/Repos/notmine/mu/mu4e/mu4e.texi:3748: @t missing close brace.
makeinfo: Removing output file `/Users/fintel/Repos/notmine/mu/build/mu4e/mu4e.info' due to errors; use --force to preserve.

[...]

ninja: build stopped: subcommand failed.
make: *** [all] Error 1
```