### PR TITLE
Multiple buffer support and standardised window and buffer handling

### DIFF
--- a/mu4e/meson.build
+++ b/mu4e/meson.build
@@ -52,7 +52,8 @@ mu4e_srcs=[
   'mu4e-speedbar.el',
   'mu4e-update.el',
   'mu4e-vars.el',
-  'mu4e-view.el'
+  'mu4e-view.el',
+  'mu4e-window.el'
 ]
 
 # note, we cannot compile mu4e-config.el without incurring

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -76,7 +76,7 @@
 (require 'mu4e-message)
 (require 'mu4e-draft)
 (require 'mu4e-context)
-
+(require 'mu4e-window)
 
 ;;; Configuration
 ;; see mu4e-drafts.el
@@ -502,8 +502,7 @@ See `mu4e-compose-crypto-policy' for more details."
           (sign (mml-secure-message-sign))
           (encrypt (mml-secure-message-encrypt)))))
 
-(cl-defun mu4e~compose-handler (compose-type &optional original-msg includes
-                                             switch-function)
+(cl-defun mu4e~compose-handler (compose-type &optional original-msg includes)
   "Create a new draft message, or open an existing one.
 
 COMPOSE-TYPE determines the kind of message to compose and is a
@@ -542,7 +541,7 @@ are optional."
   (let ((draft-buffer))
     (let ((winconf (current-window-configuration)))
       (condition-case nil
-          (setq draft-buffer (mu4e-draft-open compose-type original-msg switch-function))
+          (setq draft-buffer (mu4e-draft-open compose-type original-msg))
         (quit (set-window-configuration winconf)
               (mu4e-message "Operation aborted")
               (cl-return-from mu4e~compose-handler))))
@@ -797,8 +796,7 @@ draft message."
 
 ;;;###autoload
 (defun mu4e~compose-mail (&optional to subject other-headers _continue
-                                    switch-function yank-action
-				    _send-actions _return-action)
+                                    yank-action _send-actions _return-action)
   "This is mu4e's implementation of `compose-mail'.
 Quoting its docstring:
 
@@ -813,9 +811,6 @@ HEADER and VALUE are strings.
 
 CONTINUE, if non-nil, says to continue editing a message already
 being composed.  Interactively, CONTINUE is the prefix argument.
-
-SWITCH-FUNCTION, if non-nil, is a function to use to
-switch to and display the buffer used for mail composition.
 
 YANK-ACTION, if non-nil, is an action to perform, if and when
 necessary, to insert the raw text of the message being replied
@@ -833,11 +828,11 @@ called after the mail has been sent or put aside, and the mail
 buffer buried."
 
   (unless (mu4e-running-p)
-     (mu4e))
+    (mu4e))
 
   ;; create a new draft message 'resetting' (as below) is not actually needed in
   ;; this case, but let's prepare for the re-edit case as well
-  (mu4e~compose-handler 'new nil nil switch-function)
+  (mu4e~compose-handler 'new nil nil)
 
   (when (message-goto-to) ;; reset to-address, if needed
     (message-delete-line))

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -596,7 +596,6 @@ are optional."
     ;; don't allow undoing anything before this.
     (setq buffer-undo-list nil)
 
-    ;; TODO: replace this
     (when mu4e-compose-in-new-frame
       ;; make sure to close the frame when we're done with the message these are
       ;; all buffer-local;

--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -231,11 +231,6 @@ mu4e-specific version of `message-signature'."
   :type 'boolean
   :group 'mu4e-compose)
 
-(defcustom mu4e-compose-in-new-frame nil
-  "Whether to compose messages in a new frame."
-  :type 'boolean
-  :group 'mu4e-compose)
-
 (defvar mu4e-user-agent-string
   (format "mu4e %s; emacs %s" mu4e-mu-version emacs-version)
   "The User-Agent string for mu4e, or nil.")

--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -665,7 +665,7 @@ will be the same as in the original."
   "The drafts-folder for this compose buffer.
 This is based on `mu4e-drafts-folder', which is evaluated once.")
 
-(defun mu4e~draft-open-file (path switch-function)
+(defun mu4e~draft-open-file (path)
   "Open the the draft file at PATH."
   (find-file-noselect path))
 
@@ -676,7 +676,7 @@ This is based on `mu4e-drafts-folder', which is evaluated once.")
           (mu4e-root-maildir) draft-dir (mu4e~draft-message-filename-construct "DS")))
 
 
-(defun mu4e-draft-open (compose-type &optional msg switch-function)
+(defun mu4e-draft-open (compose-type &optional msg)
   "Open a draft file for a message MSG.
 In case of a new message (when COMPOSE-TYPE is `reply', `forward'
  or `new'), open an existing draft (when COMPOSE-TYPE is `edit'),
@@ -699,7 +699,7 @@ Returns the newly-created draft buffer."
        ;; full path, but we cannot really know 'drafts folder'... we make a
        ;; guess
        (setq draft-dir (mu4e--guess-maildir (mu4e-message-field msg :path)))
-       (setq draft-buffer (mu4e~draft-open-file (mu4e-message-field msg :path) switch-function)))
+       (setq draft-buffer (mu4e~draft-open-file (mu4e-message-field msg :path))))
 
       (resend
        ;; case-2: copy some exisisting message to a draft message, then edit
@@ -707,7 +707,7 @@ Returns the newly-created draft buffer."
        (setq draft-dir (mu4e--guess-maildir (mu4e-message-field msg :path)))
        (let ((draft-path (mu4e~draft-determine-path draft-dir)))
          (copy-file (mu4e-message-field msg :path) draft-path)
-         (setq draft-buffer (mu4e~draft-open-file draft-path switch-function))))
+         (setq draft-buffer (mu4e~draft-open-file draft-path))))
 
       ((reply forward new)
        ;; case-3: creating a new message; in this case, we can determine
@@ -719,7 +719,7 @@ Returns the newly-created draft buffer."
                 (reply   (mu4e~draft-reply-construct msg))
                 (forward (mu4e~draft-forward-construct msg))
                 (new     (mu4e~draft-newmsg-construct)))))
-         (setq draft-buffer (mu4e~draft-open-file draft-path switch-function))
+         (setq draft-buffer (mu4e~draft-open-file draft-path))
          (set-buffer draft-buffer)
          (insert initial-contents)
          (newline)

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -724,9 +724,7 @@ docid is not found."
 
 (defun mu4e~headers-view-this-message-p (docid)
   "Is DOCID currently being viewed?"
-  (when (buffer-live-p (mu4e-get-view-buffer))
-    (with-current-buffer (mu4e-get-view-buffer)
-      (eq docid (plist-get mu4e~view-message :docid)))))
+  (mu4e-get-view-buffers (lambda (buf) (eq docid (plist-get mu4e~view-message :docid)))))
 
 ;; note: this function is very performance-sensitive
 (defun mu4e~headers-append-handler (msglst)
@@ -808,10 +806,10 @@ present, don't do anything."
   ;; if we were viewing this message, close it now.
   (when (and (mu4e~headers-view-this-message-p docid)
              (buffer-live-p (mu4e-get-view-buffer)))
-    (unless (eq mu4e-split-view 'single-window)
+    (let ((buf (mu4e-get-view-buffer)))
       (mapc #'delete-window (get-buffer-window-list
-                             (mu4e-get-view-buffer) nil t)))
-    (kill-buffer (mu4e-get-view-buffer))))
+                             buf nil t))
+      (kill-buffer buf))))
 
 
 
@@ -825,7 +823,7 @@ present, don't do anything."
 
 Switch to the output buffer for the results. If IGNORE-HISTORY is
 true, do *not* update the query history stack."
