### PR TITLE
Only add bug-reference setup function after the feature was loaded

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -1328,8 +1328,9 @@ GROUP-REGEXP and each header value against HEADER-REGEXP in
        (mail-fetch-field "maildir")
        header-values))))
 
-(add-hook 'bug-reference-auto-setup-functions
-          #'mu4e--view-try-setup-bug-reference-mode)
+(with-eval-after-load 'bug-reference
+  (add-hook 'bug-reference-auto-setup-functions
+            #'mu4e--view-try-setup-bug-reference-mode))
 
 
 (provide 'mu4e-view)


### PR DESCRIPTION
This PR aims to improve the support for bug-reference-mode introduced in #2021.

Currently, we might call `add-hook` on `bug-reference-auto-setup-functions` before `bug-reference` is loaded, which results in overriding the default value. I think it makes much more sense to add our hook to the list of hooks, which is what this PR aims to achieve.

@tsdh You might be interested in this change.