### PR TITLE
Add optional name for maildir shortcuts

### DIFF
--- a/mu4e/mu4e-folders.el
+++ b/mu4e/mu4e-folders.el
@@ -92,11 +92,12 @@ This makes it possible to quickly go to a particular
 maildir (folder), or quickly moving messages to them (e.g., for
 archiving or refiling).
 
-Each of the list elements is a plist with at least:
+Each of the list elements is a plist with at least a
 `:maildir'  - the maildir for the shortcut (e.g. \"/archive\")
-`:key'      - the shortcut key.
 
 Optionally, you can add the following:
+`:key'  - the shortcut key, can also be a string that gets
+displayed in the main view.
 `:name' - name of the maildir to be displayed in main-view.
 `:hide'  - if t, the shortcut is hidden from the main-view and
 speedbar.

--- a/mu4e/mu4e-folders.el
+++ b/mu4e/mu4e-folders.el
@@ -97,6 +97,7 @@ Each of the list elements is a plist with at least:
 `:key'      - the shortcut key.
 
 Optionally, you can add the following:
+`:name' - name of the maildir to be displayed in main-view.
 `:hide'  - if t, the shortcut is hidden from the main-view and
 speedbar.
 `:hide-unread' - do not show the counts of unread/total number
@@ -159,7 +160,8 @@ This is compatibile with `mu4e-bookmarks'."
   (seq-map
    (lambda (item)
      (let* ((maildir (plist-get item :maildir))
-	    (item (plist-put item :name maildir))
+	    (name (or (plist-get item :name) maildir))
+	    (item (plist-put item :name name))
 	    (item (plist-put item :query (format "maildir:\"%s\"" maildir))))
        item)) ;; we don't need ":maildir", but it's harmless.
    (mu4e-maildir-shortcuts)))

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -212,7 +212,7 @@ clicked."
            with longest = (mu4e--longest-of-maildirs-and-bookmarks)
            with queries = (plist-get mu4e--server-props :queries)
            for m in mds
-           for key = (string (plist-get m :key))
+           for key = (plist-get m :key)
            for name = (plist-get m :name)
            for query = (plist-get m :query)
            for qcounts = (and (stringp query)
@@ -228,9 +228,12 @@ clicked."
            when (not (and mu4e-main-hide-fully-read (eq unread 0)))
            concat (concat
                    ;; menu entry
-                   (mu4e--main-action-str
-                    (concat "\t* [j" key "] " name)
-                    (concat "j" key))
+		   (cond ((characterp key)
+			  (mu4e--main-action-str
+			   (concat "\t* [j" (string key) "] " name)
+			   (concat "j" (string key))))
+			 ((stringp key) (concat "\t* " key "  " name))
+			 (t (concat "\t*      " name)))
                    ;; append all/unread numbers, if available.
                    (if qcounts
                        (let ((unread (plist-get (car qcounts) :unread))

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -1978,7 +1978,8 @@ quick access to, for example:
      (:maildir "/lists"     :key  ?l)
      (:maildir "/work"      :key  ?w)
      (:maildir "/sent"      :key  ?s)
-     (:maildir "/lists/project/project_X" :key ?x :name "Project X")))
+     (:maildir "/lists/project_a/list_b" :key "Lab")
+     (:maildir "/lists/project_c/list_x" :key ?x :name "Project X")))
 @end lisp
 
 This sets @key{i} as a shortcut for the @t{/inbox} folder --- effectively a
@@ -1988,7 +1989,8 @@ choose from @emph{all} maildirs that you have. There is support for
 autocompletion; note that the list of maildirs is determined when @t{mu4e}
 starts; if there are changes in the maildirs while @t{mu4e} is running, you
 need to restart @t{mu4e}. Optionally, you can specify a name to be displayed
-in the main view.
+in the main view. The key can also be a string, in that case the string gets
+displayed in the main view. This is useful e.g. for calling custom Hydras.
 
 Each of the folder names is relative to your top-level maildir directory; so
 if you keep your mail in @file{~/Maildir}, @file{/inbox} would refer to

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -1977,7 +1977,8 @@ quick access to, for example:
      (:maildir "/archive"   :key  ?a)
      (:maildir "/lists"     :key  ?l)
      (:maildir "/work"      :key  ?w)
-     (:maildir "/sent"      :key  ?s)))
+     (:maildir "/sent"      :key  ?s)
+     (:maildir "/lists/project/project_X" :key ?x :name "Project X")))
 @end lisp
 
 This sets @key{i} as a shortcut for the @t{/inbox} folder --- effectively a
@@ -1986,7 +1987,8 @@ query @t{maildir:/inbox}. There is a special shortcut @key{o} or @key{/} for
 choose from @emph{all} maildirs that you have. There is support for
 autocompletion; note that the list of maildirs is determined when @t{mu4e}
 starts; if there are changes in the maildirs while @t{mu4e} is running, you
-need to restart @t{mu4e}.
+need to restart @t{mu4e}. Optionally, you can specify a name to be displayed
+in the main view.
 
 Each of the folder names is relative to your top-level maildir directory; so
 if you keep your mail in @file{~/Maildir}, @file{/inbox} would refer to


### PR DESCRIPTION
Useful to nicely display maildirs with long paths such as `lists/project/project_X`. If no `:name` is specified, keep the original behavior and use `:maildir` as name.