### PR TITLE
mu4e-view: ask to create directory when saving attachments

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -1146,6 +1146,12 @@ containing commas."
                 dir (if arg (read-directory-name "Save to directory: ")
                       mu4e-attachment-dir))
           (cl-loop for (f . h) in handles
+                   initially
+                   do (when
+                          (and
+                           (not (file-directory-p dir))
+                           (y-or-n-p (format "Create directory `%s'? " dir)))
+                        (make-directory dir t))
                    when (member f files)
                    do (mm-save-part-to-file
                        h (let ((file (expand-file-name f dir)))


### PR DESCRIPTION
Add support to create initially the destination directory for the attachment(s). 

Should something be done in case the user presses 'n'?

