### PR TITLE
mu4e: temporary reset browse-url-handlers in view in xwidget action

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -654,9 +654,10 @@ determine which browser function to use."
   "Show current MSG in an embedded xwidget, if available."
   (unless (fboundp 'xwidget-webkit-browse-url)
     (mu4e-error "No xwidget support available"))
-  (let ((browse-url-browser-function
-	 (lambda (url &optional _rest)
-	   (xwidget-webkit-browse-url url))))
+  (let ((browse-url-handlers nil)
+        (browse-url-browser-function
+         (lambda (url &optional _rest)
+           (xwidget-webkit-browse-url url))))
     (mu4e-action-view-in-browser msg)))
 
 (defun mu4e~view-render-buffer (msg)


### PR DESCRIPTION
If `browse-url-handlers` is set `mu4e-action-view-in-xwidget` function tries to open url in the handler first instead of xwidget. This is happening because `browse-url` first checks `browse-url-handlers` and `browse-url-browser-function` after.