### PR TITLE
mu-error: Add missing <cstdint> include

### DIFF
--- a/lib/utils/mu-error.hh
+++ b/lib/utils/mu-error.hh
@@ -22,6 +22,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <cstdint>
 
 #include "mu-utils-format.hh"
 #include <glib.h>


### PR DESCRIPTION
GCC 13s libstdc++ reduced its dependency on some headers like <cstdint>, so it's no longer transitively included through various headers.  Include it explicitly.

See also: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

```
  ../lib/utils/mu-error.hh:36:26: error: ‘uint32_t’ does not name a type
     36 |         static constexpr uint32_t SoftError = 1 << 23;
        |                          ^~~~~~~~
```