### PR TITLE
Add support for flag:personal & fix mu4e-contacts-info

### DIFF
--- a/mu4e/mu4e-contacts.el
+++ b/mu4e/mu4e-contacts.el
@@ -290,7 +290,7 @@ For testing/debugging."
         (setq contacts (sort contacts
                              (lambda(cell1 cell2) (< (car cell1) (car cell2)))))
         (dolist (contact contacts)
-          (insert (format "%s\n" (mu4e-contact-email contact))))))
+          (insert (format "%s\n" (cdr contact))))))
 
     (pop-to-buffer "*mu4e-contacts-info*")))
 

--- a/mu4e/mu4e-search.el
+++ b/mu4e/mu4e-search.el
@@ -425,7 +425,7 @@ status, STATUS."
     (list (match-beginning 1)
 	  (match-end 1)
 	  '("attach" "draft" "flagged" "list" "new" "passed" "replied"
-	    "seen" "trashed" "unread" "encrypted" "signed")))
+	    "seen" "trashed" "unread" "encrypted" "signed" "personal")))
    ((looking-back "maildir:\\([a-zA-Z0-9/.]*\\)" nil)
     (list (match-beginning 1)
           (match-end 1)


### PR DESCRIPTION
I guess the change in `mu4e-search.el` is pretty self-explanatory.

Wrt. `mu4e-contacts-info`: `contacts` is a list with entries of the form `(rank
. full-mail-address)` where `full-mail-address` is a string like `"Name"
<mail@address.com>` and not a contact plist.