### PR TITLE
mu4e: Allow completion for symbolic links in maildir

### DIFF
--- a/mu4e/mu4e-folders.el
+++ b/mu4e/mu4e-folders.el
@@ -231,7 +231,7 @@ Do so recursively and produce a list of relative paths."
             (mu4e-join-paths path mdir) nil
             "^[^.]\\|\\.[^.][^.]" t))))
     (dolist (dentry dentries)
-      (when (and (booleanp (cadr dentry)) (cadr dentry))
+      (when (or (and (booleanp (cadr dentry)) (cadr dentry)) (file-directory-p (mu4e-join-paths path (car dentry))))
         (if (file-accessible-directory-p
              (mu4e-join-paths (mu4e-root-maildir) mdir (car dentry) "cur"))
             (setq dirs


### PR DESCRIPTION
This patch allows mu4e to autocomplete when `mu4e-root-maildor` contains symbolic links to other maildirs. Without this patch mu4e can still work when directories under `mu4e-root-maildor` are symlinks, but it will not autocomplete properly when using `mu4e-search-maildir`.

Signed-off-by: Andreas Hindborg <nmi@metaspace.dk>