### PR TITLE
Teach mu4e-copy-thing-at-point about SHR links

### DIFF
--- a/mu4e/mu4e-helpers.el
+++ b/mu4e/mu4e-helpers.el
@@ -465,8 +465,8 @@ http://cr.yp.to/proto/maildir.html."
 If there is not e-mail address at point, do nothing."
   (interactive)
   (let* ((thing (and (thing-at-point 'email)
-		     (string-trim (thing-at-point 'email 'no-props) "<" ">")))
-	 (thing (or thing (thing-at-point 'url 'no-props))))
+                     (string-trim (thing-at-point 'email 'no-props) "<" ">")))
+         (thing (or thing (thing-at-point 'url 'no-props))))
     (when thing
       (kill-new thing)
       (mu4e-message "Copied '%s' to kill-ring" thing))))

--- a/mu4e/mu4e-helpers.el
+++ b/mu4e/mu4e-helpers.el
@@ -466,6 +466,7 @@ If there is not e-mail address at point, do nothing."
   (interactive)
   (let* ((thing (and (thing-at-point 'email)
                      (string-trim (thing-at-point 'email 'no-props) "<" ">")))
+         (thing (or thing (get-text-property (point) 'shr-url)))
          (thing (or thing (thing-at-point 'url 'no-props))))
     (when thing
       (kill-new thing)


### PR DESCRIPTION
This allows one to copy the link behind a link-widget instead of using RET to open it.

I've been having good success with this patch on my system for the last several days. It's very handy -- I currently cannot open links directly into a browser with my setup.