### PR TITLE
Add a custom variable for maildir selection initial-input

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@
 ## Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 AC_PREREQ([2.68])
-AC_INIT([mu],[1.8.9],[https://github.com/djcb/mu/issues],[mu])
+AC_INIT([mu],[1.8.10],[https://github.com/djcb/mu/issues],[mu])
 AC_COPYRIGHT([Copyright (C) 2008-2022 Dirk-Jan C. Binnema])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_SRCDIR([mu/mu.cc])

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 # project setup
 #
 project('mu', ['c', 'cpp'],
-	version: '1.8.9',
+	version: '1.8.10',
 	meson_version: '>= 0.52.0', # debian 10
 	license: 'GPL-3.0-or-later',
 	default_options : [

--- a/mu4e/mu4e-folders.el
+++ b/mu4e/mu4e-folders.el
@@ -119,6 +119,11 @@ NOT be quoted, since mu4e does this for you."
   :version "1.3.9"
   :group 'mu4e-folders)
 
+(defcustom mu4e-maildir-initial-input "/"
+  "Initial input for `mu4e-completing-completing-read' function."
+  :type 'string
+  :group 'mu4e-folders)
+
 (defcustom mu4e-maildir-info-delimiter
   (if (member system-type '(ms-dos windows-nt cygwin))
       ";" ":")
@@ -301,7 +306,8 @@ from all maildirs under `mu4e-maildir'."
         (if (member kar '(?/ ?o)) ;; user chose 'other'?
             (substring-no-properties
              (funcall mu4e-completing-read-function prompt
-                      (mu4e-get-maildirs) nil nil "/"))
+                      (mu4e-get-maildirs) nil nil
+                      mu4e-maildir-initial-input))
           (or (plist-get
                (seq-find (lambda (item) (= kar (plist-get item :key)))
                          (mu4e-maildir-shortcuts)) :maildir)

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1555,12 +1555,7 @@ user)."
              (if (eq sortfield mu4e-headers-sort-field)
                  (if (eq mu4e-headers-sort-direction 'ascending)
                      'descending 'ascending)
-               'descending)))
-          ;; FIXME: This has been here for years but cl-case doesn't allow
-          ;; further clauses after t or otherwise.
-          ;; (mu4e-read-option "Direction: " '(("ascending" . 'ascending)
-          ;;                                   ("descending" . 'descending)))
-          ))
+               'descending)))))
     (setq
      mu4e-headers-sort-field sortfield
      mu4e-headers-sort-direction dir)

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -379,14 +379,14 @@ into a string."
          (lambda (cell)
            (if mu4e-use-fancy-chars (cdr cell) (car cell)))))
     (cl-case type
-      ('child         (funcall get-prefix mu4e-headers-thread-child-prefix))
-      ('first-child   (funcall get-prefix mu4e-headers-thread-first-child-prefix))
-      ('last-child    (funcall get-prefix mu4e-headers-thread-last-child-prefix))
-      ('connection    (funcall get-prefix mu4e-headers-thread-connection-prefix))
-      ('blank         (funcall get-prefix mu4e-headers-thread-blank-prefix))
-      ('orphan        (funcall get-prefix mu4e-headers-thread-orphan-prefix))
-      ('single-orphan (funcall get-prefix mu4e-headers-thread-single-orphan-prefix))
-      ('duplicate     (funcall get-prefix mu4e-headers-thread-duplicate-prefix))
+      (child         (funcall get-prefix mu4e-headers-thread-child-prefix))
+      (first-child   (funcall get-prefix mu4e-headers-thread-first-child-prefix))
+      (last-child    (funcall get-prefix mu4e-headers-thread-last-child-prefix))
+      (connection    (funcall get-prefix mu4e-headers-thread-connection-prefix))
+      (blank         (funcall get-prefix mu4e-headers-thread-blank-prefix))
+      (orphan        (funcall get-prefix mu4e-headers-thread-orphan-prefix))
+      (single-orphan (funcall get-prefix mu4e-headers-thread-single-orphan-prefix))
+      (duplicate     (funcall get-prefix mu4e-headers-thread-duplicate-prefix))
       (t              "?"))))
 
 
@@ -1555,9 +1555,12 @@ user)."
              (if (eq sortfield mu4e-headers-sort-field)
                  (if (eq mu4e-headers-sort-direction 'ascending)
                      'descending 'ascending)
-               'descending))
-            (mu4e-read-option "Direction: "
-                              '(("ascending" . 'ascending) ("descending" . 'descending))))))
+               'descending)))
+          ;; FIXME: This has been here for years but cl-case doesn't allow
+          ;; further clauses after t or otherwise.
+          ;; (mu4e-read-option "Direction: " '(("ascending" . 'ascending)
+          ;;                                   ("descending" . 'descending)))
+          ))
     (setq
      mu4e-headers-sort-field sortfield
      mu4e-headers-sort-direction dir)


### PR DESCRIPTION
`mu4e-ask-maildir` hard-codes "/" as initial input for maildir selection. This is unnecessary for substring matching with modern completing-read functions and should be user-customisable.