### PR TITLE
mu4e-main: automatically update the mail counts after indexing

### DIFF
--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -118,7 +118,8 @@ the personal addresses.")
   (mu4e-context-minor-mode)
   (mu4e-search-minor-mode)
   (mu4e-update-minor-mode)
-  (set (make-local-variable 'revert-buffer-function) #'mu4e--main-view-real))
+  (set (make-local-variable 'revert-buffer-function) #'mu4e--main-view-real)
+  (add-hook 'mu4e-index-updated-hook #'mu4e--main-update-after-index))
 
 
 (defun mu4e--main-action-str (str &optional func-or-shortcut)
@@ -416,6 +417,11 @@ When REFRESH is non nil refresh infos from server."
     (when (eq func 'mu4e-context-switch)
       (sit-for 1)
       (mu4e--main-menu))))
+
+(defun mu4e--main-update-after-index ()
+  "Update the main view buffer after indexing."
+  (with-current-buffer mu4e-main-buffer-name
+    (revert-buffer)))
 
 (provide 'mu4e-main)
 ;;; mu4e-main.el ends here


### PR DESCRIPTION
It always struck me as a bit odd to force the user to refresh the main
view after updating and indexing their mail. This change creates a hook
that will simply call `revert-buffer' after an indexing completes.