### PR TITLE
Use fake Message-ID when empty

### DIFF
--- a/lib/message/mu-message.cc
+++ b/lib/message/mu-message.cc
@@ -638,7 +638,10 @@ fill_document(Message::Private& priv)
 
 	const auto path{doc.string_value(Field::Id::Path)};
 	const auto refs{mime_msg.references()};
-	const auto message_id{mime_msg.message_id().value_or(fake_message_id(path))};
+        const auto& raw_message_id = mime_msg.message_id();
+        const auto message_id = raw_message_id.has_value() && !raw_message_id->empty()
+            ? *raw_message_id
+            : fake_message_id(path);
 
 	process_message(mime_msg, path, priv);
 


### PR DESCRIPTION
Previously, mu generated a fake message ID for messages without a Message-ID header.  This fake message ID allows these messages to show in an --include-related query. However, if a message contained a Message-ID header with the value equal to the empty string, we did not generate a fake message ID in the index, and consequently, these messages failed to appear in an --include-related query.  This change uses a fake message ID when the Message-ID header is absent _or_ empty.