### PR TITLE
mu4e-view: use `save-excursion' around toggling html

### DIFF
--- a/guile/meson.build
+++ b/guile/meson.build
@@ -51,8 +51,8 @@ if do_snarf
   snarf = find_program('guile-snarf3.0','guile-snarf')
   # there must be a better way of feeding the include paths to snarf...
   snarf_args=['-o', '@OUTPUT@', '@INPUT@', '-I' + meson.current_source_dir() + '/..',
-	      '-I' + meson.current_source_dir() + '/../lib',
-	      '-I' + meson.current_build_dir() + '/..']
+              '-I' + meson.current_source_dir() + '/../lib',
+              '-I' + meson.current_build_dir() + '/..']
   snarf_args += '-I' + join_paths(glib_dep.get_pkgconfig_variable('includedir'),
                                   'glib-2.0')
   snarf_args += '-I' + join_paths(glib_dep.get_pkgconfig_variable('libdir'),
@@ -60,8 +60,8 @@ if do_snarf
   snarf_args += '-I' + join_paths(guile_dep.get_pkgconfig_variable('includedir'),
                                   'guile', '3.0')
   snarf_gen=generator(snarf,
-		      output: '@BASENAME@.x',
-		      arguments: snarf_args)
+                      output: '@BASENAME@.x',
+                      arguments: snarf_args)
   snarf_srcs=['mu-guile.cc', 'mu-guile-message.cc']
   snarf_x=snarf_gen.process(snarf_srcs)
 else
@@ -77,25 +77,24 @@ lib_guile_mu = shared_module(
 
 if makeinfo.found()
   custom_target('mu_guile_info',
-		input: 'mu-guile.texi',
-		output: 'mu-guile.info',
-		install: true,
-		install_dir: infodir,
-		command: [makeinfo,
-			  '-o', join_paths(meson.current_build_dir(), 'mu-guile.info'),
-			  join_paths(meson.current_source_dir(), 'mu-guile.texi'),
-			  '-I', join_paths(meson.current_build_dir(), '..')])
+                input: 'mu-guile.texi',
+                output: 'mu-guile.info',
+                install: true,
+                install_dir: infodir,
+                command: [makeinfo,
+                          '-o', join_paths(meson.current_build_dir(), 'mu-guile.info'),
+                          join_paths(meson.current_source_dir(), 'mu-guile.texi'),
+                          '-I', join_paths(meson.current_build_dir(), '..')])
 
   if install_info.found()
     meson.add_install_script(install_info_script, 'share/info', 'mu-guile.info')
   endif
-
   
 endif
 
 guile_scm_dir=join_paths(datadir, 'guile', 'site', '3.0', 'mu')
 install_data(['mu.scm','mu/script.scm', 'mu/message.scm', 'mu/stats.scm', 'mu/plot.scm'],
-	     install_dir: guile_scm_dir)
+             install_dir: guile_scm_dir)
 
 guile_builddir=meson.current_build_dir()
 

--- a/guile/meson.build
+++ b/guile/meson.build
@@ -89,12 +89,24 @@ if makeinfo.found()
   if install_info.found()
     meson.add_install_script(install_info_script, 'share/info', 'mu-guile.info')
   endif
-  
 endif
 
 guile_scm_dir=join_paths(datadir, 'guile', 'site', '3.0', 'mu')
 install_data(['mu.scm','mu/script.scm', 'mu/message.scm', 'mu/stats.scm', 'mu/plot.scm'],
              install_dir: guile_scm_dir)
+
+
+mu_guile_scripts=[
+  join_paths('scripts', 'find-dups.scm'),
+  join_paths('scripts', 'msgs-count.scm'),
+  join_paths('scripts', 'msgs-per-day.scm'),
+  join_paths('scripts', 'msgs-per-hour.scm'),
+  join_paths('scripts', 'msgs-per-month.scm'),
+  join_paths('scripts', 'msgs-per-year-month.scm'),
+  join_paths('scripts', 'msgs-per-year.scm')
+]
+mu_guile_script_dir=join_paths(datadir, 'mu', 'scripts')
+install_data(mu_guile_scripts, install_dir: mu_guile_script_dir)
 
 guile_builddir=meson.current_build_dir()
 

--- a/guile/mu-guile-message.cc
+++ b/guile/mu-guile-message.cc
@@ -444,10 +444,18 @@ static void
 define_vars(void)
 {
 	field_for_each([](auto&& field){
-		const auto name{"mu:field:" +
-			std::string{field.alias.empty() ? field.name : field.alias}};
-		scm_c_define(name.c_str(), scm_from_uint(field.value_no()));
-		scm_c_export(name.c_str(), NULL);
+
+		auto defvar = [&](auto&& fname, auto&& ffield) {
+			const auto name{"mu:field:" + std::string{fname}};
+			scm_c_define(name.c_str(), scm_from_uint(field.value_no()));
+			scm_c_export(name.c_str(), NULL);
+		};
+
+		// define for both name and (if exists) alias.
+		if (!field.name.empty())
+			defvar(field.name, field);
+		if (!field.alias.empty())
+			defvar(field.alias, field);
 	});
 
 	/* non-Xapian field: timestamp */

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -1300,12 +1300,13 @@ the third MIME-part."
   (interactive)
   ;; This function assumes `gnus-article-mime-handle-alist' is sorted by
   ;; pertinence, i.e. the first HTML part found in it is the most important one.
-  (if-let ((html-part
-	    (seq-find (lambda (handle)
-			(equal (mm-handle-media-type (cdr handle)) "text/html"))
-		      gnus-article-mime-handle-alist)))
-      (gnus-article-inline-part (car html-part))
-    (mu4e-warn "No html part in this message")))
+  (save-excursion
+    (if-let ((html-part
+	      (seq-find (lambda (handle)
+			  (equal (mm-handle-media-type (cdr handle)) "text/html"))
+		        gnus-article-mime-handle-alist)))
+        (gnus-article-inline-part (car html-part))
+      (mu4e-warn "No html part in this message"))))
 
 (defun mu4e-process-file-through-pipe (path pipecmd)
   "Process file at PATH through a pipe with PIPECMD."


### PR DESCRIPTION
Previously, the cursor would be moved to the first html attachment which
would break using mu4e keybindings (e.g. delete). With this change, the
cursor isn't moved at all, presumably the expected behavior.

I've targeted this for the 1.8 release branch because it seems like a bug but if
you want to apply to master instead, that's fine.