### PR TITLE
really allow flags to be empty in move command

### DIFF
--- a/lib/mu-server.cc
+++ b/lib/mu-server.cc
@@ -888,7 +888,7 @@ void
 Server::Private::move_handler(const Command& cmd)
 {
 	auto       maildir{cmd.string_arg(":maildir").value_or("")};
-	const auto flagopt{cmd.string_arg(":flags").value_or("")};
+	const auto flagopt{cmd.string_arg(":flags")};
 	const auto rename{cmd.boolean_arg(":rename")};
 	const auto no_view{cmd.boolean_arg(":noupdate")};
 	const auto docids{determine_docids(store_, cmd)};


### PR DESCRIPTION
Without this patch, I see the following error:

```
;; mu> (move :docid 1 :maildir "/.Archive")
[2b](:error 32818 :message "invalid flags ''")
```

flags should not default to "", which is not a valid flags string.