### PR TITLE
m4e: remove disruptive characters from header fields

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -653,12 +653,17 @@ space propertized with a `display' text property which expands to
       (mu4e~headers-truncate-field-precise field val width)
     (mu4e~headers-truncate-field-fast val width)))
 
+(defsubst mu4e~headers-sanitize-field-value (val)
+  "Replace control characters in VAL by regular spaces."
+  (replace-regexp-in-string "[\0- ]+" " " val))
+
 (defsubst mu4e~headers-field-handler (f-w msg)
   "Create a description of the field of MSG described by F-W."
   (let* ((field (car f-w))
          (width (cdr f-w))
          (val (mu4e~headers-field-value msg field))
-         (val (and val (if width (mu4e~headers-truncate-field field val width) val))))
+         (val (and val (if width (mu4e~headers-truncate-field field val width) val)))
+         (val (and val (mu4e~headers-sanitize-field-value val))))
     val))
 
 (defsubst mu4e~headers-apply-flags (msg fieldval)


### PR DESCRIPTION
Sometimes fields (especially subject fields) contain disruptive characters like new lines which will mess up the mu4e-headers view. This changeset introduces `mu4e~headers-sanitize-field-value` to replace all control characters by spaces.

Note, Unicode Left to Right Overrides do not cause any problems so they are ignored.