### PR TITLE
mu4e-view: don't delete window on view msg in single-window mode

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -608,7 +608,8 @@ As a side-effect, a message that is being viewed loses its
       ;; required; this state must carry over from the killed buffer
       ;; to the new one.
       (setq linked-headers-buffer mu4e-linked-headers-buffer)
-      (delete-windows-on existing-buffer t)
+      (if (memq mu4e-split-view '(horizontal vertical))
+          (delete-windows-on existing-buffer t))
       (kill-buffer existing-buffer))
     (setq gnus-article-buffer (mu4e-get-view-buffer nil t))
     (with-current-buffer gnus-article-buffer


### PR DESCRIPTION
Don’t delete the existing buffer window when viewing a new message when `mu4e-split-view` is `single-window` or `nil`. This was causing the window layout to be trashed when navigating to a new message with `n` or `p` with a message open when in single-window mode.