### PR TITLE
Don't die if the headers buffer isn't in a window

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -155,10 +155,12 @@ Then, display the results."
             (docid (mu4e-message-field msg :docid)))
        (unless docid
          (mu4e-error "Message without docid: action is not possible"))
-       (with-current-buffer buffer
-         ;; make sure to select the window, or jumping won't
-         ;; be reflected.
-         (with-selected-window (get-buffer-window)
+
+       ;; make sure to select the window if possible, or jumping won't be
+       ;; reflected.
+       (with-selected-window (or (get-buffer-window buffer)
+                                 (get-buffer-window))
+         (with-current-buffer buffer
            (if (or (mu4e~headers-goto-docid docid)
                    ;; TODO: Is this the best way to find another
                    ;; relevant docid for a view buffer?


### PR DESCRIPTION
If the headers buffer isn't in a live window (e.g., mu4e-split-view is 'single-window), get-buffer-window will return nil. In turn, with-selected-window will die if fed a nil window, so default to using the current window in this case.

This fixes a regression from c23dad70586bbb54891c506629f2ce2ed8e463d2 that prevented using n/p from a view buffer.