### PR TITLE
Change how *mu4e-main* is displayed and default to full frame

### DIFF
--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -375,13 +375,9 @@ When REFRESH is non nil refresh infos from server."
     ;; `mu4e--main-view' is called from `mu4e--start', so don't call it
     ;; a second time here i.e. do not refresh unless specified
     ;; explicitly with REFRESH arg.
-
-    (mu4e-display-buffer buf t)
-    ;; undo some of the mu4e-display-buffer magic; we want a full screen.
-    ;; perhaps we could use display-buffer-alist instead?
-    (delete-other-windows)
     (with-current-buffer buf
       (mu4e--main-view-real-1 refresh))
+    (mu4e-display-buffer buf t)
     (goto-char (point-min))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/mu4e/mu4e-window.el
+++ b/mu4e/mu4e-window.el
@@ -27,10 +27,8 @@
 (defconst mu4e--sexp-buffer-name "*mu4e-sexp-at-point*"
   "Buffer name for sexp buffers.")
 
-(defvar mu4e-main-buffer-name " *mu4e-main*"
-  "Name of the mu4e main buffer.
-The default name starts with SPC and therefore is not visible in
-buffer list.")
+(defvar mu4e-main-buffer-name "*mu4e-main*"
+  "Name of the mu4e main buffer.")
 
 (defvar mu4e-embedded-buffer-name " *mu4e-embedded*"
   "Name for the embedded message view buffer.")
@@ -267,6 +265,7 @@ for BUFFER-OR-NAME to be displayed in."
             ('(view . vertical) '((window-min-width . fit-window-to-buffer)))
             (`(,_ . t) nil)))
          (window-action (cond
+                         ((eq buffer-type 'main) '(display-buffer-full-frame))
                          ((and (eq buffer-type 'compose) mu4e-compose-in-new-frame)
                           '(display-buffer-pop-up-frame))
                          ((memq buffer-type '(headers compose))


### PR DESCRIPTION
Fixes #2382 by making `*mu4e-main*` use `display-buffer` actions to prefer a full frame.