### PR TITLE
Change letter mark for mailing-list messages to "L"

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -187,7 +187,7 @@ query have been received and are displayed."
 ;;  mu4e-headers-encrypted-mark '("x" . "🔒")
 ;;  mu4e-headers-signed-mark    '("s" . "🔑")
 ;;  mu4e-headers-unread-mark    '("u" . "⎕")
-;;  mu4e-headers-list-mark      '("s" . "🔈")
+;;  mu4e-headers-list-mark      '("L" . "🔈")
 ;;  mu4e-headers-personal-mark  '("p" . "👨")
 ;;  mu4e-headers-calendar-mark  '("c" . "📅"))
 
@@ -203,7 +203,7 @@ query have been received and are displayed."
 (defvar mu4e-headers-encrypted-mark '("x" . "⚴") "Encrypted.")
 (defvar mu4e-headers-signed-mark    '("s" . "☡") "Signed.")
 (defvar mu4e-headers-unread-mark    '("u" . "⎕") "Unread.")
-(defvar mu4e-headers-list-mark      '("s" . "Ⓛ") "Mailing list.")
+(defvar mu4e-headers-list-mark      '("L" . "Ⓛ") "Mailing list.")
 (defvar mu4e-headers-personal-mark  '("p" . "Ⓟ") "Personal.")
 (defvar mu4e-headers-calendar-mark  '("c" . "Ⓒ") "Calendar invitation.")
 

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -4416,7 +4416,7 @@ an indication that the font you are using does not support those characters.
    mu4e-headers-encrypted-mark '("x" . "🔒")
    mu4e-headers-signed-mark    '("s" . "🔑")
    mu4e-headers-unread-mark    '("u" . "⎕")
-   mu4e-headers-list-mark      '("s" . "🔈")
+   mu4e-headers-list-mark      '("L" . "🔈")
    mu4e-headers-personal-mark  '("p" . "👨")
    mu4e-headers-calendar-mark  '("c" . "📅"))
 @end lisp


### PR DESCRIPTION
Fixed an issue where messages from mailing-list ("list" flag) were shown using "s" in header view, which is also used for "signed" messages. Therefore changing it to "L".