### PR TITLE
[ux bug] mu4e: create random name for newly detached views

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -327,11 +327,14 @@ Add this function to `mu4e-view-mode-hook' to enable this feature."
   (unless mu4e-linked-headers-buffer
     (mu4e-error "This view buffer is already detached."))
   (mu4e-message "Detached view buffer from %s"
-                (prog1 mu4e-linked-headers-buffer
+                (progn mu4e-linked-headers-buffer
                   (with-current-buffer mu4e-linked-headers-buffer
                     (when (eq (selected-window) mu4e~headers-view-win)
                       (setq mu4e~headers-view-win nil)))
-                  (setq mu4e-linked-headers-buffer nil))))
+                  (setq mu4e-linked-headers-buffer nil)
+                  ;; automatically rename mu4e-view-article buffer when
+                  ;; detaching; will get renamed back when reattaching
+                  (rename-buffer (make-temp-name (buffer-name)) t))))
 
 (defun mu4e-view-attach (headers-buffer)
   "Attaches a view buffer to a headers buffer."

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -1504,7 +1504,7 @@ messages. You can reattach a buffer to an live headers buffer by
 typing @key{Z}.
 
 You can freely rename a message view buffer -- such as with @key{C-x x
-r} -- if you want multiple, open messages.
+r} -- if you want a custom, non-randomized name.
 
 Detached messages are often useful for workflows involving lots of
 simultaneous messages.


### PR DESCRIPTION
Without creating some kind of a temporary name (which could then be
trivially renamed by the user as the current instructions say) a new
user trying to learn how to detach a view will run into this error when
switching to a new message after detaching:

[mu4e] Detached view buffer from *mu4e-headers*
funcall-interactively: No buffer named *mu4e-article*<2>

It seems like a good default and less friction to create a random name
automatically when detaching.