-  (let* ((buf (get-buffer-create mu4e-headers-buffer-name))
+  (let* ((buf (mu4e-get-headers-buffer nil t))
          (inhibit-read-only t)
          (rewritten-expr (funcall mu4e-query-rewrite-function expr))
          (maxnum (unless mu4e-search-full mu4e-search-results-limit)))
@@ -842,7 +840,7 @@ true, do *not* update the query history stack."
     ;; when the buffer is already visible, select it; otherwise,
     ;; switch to it.
     (unless (get-buffer-window buf 0)
-      (switch-to-buffer buf))
+      (mu4e-display-buffer buf t))
     (run-hook-with-args 'mu4e-search-hook expr)
     (mu4e~headers-clear mu4e~search-message)
     (setq mu4e~headers-search-start (float-time))
@@ -1155,7 +1153,8 @@ no user-interaction ongoing."
   (when (and mu4e-headers-auto-update          ;; must be set
 	     mu4e-index-update-status
 	     (not (zerop (plist-get mu4e-index-update-status :updated)))
-             (zerop (mu4e-mark-marks-num))     ;; non active marks
+             ;; NOTE: `mu4e-mark-marks-num' can return nil. Is that intended?
+             (zerop (or (mu4e-mark-marks-num) 0))     ;; non active marks
              (not (active-minibuffer-window))) ;; no user input only
     ;; rerun search if there's a live window with search results;
     ;; otherwise we'd trigger a headers view from out of nowhere.
@@ -1329,32 +1328,6 @@ message plist, or nil if not found."
                         ""))))))
 
 
-(defun mu4e~headers-redraw-get-view-window ()
-  "Close all windows, redraw the headers buffer based on the value
-of `mu4e-split-view', and return a window for the message view."
-  (if (eq mu4e-split-view 'single-window)
-      (or (and (buffer-live-p (mu4e-get-view-buffer))
-               (get-buffer-window (mu4e-get-view-buffer)))
-          (selected-window))
-    (mu4e-hide-other-mu4e-buffers)
-    (unless (buffer-live-p (mu4e-get-headers-buffer))
-      (mu4e-error "No headers buffer available"))
-    (switch-to-buffer (mu4e-get-headers-buffer))
-    ;; kill the existing view buffer
-    (when (buffer-live-p (mu4e-get-view-buffer))
-      (kill-buffer (mu4e-get-view-buffer)))
-    ;; get a new view window
-    (setq mu4e~headers-view-win
-          (with-demoted-errors "Unable to split window: %S"
-            (cond
-             ((eq mu4e-split-view 'horizontal) ;; split horizontally
-              (split-window-vertically mu4e-headers-visible-lines))
-             ((eq mu4e-split-view 'vertical) ;; split vertically
-              (split-window-horizontally mu4e-headers-visible-columns))
-             ((functionp mu4e-split-view)
-              (funcall mu4e-split-view))
-             (t ;; no splitting; just use the currently selected one
-              (selected-window)))))))
 
 ;;; Search-based marking
 
@@ -1623,41 +1596,21 @@ _not_ refresh the last search with the new setting for threading."
   (mu4e~headers-toggle "Skip-duplicates"
                        'mu4e-headers-skip-duplicates dont-refresh))
 
-(defvar mu4e~headers-loading-buf nil
-  "A buffer for loading a message view.")
-
 (defun mu4e-headers-view-message ()
-  "View message at point                                    .
-If there's an existing window for the view, re-use that one . If
-not, create a new one, depending on the value of
-`mu4e-split-view': if it's a symbol `horizontal' or `vertical',
-split the window accordingly; if it is nil, replace the current
-window                                                      . "
+  "View message at point."
   (interactive)
   (unless (eq major-mode 'mu4e-headers-mode)
     (mu4e-error "Must be in mu4e-headers-mode (%S)" major-mode))
   (let* ((msg (mu4e-message-at-point))
 	 (path (mu4e-message-field msg :path))
 	 (_exists (or (file-readable-p  path)
-		     (mu4e-warn "No message at %s" path)))
+		      (mu4e-warn "No message at %s" path)))
          (docid (or (mu4e-message-field msg :docid)
                     (mu4e-warn "No message at point")))
          (mark-as-read
           (if (functionp mu4e-view-auto-mark-as-read)
               (funcall mu4e-view-auto-mark-as-read msg)
-            mu4e-view-auto-mark-as-read))
-         (viewwin (mu4e~headers-redraw-get-view-window)))
-    (unless (window-live-p viewwin)
-      (mu4e-error "Cannot get a message view"))
-    (select-window viewwin)
-
-    ;; show some 'loading...' buffer
-    (unless (buffer-live-p mu4e~headers-loading-buf)
-      (setq mu4e~headers-loading-buf (get-buffer-create " *mu4e-loading*"))
-      (with-current-buffer mu4e~headers-loading-buf
-        (mu4e-loading-mode)))
-
-    (switch-to-buffer mu4e~headers-loading-buf)
+            mu4e-view-auto-mark-as-read)))
     (mu4e--server-view docid mark-as-read)))
 
 
@@ -1688,15 +1641,15 @@ return nil."
         ;; update all windows showing the headers buffer
         (walk-windows
          (lambda (win)
-           (when (eq (window-buffer win) (mu4e-get-headers-buffer))
+           (when (eq (window-buffer win) (mu4e-get-headers-buffer (buffer-name)))
              (set-window-point win (point))))
          nil t)
-        (if (eq mu4e-split-view 'single-window)
-            (when (eq (window-buffer) (mu4e-get-view-buffer))
-              (mu4e-headers-view-message))
-          ;; update message view if it was already showing
-          (when (and mu4e-split-view (window-live-p mu4e~headers-view-win))
-            (mu4e-headers-view-message)))
+        ;; If the assigned (and buffer-local) `mu4e~headers-view-win'
+        ;; is not live then that is indicates the user does not want
+        ;; to pop up the view when they navigate in the headers
+        ;; buffer.
+        (when (window-live-p mu4e~headers-view-win)
+          (mu4e-headers-view-message))
         ;; attempt to highlight the new line, display the message
         (mu4e~headers-highlight docid)
         (if succeeded
@@ -1807,42 +1760,19 @@ region if there is a region, then move to the next message."
 This is a rather complex function, to ensure we don't disturb
 other windows."
   (interactive)
-  (if (eq mu4e-split-view 'single-window)
-      (progn (mu4e-mark-handle-when-leaving)
-             (kill-buffer))
-    (unless (eq major-mode 'mu4e-headers-mode)
-      (mu4e-error "Must be in mu4e-headers-mode (%S)" major-mode))
-    (mu4e-mark-handle-when-leaving)
-    (let ((curbuf (current-buffer))
-          (curwin (selected-window)))
-      (walk-windows
-       (lambda (win)
-         (with-selected-window win
-           ;; if we the view window connected to this one, kill it
-           (when (and (not (one-window-p win)) (eq mu4e~headers-view-win win))
-             (delete-window win)
-             (setq mu4e~headers-view-win nil)))
-         ;; and kill any _other_ (non-selected) window that shows the current
-         ;; buffer
-         (when (and
-                (eq curbuf (window-buffer win)) ;; does win show curbuf?
-                (not (eq curwin win))             ;; it's not the curwin?
-                (not (one-window-p)))           ;; and not the last one?
-           (delete-window win))))  ;; delete it!
-      ;; now, all *other* windows should be gone. kill ourselves, and return
-      ;; to the main view
-      (kill-buffer)
-      (mu4e--main-view 'refresh))))
+  (mu4e-mark-handle-when-leaving)
+  (quit-window t)
+  (mu4e--main-view 'refresh))
 
 
 ;;; Loading messages
 ;;
 (defvar mu4e-loading-mode-map
   (let ((map (make-sparse-keymap)))
-          (define-key map "n" #'ignore)
-          (define-key map "p" #'ignore)
-          (define-key map "q" #'bury-buffer)
-          map)
+    (define-key map "n" #'ignore)
+    (define-key map "p" #'ignore)
+    (define-key map "q" #'bury-buffer)
+    map)
   "Keymap for *mu4e-loading* buffers.")
 
 (define-derived-mode mu4e-loading-mode special-mode

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -724,7 +724,7 @@ docid is not found."
 
 (defun mu4e~headers-view-this-message-p (docid)
   "Is DOCID currently being viewed?"
-  (mu4e-get-view-buffers (lambda (buf) (eq docid (plist-get mu4e~view-message :docid)))))
+  (mu4e-get-view-buffers (lambda (_) (eq docid (plist-get mu4e~view-message :docid)))))
 
 ;; note: this function is very performance-sensitive
 (defun mu4e~headers-append-handler (msglst)
@@ -1771,23 +1771,30 @@ other windows."
 ;;; Loading messages
 ;;
 
+
+(defvar-local mu4e--loading-overlay-bg nil
+  "Internal variable that holds the loading overlay for the background.")
+
+(defvar-local mu4e--loading-overlay-text nil
+  "Internal variable that holds the loading overlay for the text.")
+
 (define-minor-mode mu4e-loading-mode
   "Minor mode for buffers awaiting data from mu"
   :init-value nil :lighter " Loading" :keymap nil
   (if mu4e-loading-mode
       (progn
         (when mu4e-dim-when-loading
-          (set (make-variable-buffer-local 'mu4e--loading-overlay-bg)
-               (let ((overlay (make-overlay (point-min) (point-max))))
-                 (overlay-put overlay 'face `(:foreground "gray22" :background
-                                                          ,(face-attribute 'default :background)))
-                 (overlay-put overlay 'priority 9998)
-                 overlay)))
-        (set (make-variable-buffer-local 'mu4e--loading-overlay-text)
-             (let ((overlay (make-overlay (point-min) (point-min))))
-               (overlay-put overlay 'priority 9999)
-               (overlay-put overlay 'before-string (propertize "Loading…\n" 'face 'mu4e-header-title-face))
-               overlay)))
+          (setq mu4e--loading-overlay-bg
+                (let ((overlay (make-overlay (point-min) (point-max))))
+                  (overlay-put overlay 'face `(:foreground "gray22" :background
+                                                           ,(face-attribute 'default :background)))
+                  (overlay-put overlay 'priority 9998)
+                  overlay)))
+        (setq mu4e--loading-overlay-text
+              (let ((overlay (make-overlay (point-min) (point-min))))
+                (overlay-put overlay 'priority 9999)
+                (overlay-put overlay 'before-string (propertize "Loading…\n" 'face 'mu4e-header-title-face))
+                overlay)))
     (when mu4e--loading-overlay-bg
       (delete-overlay mu4e--loading-overlay-bg))
     (when mu4e--loading-overlay-text

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1611,7 +1611,7 @@ _not_ refresh the last search with the new setting for threading."
           (if (functionp mu4e-view-auto-mark-as-read)
               (funcall mu4e-view-auto-mark-as-read msg)
             mu4e-view-auto-mark-as-read)))
-    (when-let ((buf (mu4e-get-view-buffer nil nil)))
+    (when-let ((buf (mu4e-get-view-buffer (current-buffer) nil)))
       (with-current-buffer buf
         (mu4e-loading-mode 1)))
     (mu4e--server-view docid mark-as-read)))

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -104,18 +104,7 @@ In the format of `format-time-string'."
   :type  'string
   :group 'mu4e-headers)
 
-(defcustom mu4e-headers-visible-lines 10
-  "Number of lines to display in the header view when using the
-horizontal split-view. This includes the header-line at the top,
-and the mode-line."
-  :type 'integer
-  :group 'mu4e-headers)
 
-(defcustom mu4e-headers-visible-columns 30
-  "Number of columns to display for the header view when using the
-vertical split-view."
-  :type 'integer
-  :group 'mu4e-headers)
 
 (defcustom mu4e-headers-precise-alignment nil
   "When set, use precise (but relatively slow) alignment for columns.

--- a/mu4e/mu4e-helpers.el
+++ b/mu4e/mu4e-helpers.el
@@ -106,7 +106,6 @@ and `mu4e-headers-visible-columns'."
   :group 'mu4e-headers)
 
 
-;;; TODO: rewrite select other window
 (defun mu4e-select-other-view ()
   "Switch between headers view and message view."
   (interactive)

--- a/mu4e/mu4e-helpers.el
+++ b/mu4e/mu4e-helpers.el
@@ -32,6 +32,7 @@
 (require 'cl-lib)
 (require 'bookmark)
 
+(require 'mu4e-window)
 (require 'mu4e-config)
 
 ;;; Customization
@@ -86,24 +87,7 @@ marked as read-only, or non-nil otherwise."
   :group 'mu4e-view)
 
 
-(defcustom mu4e-split-view 'horizontal
-  "How to show messages / headers.
-A symbol which is either:
- * `horizontal':    split horizontally (headers on top)
- * `vertical':      split vertically (headers on the left).
- * `single-window': view and headers in one window (mu4e will try not to
-        touch your window layout), main view in minibuffer
- * a function:      the function is responsible to return some window for
-        the view.
- * anything else:   don't split (show either headers or messages,
-        not both).
-Also see `mu4e-headers-visible-lines'
-and `mu4e-headers-visible-columns'."
-  :type '(choice (const :tag "Split horizontally" horizontal)
-                 (const :tag "Split vertically" vertical)
-                 (const :tag "Single window" single-window)
-                 (const :tag "Don't split" nil))
-  :group 'mu4e-headers)
+
 
 
 (defun mu4e-select-other-view ()

--- a/mu4e/mu4e-helpers.el
+++ b/mu4e/mu4e-helpers.el
@@ -163,8 +163,6 @@ Create [mu4e]-prefixed error based on format FRM and ARGS. Does a
 local-exit and does not return, and raises a
 debuggable (backtrace) error."
   (mu4e-log 'error (apply 'mu4e-format frm args))
-  ;; opportunistically close the "loading" window.
-  (mu4e~loading-close)
   (error "%s" (apply 'mu4e-format frm args)))
 
 (defun mu4e-warn (frm &rest args)

--- a/mu4e/mu4e-icalendar.el
+++ b/mu4e/mu4e-icalendar.el
@@ -191,7 +191,7 @@
         (funcall action docid original-msg target))
       (when (and (mu4e~headers-view-this-message-p docid)
                  (buffer-live-p (mu4e-get-view-buffer)))
-        (switch-to-buffer (mu4e-get-view-buffer))
+        (mu4e-display-buffer (mu4e-get-view-buffer))
         (or (mu4e-view-headers-next)
             (kill-buffer-and-window))))))
 

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -33,6 +33,7 @@
 (require 'mu4e-contacts)
 (require 'mu4e-search)
 (require 'mu4e-vars)     ;; mu-wide variables
+(require 'mu4e-window)
 
 (declare-function mu4e-compose-new  "mu4e-compose")
 (declare-function mu4e~headers-jump-to-maildir  "mu4e-headers")

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -371,17 +371,13 @@ When REFRESH is non nil refresh infos from server."
 
 When REFRESH is non nil refresh infos from server."
   (let ((buf (get-buffer-create mu4e-main-buffer-name)))
-    (if (eq mu4e-split-view 'single-window)
-        (if (buffer-live-p (mu4e-get-headers-buffer))
-            (switch-to-buffer (mu4e-get-headers-buffer))
-          (mu4e--main-menu))
-      ;; `mu4e--main-view' is called from `mu4e--start', so don't call it
-      ;; a second time here i.e. do not refresh unless specified
-      ;; explicitly with REFRESH arg.
-      (switch-to-buffer buf)
-      (with-current-buffer buf
-        (mu4e--main-view-real-1 refresh))
-      (goto-char (point-min)))))
+    ;; `mu4e--main-view' is called from `mu4e--start', so don't call it
+    ;; a second time here i.e. do not refresh unless specified
+    ;; explicitly with REFRESH arg.
+    (mu4e-display-buffer buf t)
+    (with-current-buffer buf
+      (mu4e--main-view-real-1 refresh))
+    (goto-char (point-min))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Interactive functions
@@ -420,8 +416,9 @@ When REFRESH is non nil refresh infos from server."
 
 (defun mu4e--main-update-after-index ()
   "Update the main view buffer after indexing."
-  (with-current-buffer mu4e-main-buffer-name
-    (revert-buffer)))
+  (when (buffer-live-p mu4e-main-buffer-name)
+    (with-current-buffer mu4e-main-buffer-name
+      (revert-buffer))))
 
 (provide 'mu4e-main)
 ;;; mu4e-main.el ends here

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -98,7 +98,7 @@ is the target directory (for \"move\")")
 
 (defun mu4e--mark-find-headers-buffer ()
   "Find the headers buffer, if any."
-  (seq-find (lambda (b)
+  (seq-find (lambda (_)
 	      (mu4e-current-buffer-type-p 'headers))
 	    (buffer-list)))
 

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -99,30 +99,22 @@ is the target directory (for \"move\")")
 (defun mu4e--mark-find-headers-buffer ()
   "Find the headers buffer, if any."
   (seq-find (lambda (b)
-	      (with-current-buffer b
-		(eq major-mode 'mu4e-headers-mode)))
+	      (mu4e-current-buffer-type-p 'headers))
 	    (buffer-list)))
 
 (defmacro mu4e--mark-in-context (&rest body)
   "Evaluate BODY in the context of the headers buffer.
 The current buffer must be either a headers or view buffer."
   `(cond
-    ((eq major-mode 'mu4e-headers-mode) ,@body)
-    ((eq major-mode 'mu4e-view-mode)
+    ((mu4e-current-buffer-type-p 'headers) ,@body)
+    ((mu4e-current-buffer-type-p 'view)
      (when (buffer-live-p (mu4e-get-headers-buffer))
        (let* ((msg (mu4e-message-at-point))
               (docid (mu4e-message-field msg :docid)))
          (with-current-buffer (mu4e-get-headers-buffer)
            (if (mu4e~headers-goto-docid docid)
                ,@body
-             (mu4e-error "Cannot find message in headers buffer"))))))
-    (t
-     ;; even in other modes (e.g. mu4e-main-mode we try to find
-     ;; the headers buffer
-     (let ((hbuf (mu4e--mark-find-headers-buffer)))
-       (if (buffer-live-p hbuf)
-           (with-current-buffer hbuf ,@body)
-         ,@body)))))
+             (mu4e-error "Cannot find message in headers buffer"))))))))
 
 (defconst mu4e-marks
   '((refile

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -112,9 +112,9 @@ The current buffer must be either a headers or view buffer."
        (let* ((msg (mu4e-message-at-point))
               (docid (mu4e-message-field msg :docid)))
          (with-current-buffer (mu4e-get-headers-buffer)
-           (if (mu4e~headers-goto-docid docid)
-               ,@body
-             (mu4e-error "Cannot find message in headers buffer"))))))))
+           (when (mu4e~headers-goto-docid docid)
+             ,@body
+             )))))))
 
 (defconst mu4e-marks
   '((refile

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -28,6 +28,7 @@
 
 (require 'mu4e-vars)
 (require 'mu4e-contacts)
+(require 'mu4e-window)
 (require 'flow-fill)
 (require 'shr)
 (require 'pp)

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -217,7 +217,7 @@ If MSG is nil, use `mu4e-message-at-point'."
       (with-current-buffer-window (get-buffer-create mu4e--sexp-buffer-name) nil nil
         (lisp-data-mode)
 	(insert (pp-to-string msg))
-        (font-lock-fontify-buffer)
+        (font-lock-ensure)
         ;; add basic `quit-window' bindings
         (view-mode 1)))))
 

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -206,18 +206,20 @@ If MSG is nil, use `mu4e-message-at-point'."
     (kill-new path)
     (mu4e-message "Saved '%s' to kill-ring" path)))
 
-(defconst mu4e--sexp-buffer-name " *mu4e-sexp-at-point"
-  "Buffer name for sexp buffers.")
-
 (defun mu4e-sexp-at-point ()
   "Show or hide the s-expression for the message-at-point, if any."
   (interactive)
   (if-let ((win (get-buffer-window mu4e--sexp-buffer-name)))
       (delete-window win)
     (when-let ((msg (mu4e-message-at-point 'noerror)))
-      (with-current-buffer-window mu4e--sexp-buffer-name nil nil
-	;; the "pretty-printing" is not very pretty...
-	(insert (pp-to-string msg))))))
+      (when (buffer-live-p mu4e--sexp-buffer-name)
+        (kill-buffer mu4e--sexp-buffer-name))
+      (with-current-buffer-window (get-buffer-create mu4e--sexp-buffer-name) nil nil
+        (lisp-data-mode)
+	(insert (pp-to-string msg))
+        (font-lock-fontify-buffer)
+        ;; add basic `quit-window' bindings
+        (view-mode 1)))))
 
 ;;;
 (provide 'mu4e-message)

--- a/mu4e/mu4e-update.el
+++ b/mu4e/mu4e-update.el
@@ -211,21 +211,22 @@ if you otherwise want to use `mu4e-index-lazy-check'."
 (defvar mu4e--update-buffer nil
   "The buffer of the update process when updating.")
 
-(define-derived-mode mu4e--update-mail-mode
-special-mode "mu4e:update"
+(define-derived-mode mu4e--update-mail-mode special-mode "mu4e:update"
   "Major mode used for retrieving new e-mail messages in `mu4e'.")
 
 (define-key mu4e--update-mail-mode-map (kbd "q") 'mu4e-kill-update-mail)
 
 (defun mu4e--temp-window (buf height)
-  "Create a temporary window with HEIGHT at the bottom BUF."
-  (let ((win
-         (split-window
-          (frame-root-window)
-          (- (window-height (frame-root-window)) height))))
-    (set-window-buffer win buf)
-    (set-window-dedicated-p win t)
-    win))
+  "Create a temporary window with HEIGHT at the bottom BUF.
+
+This function uses `display-buffer' with a default preset.
+
+To override this behavior, customize `display-buffer-alist'."
+  (let ((win (display-buffer buf `(display-buffer-at-bottom
+                                   (preserve-size . (nil . t))
+                                   (height . ,height)
+                                   (window-height . fit-window-to-buffer)))))
+    (set-window-buffer (get-buffer-window buf) buf)))
 
 (defun mu4e--update-sentinel-func (proc _msg)
   "Sentinel function for the update process PROC."
@@ -244,8 +245,7 @@ special-mode "mu4e:update"
           (mu4e-update-index)))
     (mu4e-update-index))
   (when (buffer-live-p mu4e--update-buffer)
-    (unless (eq mu4e-split-view 'single-window)
-      (mapc #'delete-window (get-buffer-window-list mu4e--update-buffer)))
+    (delete-windows-on mu4e--update-buffer t)
     (kill-buffer mu4e--update-buffer)))
 
 ;; complicated function, as it:
@@ -268,8 +268,6 @@ run in the background; otherwise, pop up a window."
     (setq mu4e--update-buffer buf)
     (when (window-live-p win)
       (with-selected-window win
-        ;; ;;(switch-to-buffer buf)
-        ;; (set-window-dedicated-p win t)
         (erase-buffer)
         (insert "\n") ;; FIXME -- needed so output starts
         (mu4e--update-mail-mode)))

--- a/mu4e/mu4e-update.el
+++ b/mu4e/mu4e-update.el
@@ -222,11 +222,11 @@ if you otherwise want to use `mu4e-index-lazy-check'."
 This function uses `display-buffer' with a default preset.
 
 To override this behavior, customize `display-buffer-alist'."
-  (let ((win (display-buffer buf `(display-buffer-at-bottom
-                                   (preserve-size . (nil . t))
-                                   (height . ,height)
-                                   (window-height . fit-window-to-buffer)))))
-    (set-window-buffer (get-buffer-window buf) buf)))
+  (display-buffer buf `(display-buffer-at-bottom
+                        (preserve-size . (nil . t))
+                        (height . ,height)
+                        (window-height . fit-window-to-buffer)))
+  (set-window-buffer (get-buffer-window buf) buf))
 
 (defun mu4e--update-sentinel-func (proc _msg)
   "Sentinel function for the update process PROC."

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -58,7 +58,7 @@ Follows the format of `format-time-string'."
 
 (defcustom mu4e-dim-when-loading t
   "Dim buffer text when loading new data.
-If non-nil, dim some buffers during data retrieval and rendering. Disable this if you"
+If non-nil, dim some buffers during data retrieval and rendering."
   :type 'boolean
   :group 'mu4e)
 

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -355,7 +355,7 @@ header-view, not including, for instance, the message body.")
 
 ;;; Internals
 
-(defvar mu4e~headers-view-win nil
+(defvar-local mu4e~headers-view-win nil
   "The view window connected to this headers view.")
 
 ;; It's useful to have the current view message available to
@@ -363,7 +363,7 @@ header-view, not including, for instance, the message body.")
 ;; before calling `mu4e-view-mode'.  However, changing the major mode
 ;; clobbers any local variables.  Work around that by declaring the
 ;; variable permanent-local.
-(defvar mu4e~view-message nil "The message being viewed in view mode.")
+(defvar-local mu4e~view-message nil "The message being viewed in view mode.")
 (put 'mu4e~view-message 'permanent-local t)
 ;;; _
 (provide 'mu4e-vars)

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -56,6 +56,12 @@ Follows the format of `format-time-string'."
   :type 'string
   :group 'mu4e)
 
+(defcustom mu4e-dim-when-loading t
+  "Dim buffer text when loading new data.
+If non-nil, dim some buffers during data retrieval and rendering. Disable this if you"
+  :type 'boolean
+  :group 'mu4e)
+
 
 ;;; Faces
 

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -602,8 +602,15 @@ in the the message view affects HDRSBUF, as does marking etc.
 
 As a side-effect, a message that is being viewed loses its
 `unread' marking if it still had that."
-  (mu4e~headers-update-handler msg nil nil) ;; update headers, if necessary.
-  ;; create a new view buffer (if needed)
+  ;; update headers, if necessary.
+  (mu4e~headers-update-handler msg nil nil)
+  ;; Create a new view buffer (if needed) as it is not
+  ;; feasible to recycle an existing window due to buffer-specific
+  ;; state (buttons, etc.) that can interfere with message rendering
+  ;; in gnus.
+  (when-let ((existing-buffer (mu4e-get-view-buffer nil nil)))
+    (delete-windows-on existing-buffer t)
+    (kill-buffer existing-buffer))
   (setq gnus-article-buffer (mu4e-get-view-buffer nil t))
   (with-current-buffer gnus-article-buffer
     (let ((inhibit-read-only t))

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -605,7 +605,7 @@ As a side-effect, a message that is being viewed loses its
   ;; update headers, if necessary.
   (mu4e~headers-update-handler msg nil nil)
   ;; Create a new view buffer (if needed) as it is not
-  ;; feasible to recycle an existing window due to buffer-specific
+  ;; feasible to recycle an existing buffer due to buffer-specific
   ;; state (buttons, etc.) that can interfere with message rendering
   ;; in gnus.
   (when-let ((existing-buffer (mu4e-get-view-buffer nil nil)))

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -112,6 +112,10 @@ specified a function as viewer."
   :type 'integer
   :group 'mu4e-view)
 
+(defcustom mu4e-after-view-message-hook '(mu4e-resize-linked-headers-window)
+  "Hook run by `mu4e-view' after a message is rendered."
+  :type 'hook
+  :group 'mu4e-view)
 
 
 
@@ -644,7 +648,9 @@ As a side-effect, a message that is being viewed loses its
       (setq-local mu4e~headers-view-win (mu4e-display-buffer gnus-article-buffer nil))
       (unless (window-live-p mu4e~headers-view-win)
         (mu4e-error "Cannot get a message view"))
-      (select-window mu4e~headers-view-win))))
+      (select-window mu4e~headers-view-win)))
+  (with-current-buffer gnus-article-buffer
+    (run-hooks 'mu4e-after-view-message-hook)))
 
 (defun mu4e-view-message-text (msg)
   "Return the pristine MSG as a string."

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -618,8 +618,8 @@ As a side-effect, a message that is being viewed loses its
       (erase-buffer)
       (insert-file-contents-literally
        (mu4e-message-readable-path msg) nil nil nil t)
-      (setq-local mu4e~view-message msg)))
-  (mu4e~view-render-buffer msg)
+      (setq-local mu4e~view-message msg)
+      (mu4e~view-render-buffer msg)))
   (unless (mu4e--view-detached-p gnus-article-buffer)
     (with-current-buffer mu4e-linked-headers-buffer
       ;; We need this here as we want to avoid displaying the buffer until

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -156,7 +156,10 @@ Then, display the results."
                      ;; are we already inside a headers buffer?
                      ((mu4e-current-buffer-type-p 'headers) (current-buffer))
                      ;; if not, are we inside a view buffer, and does it have linked headers buffer?
-                     ((mu4e-current-buffer-type-p 'view) (mu4e-get-headers-buffer))
+                     ((mu4e-current-buffer-type-p 'view)
+                      (when (mu4e--view-detached-p (current-buffer))
+                        (mu4e-error "You cannot navigate in a detached view buffer."))
+                      (mu4e-get-headers-buffer))
                      ;; fallback; but what would trigger this?
                      (t (mu4e-get-headers-buffer))))
 	    (docid (mu4e-message-field msg :docid)))

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -619,7 +619,8 @@ As a side-effect, a message that is being viewed loses its
       (insert-file-contents-literally
        (mu4e-message-readable-path msg) nil nil nil t)
       (setq-local mu4e~view-message msg)
-      (mu4e~view-render-buffer msg)))
+      (mu4e~view-render-buffer msg))
+    (mu4e-loading-mode 0))
   (unless (mu4e--view-detached-p gnus-article-buffer)
     (with-current-buffer mu4e-linked-headers-buffer
       ;; We need this here as we want to avoid displaying the buffer until

--- a/mu4e/mu4e-window.el
+++ b/mu4e/mu4e-window.el
@@ -56,6 +56,45 @@ linked to.")
 (defvar-local mu4e-linked-headers-buffer nil
   "Holds the headers buffer object that ties it to a view.")
 
+(defcustom mu4e-split-view 'horizontal
+  "How to show messages / headers.
+A symbol which is either:
+ * `horizontal':    split horizontally (headers on top)
+ * `vertical':      split vertically (headers on the left).
+ * `single-window': view and headers in one window (mu4e will try not to
+        touch your window layout), main view in minibuffer
+ * a function:      the function is responsible to return some window for
+        the view.
+ * anything else:   don't split (show either headers or messages,
+        not both).
+Also see `mu4e-headers-visible-lines'
+and `mu4e-headers-visible-columns'."
+  :type '(choice (const :tag "Split horizontally" horizontal)
+                 (const :tag "Split vertically" vertical)
+                 (const :tag "Single window" single-window)
+                 (const :tag "Don't split" nil))
+  :group 'mu4e-headers)
+
+(defcustom mu4e-compose-in-new-frame nil
+  "Whether to compose messages in a new frame."
+  :type 'boolean
+  :group 'mu4e-compose)
+
+(defcustom mu4e-headers-visible-lines 10
+  "Number of lines to display in the header view when using the
+horizontal split-view. This includes the header-line at the top,
+and the mode-line."
+  :type 'integer
+  :group 'mu4e-headers)
+
+(defcustom mu4e-headers-visible-columns 30
+  "Number of columns to display for the header view when using the
+vertical split-view."
+  :type 'integer
+  :group 'mu4e-headers)
+
+(declare-function mu4e-view-mode "mu4e-view")
+
 (defun mu4e-get-headers-buffer (&optional buffer-name create)
   "Return a related headers buffer optionally named BUFFER-NAME.
 
@@ -160,7 +199,7 @@ being created if CREATE is non-nil."
                                         (eq mu4e-linked-headers-buffer headers-buffer))))))
       ;; If such a linked buffer exists and its buffer is live, we use that buffer.
       (if (and linked-buffer (buffer-live-p (car linked-buffer)))
-          ;; NOTE: It's possible for there to be one than one linked view buffer.
+          ;; NOTE: It's possible for there to be more than one linked view buffer.
           ;;
           ;; What, if anything, should the heuristic be to pick the
           ;; one to use? Presently `car' is used, but there are better

--- a/mu4e/mu4e-window.el
+++ b/mu4e/mu4e-window.el
@@ -24,9 +24,6 @@
 
 ;;; Buffer names for internal use
 
-(defvar mu4e~headers-loading-buf nil
-  "A buffer for loading a message view.")
-
 (defconst mu4e--sexp-buffer-name "*mu4e-sexp-at-point*"
   "Buffer name for sexp buffers.")
 
@@ -110,7 +107,6 @@ tested."
             (and pred (funcall pred buf)))))
    (buffer-list)))
 
-
 (defun mu4e--view-detached-p (buffer)
   "Return non-nil if BUFFER is a detached view buffer."
   (with-current-buffer buffer
@@ -121,7 +117,6 @@ tested."
 (defun mu4e--get-current-buffer-type ()
   "Return an internal symbol that corresponds to each mu4e major mode."
   (cond ((derived-mode-p 'mu4e-view-mode 'mu4e-raw-view-mode) 'view)
-        ((derived-mode-p 'mu4e-loading-mode) 'loading)
         ((derived-mode-p 'mu4e-headers-mode) 'headers)
         ((derived-mode-p 'mu4e-compose-mode) 'compose)
         ((derived-mode-p 'mu4e-main-mode) 'main)
@@ -130,8 +125,7 @@ tested."
 (defun mu4e-current-buffer-type-p (type)
   "Return non-nil if the current buffer is a mu4e buffer of TYPE.
 
-Where TYPE is `view', `loading', `headers', `compose',
-`main' or `unknown'.
+Where TYPE is `view', `headers', `compose', `main' or `unknown'.
 
 Checks are performed using `derived-mode-p' and the current
 buffer's major mode."
@@ -226,7 +220,6 @@ for BUFFER-OR-NAME to be displayed in."
               ('(view . vertical) '((window-min-width . fit-window-to-buffer)))
               (`(,_ . t) nil)))
            (window-action (cond
-                           ((memq buffer-type '(loader)) '(display-buffer-same-window))
                            ((memq buffer-type '(headers compose))
                             '(display-buffer-reuse-mode-window display-buffer-same-window))
                            ((memq mu4e-split-view '(horizontal vertical))

--- a/mu4e/mu4e-window.el
+++ b/mu4e/mu4e-window.el
@@ -80,7 +80,8 @@ generated name does not already exist."
            ;; detached -- raise an error.
            (and (mu4e-current-buffer-type-p 'view)
                 (or mu4e-linked-headers-buffer
-                    (error "This view buffer is detached")))
+                    ;; (error "This view buffer is detached")
+                    ))
            ;; if we're already in a headers buffer then
            ;; that is the one we use.
            (and (mu4e-current-buffer-type-p 'headers)

--- a/mu4e/mu4e-window.el
+++ b/mu4e/mu4e-window.el
@@ -115,9 +115,7 @@ generated name does not already exist."
            ;; there is no such linked buffer -- it is
            ;; detached -- raise an error.
            (and (mu4e-current-buffer-type-p 'view)
-                (or mu4e-linked-headers-buffer
-                    ;; (error "This view buffer is detached")
-                    ))
+                mu4e-linked-headers-buffer)
            ;; if we're already in a headers buffer then
            ;; that is the one we use.
            (and (mu4e-current-buffer-type-p 'headers)

--- a/mu4e/mu4e-window.el
+++ b/mu4e/mu4e-window.el
@@ -1,0 +1,256 @@
+;;; mu4e-window.el --- window management for mu4e    -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022  Mickey Petersen
+
+;; Author: Mickey Petersen <mickey@masteringemacs.org>
+;; Keywords: mail
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
+
+;; TODO: write function to get headers buffer (and return an error if it is missing)
+;; TODO: write a function that displays the headers/view buffer(s)
+;; TODO: write a function that returns buffer livenness for headers/view
+;; TODO: write a function that returns whether a buffer is visible
+;; TODO: write a function that selects the headers/view buffer if it exists or is visible.
+
+;;; Buffer names for internal use
+
+(defvar mu4e~headers-loading-buf nil
+  "A buffer for loading a message view.")
+
+(defconst mu4e--sexp-buffer-name "*mu4e-sexp-at-point*"
+  "Buffer name for sexp buffers.")
+
+(defvar mu4e-main-buffer-name " *mu4e-main*"
+  "Name of the mu4e main buffer.
+The default name starts with SPC and therefore is not visible in
+buffer list.")
+
+(defvar mu4e-embedded-buffer-name " *mu4e-embedded*"
+  "Name for the embedded message view buffer.")
+
+
+;; Buffer names for public use
+
+(defvar mu4e-headers-buffer-name "*mu4e-headers*"
+  "Name of the buffer for message headers.")
+
+(defvar mu4e-view-buffer-name "*mu4e-article*"
+  "Name of the view buffer.")
+
+(defvar mu4e-headers-buffer-name-func nil
+  "Function used to name the headers buffers.")
+
+(defvar mu4e-view-buffer-name-func nil
+  "Function used to name the view buffers.
+
+The function is given one argument, the headers buffer it is
+linked to.")
+
+(defvar-local mu4e-linked-headers-buffer nil
+  "Holds the headers buffer object that ties it to a view")
+
+(defun mu4e-get-headers-buffer (&optional buffer-name create)
+  "Return a related headers buffer optionally named BUFFER-NAME.
+
+If CREATE is non-nil, the headers buffer is created if the
+generated name does not already exist."
+  (let* ((buffer-name
+          (or
+           ;; buffer name generator func. If a user wants
+           ;; to supply its own naming scheme, we use that
+           ;; in lieu of our own heuristic.
+           (and mu4e-headers-buffer-name-func
+                (funcall mu4e-headers-buffer-name-func))
+           ;; if we're supplied a buffer name for a
+           ;; headers buffer then try to use that one.
+           buffer-name
+           ;; if we're asking for a headers buffer from a
+           ;; view, then we get our linked buffer. If
+           ;; there is no such linked buffer -- it is
+           ;; detached -- raise an error.
+           (and (mu4e-current-buffer-type-p 'view)
+                (or mu4e-linked-headers-buffer
+                    (error "This view buffer is detached")))
+           ;; if we're already in a headers buffer then
+           ;; that is the one we use.
+           (and (mu4e-current-buffer-type-p 'headers)
+                (current-buffer))
+           ;; default name to use if all other checks fail.
+           mu4e-headers-buffer-name))
+         (buffer (get-buffer buffer-name)))
+    (when (and (not (buffer-live-p buffer)) create)
+      (setq buffer (get-buffer-create buffer-name)))
+    ;; This may conceivably return a non-existent buffer if `create'
+    ;; and `buffer-live-p' are nil.
+    ;;
+    ;; This is seemingly "OK" as various parts of the code check for
+    ;; buffer liveness themselves.
+    buffer))
+
+(defun mu4e-get-view-buffers (pred)
+  "Filter all known view buffers and keep those where PRED returns non-nil.
+
+The PRED function is called from inside the buffer that is being
+tested."
+  (seq-filter
+   (lambda (buf)
+     (with-current-buffer buf
+       (and (mu4e-current-buffer-type-p 'view)
+            (and pred (funcall pred buf)))))
+   (buffer-list)))
+
+
+(defun mu4e--view-detached-p (buffer)
+  "Returns non-nil if BUFFER is a detached view buffer."
+  (with-current-buffer buffer
+    (unless (mu4e-current-buffer-type-p 'view)
+      (error "Buffer `%s' is not a valid mu4e view buffer" buffer))
+    (null mu4e-linked-headers-buffer)))
+
+(defun mu4e--get-current-buffer-type ()
+  "Returns an internal symbol that corresponds to each mu4e major mode."
+  (cond ((derived-mode-p 'mu4e-view-mode 'mu4e-raw-view-mode) 'view)
+        ((derived-mode-p 'mu4e-loading-mode) 'loading)
+        ((derived-mode-p 'mu4e-headers-mode) 'headers)
+        ((derived-mode-p 'mu4e-compose-mode) 'compose)
+        ((derived-mode-p 'mu4e-main-mode) 'main)
+        (t 'unknown)))
+
+(defun mu4e-current-buffer-type-p (type)
+  "Returns non-nil if the current buffer is a mu4e buffer of TYPE.
+
+Where TYPE is `view', `loading', `headers', `compose',
+`main' or `unknown'.
+
+Checks are performed using `derived-mode-p' and the current
+buffer's major mode."
+  (eq (mu4e--get-current-buffer-type) type))
+
+(defun mu4e-get-view-buffer (&optional headers-buffer create)
+  "Return a view buffer belonging optionally to HEADERS-BUFFER.
+
+If HEADERS-BUFFER is nil, the most likely (and available) headers
+buffer is used.
+
+Detached view buffers are ignored; that may result in a new view buffer
+being created if CREATE is non-nil."
+  ;; If `headers-buffer' is nil, then the caller does not have a
+  ;; headers buffer preference.
+  ;;
+  ;; In that case, we request the most plausible headers buffer from
+  ;; `mu4e-get-headers-buffer'.
+  (when (setq headers-buffer (or headers-buffer (mu4e-get-headers-buffer)))
+    (let ((buffer)
+          ;; If `mu4e-view-buffer-name-func' is non-nil, then use that
+          ;; to source the name of the view buffer to create or re-use.
+          (buffer-name (or (and mu4e-view-buffer-name-func
+                                (funcall mu4e-view-buffer-name-func headers-buffer))
+                           ;; If the variable is nil, use the default
+                           ;; name
+                           mu4e-view-buffer-name))
+          ;; Search all view buffers and return those that are linked to
+          ;; `headers-buffer'.
+          (linked-buffer (mu4e-get-view-buffers
+                          (lambda (buf) (and (buffer-local-boundp 'mu4e-linked-headers-buffer buf)
+                                        (eq mu4e-linked-headers-buffer headers-buffer))))))
+      ;; If such a linked buffer exists and its buffer is live, we use that buffer.
+      (if (and linked-buffer (buffer-live-p (car linked-buffer)))
+          ;; NOTE: It's possible for there to be one than one linked view buffer.
+          ;;
+          ;; What, if anything, should the heuristic be to pick the
+          ;; one to use? Presently `car' is used, but there are better
+          ;; ways, no doubt. Perhaps preferring those with live windows?
+          (setq buffer (car linked-buffer))
+        (setq buffer (get-buffer buffer-name))
+        ;; check if `buffer' is already live *and* detached. If it is,
+        ;; we'll generate a new, unique name.
+        (when (and (buffer-live-p buffer) (mu4e--view-detached-p buffer))
+          (setq buffer (generate-new-buffer-name buffer-name)))
+        (when (and (not (buffer-live-p buffer)) create)
+          (setq buffer (get-buffer-create (or buffer buffer-name)))
+          (with-current-buffer buffer
+            (mu4e-view-mode))))
+      (when buffer
+        ;; Required. Callers expect the view buffer to be set.
+        (set-buffer buffer)
+        ;; Required. The call chain of `mu4e-view-mode' ends up
+        ;; calling `kill-all-local-variables', which destroys the
+        ;; local binding.
+        (set (make-local-variable 'mu4e-linked-headers-buffer) headers-buffer))
+      buffer)))
+
+(defun mu4e-display-buffer (buffer-or-name &optional select)
+  "Display BUFFER-OR-NAME as per `mu4e-split-view'.
+
+If SELECT is non-nil, the final window (and thus BUFFER-OR-NAME)
+is selected.
+
+This function internally uses `display-buffer' (or
+`pop-to-buffer' if SELECT is non-nil).
+
+It is therefore possible to change the display behavior by
+modifying `display-buffer-alist'.
+
+If `mu4e-split-view' is a function, then it must return a live window
+for BUFFER-OR-NAME to be displayed in."
+  (if (functionp mu4e-split-view)
+      (set-window-buffer (funcall mu4e-split-view) buffer-or-name)
+    (let* ((buffer-name (or (get-buffer buffer-or-name)
+                            (error "Buffer `%s' does not exist." buffer-or-name)))
+           (buffer-type (with-current-buffer buffer-name (mu4e--get-current-buffer-type)))
+           (direction (cons 'direction
+                            (pcase (cons buffer-type mu4e-split-view)
+                              ;; views or headers can display
+                              ;; horz/vert depending on the value of
+                              ;; `mu4e-split-view'
+                              (`(,(or 'view 'headers) . horizontal) 'below)
+                              (`(,(or 'view 'headers) . vertical) 'right)
+                              (`(,_ . t) nil))))
+           (window-size
+            (pcase (cons buffer-type mu4e-split-view)
+              ;; views or headers can display
+              ;; horz/vert depending on the value of
+              ;; `mu4e-split-view'
+              ('(view . horizontal) '((window-height . shrink-window-if-larger-than-buffer)))
+              ('(view . vertical) '((window-min-width . fit-window-to-buffer)))
+              (`(,_ . t) nil)))
+           (window-action (cond
+                           ((memq buffer-type '(loader)) '(display-buffer-same-window))
+                           ((memq buffer-type '(headers compose))
+                            '(display-buffer-reuse-mode-window display-buffer-same-window))
+                           ((memq mu4e-split-view '(horizontal vertical))
+                            '(display-buffer-in-direction))
+                           ((memq mu4e-split-view '(single-window))
+                            '(display-buffer-same-window))
+                           ;; I cannot discern a difference between
+                           ;; `single-window' and "anything else" in
+                           ;; `mu4e-split-view'.
+                           (t '(display-buffer-same-window))))
+           (arg `((display-buffer-reuse-window
+                   display-buffer-reuse-mode-window
+                   ,@window-action)
+                  ,@window-size
+                  ,direction
+                  )))
+      (funcall (if select #'pop-to-buffer #'display-buffer)
+               buffer-name
+               arg))))
+
+(provide 'mu4e-window)
+;;; mu4e-window.el ends here

--- a/mu4e/mu4e-window.el
+++ b/mu4e/mu4e-window.el
@@ -171,11 +171,11 @@ being created if CREATE is non-nil."
         ;; we'll generate a new, unique name.
         (when (and (buffer-live-p buffer) (mu4e--view-detached-p buffer))
           (setq buffer (generate-new-buffer-name buffer-name)))
-        (when (and (not (buffer-live-p buffer)) create)
+        (when (or (not (buffer-live-p buffer)) create)
           (setq buffer (get-buffer-create (or buffer buffer-name)))
           (with-current-buffer buffer
             (mu4e-view-mode))))
-      (when buffer
+      (when (and buffer (buffer-live-p buffer))
         ;; Required. Callers expect the view buffer to be set.
         (set-buffer buffer)
         ;; Required. The call chain of `mu4e-view-mode' ends up

--- a/mu4e/mu4e-window.el
+++ b/mu4e/mu4e-window.el
@@ -22,12 +22,6 @@
 
 ;;; Code:
 
-;; TODO: write function to get headers buffer (and return an error if it is missing)
-;; TODO: write a function that displays the headers/view buffer(s)
-;; TODO: write a function that returns buffer livenness for headers/view
-;; TODO: write a function that returns whether a buffer is visible
-;; TODO: write a function that selects the headers/view buffer if it exists or is visible.
-
 ;;; Buffer names for internal use
 
 (defvar mu4e~headers-loading-buf nil

--- a/mu4e/mu4e-window.el
+++ b/mu4e/mu4e-window.el
@@ -220,6 +220,8 @@ for BUFFER-OR-NAME to be displayed in."
               ('(view . vertical) '((window-min-width . fit-window-to-buffer)))
               (`(,_ . t) nil)))
            (window-action (cond
+                           ((and (eq buffer-type 'compose) mu4e-compose-in-new-frame)
+                            '(display-buffer-pop-up-frame))
                            ((memq buffer-type '(headers compose))
                             '(display-buffer-reuse-mode-window display-buffer-same-window))
                            ((memq mu4e-split-view '(horizontal vertical))

--- a/mu4e/mu4e-window.el
+++ b/mu4e/mu4e-window.el
@@ -63,7 +63,7 @@ The function is given one argument, the headers buffer it is
 linked to.")
 
 (defvar-local mu4e-linked-headers-buffer nil
-  "Holds the headers buffer object that ties it to a view")
+  "Holds the headers buffer object that ties it to a view.")
 
 (defun mu4e-get-headers-buffer (&optional buffer-name create)
   "Return a related headers buffer optionally named BUFFER-NAME.
@@ -104,7 +104,7 @@ generated name does not already exist."
     buffer))
 
 (defun mu4e-get-view-buffers (pred)
-  "Filter all known view buffers and keep those where PRED returns non-nil.
+  "Filter all known view buffers and keep those where PRED return non-nil.
 
 The PRED function is called from inside the buffer that is being
 tested."
@@ -117,14 +117,14 @@ tested."
 
 
 (defun mu4e--view-detached-p (buffer)
-  "Returns non-nil if BUFFER is a detached view buffer."
+  "Return non-nil if BUFFER is a detached view buffer."
   (with-current-buffer buffer
     (unless (mu4e-current-buffer-type-p 'view)
       (error "Buffer `%s' is not a valid mu4e view buffer" buffer))
     (null mu4e-linked-headers-buffer)))
 
 (defun mu4e--get-current-buffer-type ()
-  "Returns an internal symbol that corresponds to each mu4e major mode."
+  "Return an internal symbol that corresponds to each mu4e major mode."
   (cond ((derived-mode-p 'mu4e-view-mode 'mu4e-raw-view-mode) 'view)
         ((derived-mode-p 'mu4e-loading-mode) 'loading)
         ((derived-mode-p 'mu4e-headers-mode) 'headers)
@@ -133,7 +133,7 @@ tested."
         (t 'unknown)))
 
 (defun mu4e-current-buffer-type-p (type)
-  "Returns non-nil if the current buffer is a mu4e buffer of TYPE.
+  "Return non-nil if the current buffer is a mu4e buffer of TYPE.
 
 Where TYPE is `view', `loading', `headers', `compose',
 `main' or `unknown'.
@@ -212,7 +212,7 @@ for BUFFER-OR-NAME to be displayed in."
   (if (functionp mu4e-split-view)
       (set-window-buffer (funcall mu4e-split-view) buffer-or-name)
     (let* ((buffer-name (or (get-buffer buffer-or-name)
-                            (error "Buffer `%s' does not exist." buffer-or-name)))
+                            (error "Buffer `%s' does not exist" buffer-or-name)))
            (buffer-type (with-current-buffer buffer-name (mu4e--get-current-buffer-type)))
            (direction (cons 'direction
                             (pcase (cons buffer-type mu4e-split-view)

--- a/mu4e/mu4e-window.el
+++ b/mu4e/mu4e-window.el
@@ -242,5 +242,30 @@ for BUFFER-OR-NAME to be displayed in."
                buffer-name
                arg))))
 
+(defun mu4e-resize-linked-headers-window ()
+  "Resizes the linked headers window belonging to a view.
+
+Resizes the current headers view according to `mu4e-split-view'
+and `mu4e-headers-visible-lines' or
+`mu4e-headers-visible-columns'.
+
+This function is best called from the hook
+`mu4e-after-view-message-hook'."
+  (unless (mu4e-current-buffer-type-p 'view)
+    (error "Cannot resize as this is not a valid view buffer."))
+  (when-let (win (and mu4e-linked-headers-buffer
+                      (get-buffer-window mu4e-linked-headers-buffer)))
+    ;; This can fail for any number of reasons. If it does, we do
+    ;; nothing. If the user has customized the window display we may
+    ;; find it impossible to resize the window, and that should not be
+    ;; cause for error.
+    (ignore-errors
+      (cond ((eq mu4e-split-view 'vertical)
+             (window-resize win (- mu4e-headers-visible-columns (window-width win nil))
+                            t t nil))
+            ((eq mu4e-split-view 'horizontal)
+             (set-window-text-height win mu4e-headers-visible-lines))))))
+
+
 (provide 'mu4e-window)
 ;;; mu4e-window.el ends here

--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -26,6 +26,7 @@
 ;;; Code:
 
 (require 'mu4e-vars)
+(require 'mu4e-window)
 (require 'mu4e-obsolete)
 (require 'mu4e-helpers)
 (require 'mu4e-folders)

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -837,7 +837,7 @@ major-mode for the headers view is @code{mu4e-headers-mode}.
 * Sorting and threading::Influencing the display
 * Custom headers: HV Custom headers. Adding your own headers
 * Actions: HV Actions. Defining and using actions
-* Split view::Seeing both headers and messages
+* Controlling and Displaying Buffers:: How and where the buffers are displayed
 @end menu
 
 @node HV Overview
@@ -1117,14 +1117,24 @@ attachment, using @code{mu4e-compose-attach-captured-message}. See
 @file{mu4e-actions.el} in the @t{mu4e} source distribution for more example
 actions.
 
-@node Split view
-@section Split view
+@node Controlling and Displaying Buffers
+@section Display
 
-Using the @emph{Split view}, we can see the @ref{Headers view} and the
-@ref{Message view} next to each other, with the message selected in the
-former, visible in the latter. You can influence the way the splitting
-is done by customizing the variable @code{mu4e-split-view}. Possible
-values are:
+By default, @t{mu4e} will attempt to manage the display of its own
+buffers. To do this, the variable @code{mu4e-split-view} is used to determine
+how, or where, windows and buffers are placed.
+
+However, @t{mu4e}'s display rules are provisional; you can override them
+easily by customizing @code{display-buffer-alist}, which governs how Emacs --
+and thus @t{mu4e} -- must display your buffers.
+
+That means you can instruct @t{mu4e} to place message views in separate tabs
+or frames, if you so desire.
+
+@section Split view
+You can control how @t{mu4e} displays its buffers, including the @ref{Headers
+view} and the @ref{Message view}, by customizing
+@code{mu4e-split-view}. There are several options available:
 
 @itemize
 @item @t{horizontal} (this is the default): display the message view below the
@@ -1138,7 +1148,9 @@ minimize mu4e window operations (opening, killing, resizing, etc) and
 buffer changes, while still retaining the view and headers buffers. In
 addition, it replaces mu4e main view with a minibuffer prompt containing
 the same information.
-@item anything else: don't do any splitting
+@item @t{function}: a function that takes a buffer name and returns a
+window to display the buffer in.
+@item anything else: prefer reusing the same window, if possible.
 @end itemize
 
 @noindent
@@ -1151,6 +1163,26 @@ headers-view to the message-view and vice-versa with
 @code{mu4e-select-other-view}, bound to @key{y}
 @end itemize
 
+@section Display Buffer Example
+
+Here are a couple of examples that override @t{mu4e}'s default buffer
+placement. You do not need to configure @code{mu4e-split-view} for this to
+work. In the absence of explicit rules to the contrary, @t{mu4e} will fall
+back on the value you have set in @code{mu4e-split-view} @emph{unless} you
+have assigned your own custom window function.
+
+Here is an example that displays the headers buffer in a side window to the
+right. It occupies half of the width of the frame.
+
+@lisp
+(add-to-list 'display-buffer-alist
+  '(("\\*mu4e-headers\\*" display-buffer-in-side-window
+    (side . right)
+    (window-width . 0.5)))
+@end lisp
+
+You can type @key{C-x w s} to toggle the side windows to hide or show them at
+will.
 
 @node Message view
 @chapter The message view
@@ -1170,6 +1202,7 @@ from @t{gnus-article-mode}.
 * Rich-text and images: MSGV Rich-text and images. Reading rich-text messages
 * Custom headers: MSGV Custom headers. Your very own headers
 * Actions: MSGV Actions. Defining and using actions.
+* Detaching and Reattaching messages: MSGV Detaching and reattaching. Multiple message views.
 @end menu
 
 @node MSGV Overview
@@ -1286,6 +1319,7 @@ A            execute some custom action on the message's MIME-parts
 
 misc
 ----
+z, Z         detach (or reattach) a message view to a headers buffer
 .            show the raw message view. 'q' takes you back.
 C-+,C--      increase / decrease the number of headers shown
 H            get help
@@ -1397,6 +1431,35 @@ MIME-part actions allow you to act upon MIME-parts in a message - such
 as attachments.  For now, these actions are defined and documented in
 @code{mu4e-view-mime-part-actions}.
 
+
+
+@node MSGV Detaching and reattaching
+@section Detaching and reattaching messages
+
+You can have multiple message views, but you must rename the view
+buffer and detach it to stop @t{mu4e} from reusing it when you
+navigate up or down in the headers buffer. If you have several view
+buffers attached to a headers view, then @t{mu4e} may pick one at
+random when it has to choose which one to display a message in.
+
+To detach the message view from its linked headers buffer, type
+@key{z}. A message will appear saying it is detached (or warn you if
+it is already detached.)
+
+Detached buffers are static; they cannot change the displayed message,
+and no headers buffer will use a detached buffer to display its
+messages. You can reattach a buffer to an live headers buffer by
+typing @key{Z}.
+
+You can freely rename a message view buffer -- such as with @key{C-x x
+r} -- if you want multiple, open messages.
+
+Detached messages are often useful for workflows involving lots of
+simultaneous messages.
+
+You can @emph{tear off} the window a message is in and place it in a
+new tab by typing @key{C-x w ^ f}. You can also detach a window and
+put it in its own tab with @key{C-x w ^ t}.
 
 @node Editor view
 @chapter The editor view
@@ -4022,8 +4085,12 @@ Sending...done
 The first and final messages are the most important, and there may be
 considerable time between them, depending on the size of the message.
 
-@subsection Is it possible to compose messages in a separate frame?
-Yes --- set the variable @code{mu4e-compose-in-new-frame} to @code{t}.
+@subsection Is it possible to view headers and messages, or compose new ones, in a separate frame?
+Yes. There is builtin support for composing messages in a new
+frame. Set the variable @code{mu4e-compose-in-new-frame} to @code{t}.
+
+However, if you want to personalize the display of all of @t{mu4e}'s
+buffers, you can do so by customizing @code{display-buffer-alist}.
 
 @subsection How can I apply format=flowed to my outgoing messages?
 This enables receiving clients that support this feature to reflow


### PR DESCRIPTION
Hi Dirk-Jan,

Phew. OK, so, this (sadly rather large) PR fixes a large number of long-standing issues and standardises buffer display so it uses Emacs's `display-buffer`, `pop-to-buffer`, and action system so users can override everything in `display-buffer-alist`.

Here's what it does:

1. Separate (all, I think!) window and buffer management into `mu4e-window.el`;
2. Centralise the creation and retrieval of headers and view buffer into two functions;
3. Centralise the display of buffers to `mu4e-display-buffer`;
4. Rewrite all split window code to use `display-buffer` and the action display system;
5. Support multiple, distinct and standalone headers and views. Views are now detachable (`z` key) from a header, meaning it is inviolable and not touched by movement and navigation elsewhere.
6. Re-attachment (`Z`) to another headers buffer.

Things left to do, pending your approval:

1. Documentation update
2. Testing and bug fixing.

I use it, and it works well, though.

In practice this means you can write a `display-buffer-alist` rule to force buffers to display in tabs; in sidebars; in new frames; etc. with a simple rule.

Feedback welcome. Sorry about the massive PR, but it took quite a lot of effort to rip out all the window and buffer code from all the different places and centralise it.