### PR TITLE
Re-add missing argument as `define-mail-user-agent' expects it

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -796,7 +796,7 @@ draft message."
 
 ;;;###autoload
 (defun mu4e~compose-mail (&optional to subject other-headers _continue
-                                    yank-action _send-actions _return-action)
+                                    _ yank-action _send-actions _return-action)
   "This is mu4e's implementation of `compose-mail'.
 Quoting its docstring:
 


### PR DESCRIPTION
`C-x m` with the user agent set to mu4e is broken. This undoes a fix I'd done earlier due to a byte compiler warning.

@djcb, can you think of a better way of handling this issue?