### PR TITLE
Add optional :name property to maildir shortcuts

### DIFF
--- a/mu4e/mu4e-folders.el
+++ b/mu4e/mu4e-folders.el
@@ -97,6 +97,7 @@ Each of the list elements is a plist with at least:
 `:key'      - the shortcut key.
 
 Optionally, you can add the following:
+`:name' - name of the maildir to be displayed in main-view.
 `:hide'  - if t, the shortcut is hidden from the main-view and
 speedbar.
 `:hide-unread' - do not show the counts of unread/total number
@@ -159,7 +160,8 @@ This is compatibile with `mu4e-bookmarks'."
   (seq-map
    (lambda (item)
      (let* ((maildir (plist-get item :maildir))
-	    (item (plist-put item :name maildir))
+	    (name (or (plist-get item :name) maildir))
+	    (item (plist-put item :name name))
 	    (item (plist-put item :query (format "maildir:\"%s\"" maildir))))
        item)) ;; we don't need ":maildir", but it's harmless.
    (mu4e-maildir-shortcuts)))

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -1879,6 +1879,7 @@ Each of the list elements is a plist with at least:
 :key   - the shortcut key.
 
 Optionally, you add the following:
+:name  - name of the maildir to be displayed in main-view.
 :hide  - if t, bookmark is hdden from the main-view and speedbar.
 :hide-unread - do not show the counts of unread/total number
  of matches for the query. This can be useful if a bookmark uses


### PR DESCRIPTION
Useful for prettifying long paths of sub-maildirs. E.g., for mailing lists located in sub-directories like `lists/project/listX` 