### PR TITLE
Preserve `mu4e~headers-view-win' when a search is (re-)executed

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -813,11 +813,17 @@ present, don't do anything."
 Switch to the output buffer for the results. If IGNORE-HISTORY is
 true, do *not* update the query history stack."
   (let* ((buf (mu4e-get-headers-buffer nil t))
+         (view-window mu4e~headers-view-win)
          (inhibit-read-only t)
          (rewritten-expr (funcall mu4e-query-rewrite-function expr))
          (maxnum (unless mu4e-search-full mu4e-search-results-limit)))
     (with-current-buffer buf
+      ;; NOTE: this resets all buffer-local variables, including
+      ;; `mu4e~headers-view-win', which may have a live window if the
+      ;; headers buffer already exists when `mu4e-get-headers-buffer'
+      ;; is called.
       (mu4e-headers-mode)
+      (setq mu4e~headers-view-win view-window)
       (unless ignore-history
         ;; save the old present query to the history list
         (when mu4e--search-last-query


### PR DESCRIPTION
Triggering a search -- directly, or indirectly through reindexing -- calls `mu4e-headers-mode` which kills all buffer-local variables including `mu4e~headers-view-win`, which causes any live view windows to lose their 'connection' to the now-updated headers buffer.

