### PR TITLE
Add a custom maildir list to show in the maildir section.

### DIFF
--- a/mu4e/mu4e-bookmarks.el
+++ b/mu4e/mu4e-bookmarks.el
@@ -44,7 +44,6 @@
       :key ?t)
     ( :name "Last 7 days"
       :query "date:7d..now"
-      :hide-unread t
       :key ?w)
     ( :name "Messages with images"
       :query "mime:image/*"

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -81,6 +81,15 @@
 ;;; Configuration
 ;; see mu4e-drafts.el
 
+(defcustom mu4e-allow-edit-any-message nil
+  "Whether to allow to edit any message or just the draft messages.
+Setting this to t allows any message to be edited, not just the draft messages.
+
+Changes to this value only take effect after (re)starting the mu
+session."
+  :type 'boolean
+  :group 'mu4e)
+
 ;;; Attachments
 (defun mu4e-compose-attach-message (msg)
   "Insert message MSG as an attachment."
@@ -736,6 +745,7 @@ Symbol `edit' is only allowed for draft messages."
     (unless (member compose-type '(reply forward edit resend new))
       (mu4e-error "Invalid compose type '%S'" compose-type))
     (when (and (eq compose-type 'edit)
+               (not (eq mu4e-allow-edit-any-message 't))
                (not (member 'draft (mu4e-message-field msg :flags))))
       (mu4e-warn "Editing is only allowed for draft messages"))
 

--- a/mu4e/mu4e-folders.el
+++ b/mu4e/mu4e-folders.el
@@ -86,6 +86,12 @@ nil otherwise."
           (function :tag "Function return folder name"))
   :group 'mu4e-folders)
 
+(defcustom mu4e-maildirs nil
+  "A custom list of maildirs"
+  :type '(repeat string)
+  :version "1.3.9"
+  :group 'mu4e-folders)
+
 (defcustom mu4e-maildir-shortcuts nil
   "A list of maildir shortcuts.
 This makes it possible to quickly go to a particular
@@ -174,6 +180,12 @@ called."
   :group 'mu4e-folders)
 
 
+(defun mu4e-maildirs ()
+  "Get `mu4e-maildirs'."
+  (seq-map (lambda (item)
+             `(:maildir  ,item :key ,?.))
+  mu4e-maildirs))
+
 (defun mu4e-maildir-shortcuts ()
   "Get `mu4e-maildir-shortcuts' in the (new) format.
 Converts from the old format if needed."

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -227,7 +227,7 @@ for aligning them."
                 ;; note, we have a function for the binding,
                 ;; and perhaps a different one for the lambda.
                 (cond
-                 ((eq item-type 'maildirs)
+                 ((or (eq item-type 'maildirs) (eq item-type 'maildirs-with-shortcut))
                   (list #'mu4e-search-maildir #'mu4e-search
                         query))
                  ((eq item-type 'bookmarks)
@@ -311,7 +311,10 @@ Otherwise, do nothing."
            (propertize "  Bookmarks\n\n" 'face 'mu4e-title-face)
            (mu4e--main-items 'bookmarks max-length)
            "\n"
-           (propertize "  Maildirs\n\n" 'face 'mu4e-title-face)
+           (propertize "  Quick access maildirs\n\n" 'face 'mu4e-title-face)
+           (mu4e--main-items 'maildirs-with-shortcut max-length)
+           "\n"
+           (propertize "  Other maildirs\n\n" 'face 'mu4e-title-face)
            (mu4e--main-items 'maildirs max-length)
            "\n"
            (propertize "  Misc\n\n" 'face 'mu4e-title-face)

--- a/mu4e/mu4e-query-items.el
+++ b/mu4e/mu4e-query-items.el
@@ -92,10 +92,12 @@ If ITEMS does not yet have a favorite item, pick the first."
   items)
 
 (defvar mu4e--bookmark-items-cached nil "Cached bookmarks query items.")
+(defvar mu4e--maildir-with-shortcut-items-cached nil "Cached maildirs query items.")
 (defvar mu4e--maildir-items-cached nil "Cached maildirs query items.")
 
 (declare-function  mu4e-bookmarks "mu4e-bookmarks")
 (declare-function  mu4e-maildir-shortcuts "mu4e-folders")
+(declare-function  mu4e-maildirs "mu4e-folders")
 
 (defun mu4e--query-item-display-counts (item)
   "Get the count display string for some query-data ITEM."
@@ -123,6 +125,7 @@ With RESET-BASELINE, reset the baseline first."
     (setq mu4e--query-items-baseline nil
           mu4e--query-items-baseline-tstamp nil
           mu4e--bookmark-items-cached nil
+          mu4e--maildir-with-shortcut-items-cached nil
           mu4e--maildir-items-cached nil
           mu4e--last-delta-unread 0))
   (mu4e--server-queries
@@ -146,6 +149,7 @@ I.e. what we get in response to mu4e--query-items-refresh."
           mu4e--query-items-baseline-tstamp (current-time)))
 
   (setq mu4e--bookmark-items-cached nil
+        mu4e--maildir-with-shortcut-items-cached nil
         mu4e--maildir-items-cached nil)
   (mu4e-query-items) ;; for side-effects
   ;; tell the world.
@@ -240,12 +244,15 @@ for use in various places."
         (setq mu4e--bookmark-items-cached
               (mu4e--query-items-pick-favorite
                (mu4e--make-query-items (mu4e-bookmarks) 'bookmarks)))))
+   ((equal type 'maildirs-with-shortcut)
+    (or mu4e--maildir-with-shortcut-items-cached
+        (setq mu4e--maildir-with-shortcut-items-cached (mu4e--make-query-items (mu4e-maildir-shortcuts) 'maildirs))))
    ((equal type 'maildirs)
     (or mu4e--maildir-items-cached
-        (setq mu4e--maildir-items-cached
-              (mu4e--make-query-items (mu4e-maildir-shortcuts) 'maildirs))))
+        (setq mu4e--maildir-items-cached (mu4e--make-query-items (mu4e-maildirs) 'maildirs))))
    ((not type)
     (append (mu4e-query-items 'bookmarks)
+            (mu4e-query-items 'maildirs-with-shortcut)
             (mu4e-query-items 'maildirs)))
    (t
     (mu4e-error "No such type %s" type))))

--- a/mu4e/mu4e-server.el
+++ b/mu4e/mu4e-server.el
@@ -207,7 +207,7 @@ Checks whether the server process is live."
              '(run open listen connect stop)) t))
 
 (defsubst mu4e--server-eat-sexp-from-buf ()
-  "'Eat' the next s-expression from `mu4e--server-buf'.
+  "`Eat' the next s-expression from `mu4e--server-buf'.
 Note: this is a string, not an emacs-buffer. `mu4e--server-buf gets
 its contents from the mu-servers in the following form:
    <`mu4e--server-cookie-pre'><length-in-hex><`mu4e--server-cookie-post'>


### PR DESCRIPTION
I have a bunch of maildirs that I don't want to have with a shortcut defined, but I want to be shown in the `Maildirs` section, so I'm adding a new variable, `mu4e-maildir-custom-list`, to define all the maildirs I want to be shown in the `Maildirs` section. It's my first PR, so comments are welcome :).

Signed-off-by: Ritho <palvarez@ritho.net>