### PR TITLE
query: include Message-ID header query for related messages

### DIFF
--- a/lib/mu-query.cc
+++ b/lib/mu-query.cc
@@ -112,8 +112,15 @@ Query::Private::make_related_enquire(const StringSet& thread_ids,
 {
 	Xapian::Enquire            enq{store_.database()};
 	std::vector<Xapian::Query> qvec;
-	for (auto&& t : thread_ids)
+	for (auto&& t : thread_ids) {
 		qvec.emplace_back(field_from_id(Field::Id::ThreadId).xapian_term(t));
+                // The first email in a thread might not have a References
+                // header, or might have References header with bogus value
+                // (since it is the first email in the thread). In such case,
+                // the Message-ID header can be used to lookup the this first
+                // email.
+                qvec.emplace_back(field_from_id(Field::Id::MessageId).xapian_term(t));
+        }
 
 	Xapian::Query qr{Xapian::Query::OP_OR, qvec.begin(), qvec.end()};
 	enq.set_query(qr);


### PR DESCRIPTION
When mu-find is called with a query that includes few emails in a thread, and if
--include-related flag is passed, mu does not find the first email in
thread. This is because in some cases, the first email in the thread does not
includes its own Message-ID header value in the References header. Subsequent
emails include the parent's Message-ID in their own References header, and
that's why mu finds them.

This change modifies the executed query. When searching for related messages, we
include Message-ID search as well. This does pull the first email in the thread.

As a test, I ran the following query:

```
husain@localhost:~/src/mu$ build/mu/mu find "fix buffer overflow debugfs flag:unread" --threads --include-related
Thu 04 Aug 2022 09:32:39 AM CDT Dan Carpenter <dan.carpenter@oracle.com> [PATCH] iommu/omap: fix buffer overflow in debugfs
\-> Thu 04 Aug 2022 11:26:16 AM CDT Laurent Pinchart <laurent.pinchart@ideasonboard.com> Re: [PATCH] iommu/omap: fix buffer overflow in debugfs
/-> Thu 04 Aug 2022 11:31:39 AM CDT Robin Murphy <robin.murphy@arm.com> Re: [PATCH] iommu/omap: fix buffer overflow in debugfs
  \-> Fri 05 Aug 2022 01:37:02 AM CDT Dan Carpenter <dan.carpenter@oracle.com> Re: [PATCH] iommu/omap: fix buffer overflow in debugfs
```

(similar query as to the one mentioned in the bug report: #2312 )

The first email in the thread includes the following headers:

```
References:  <EZrZOnVCsYfFcX3Ls0VFoRnJdCGV4GM5YtO739l-iOB2ADNH7cIJWb0DaO5Of3BWDUEKq18Rz3a7rNoI96bNwQ==@protonmail.internalid>
...
Cc: "Will Deacon" <will@kernel.org>, "Robin Murphy" <robin.murphy@arm.com>,
 "Laurent Pinchart" <laurent.pinchart@ideasonboard.com>,
 <iommu@lists.linux.dev>, <kernel-janitors@vger.kernel.org>
To: "Joerg Roedel" <joro@8bytes.org>, "Suman Anna" <s-anna@ti.com>
Reply-To: "Dan Carpenter" <dan.carpenter@oracle.com>
From: "Dan Carpenter" <dan.carpenter@oracle.com>
Subject: [PATCH] iommu/omap: fix buffer overflow in debugfs
Date: Thu, 4 Aug 2022 17:32:39 +0300
..
X-Mailing-List: kernel-janitors@vger.kernel.org
Message-Id: <YuvYh1JbE3v+abd5@kili>
```

while subsequent emails have something like:

```
References: <YuvYh1JbE3v+abd5@kili>
 <90a760c4-6e88-07b4-1f20-8b10414e49aa@arm.com>
 <T4CDWjUrgtI5n4mh1JEdW6RLYzqbPE9-yDrhEVwDM22WX-198fBwcnLd-4_xR1gvsVSHQps9fp_pZevTF0ZmaA==@protonmail.internalid>
...
Message-Id: <20220805063702.GH3438@kadam>
```
