### PR TITLE
Fix defcustom type definitions

### DIFF
--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -60,7 +60,7 @@ Useful when this is not equal to the From: address."
   :group 'mu4e-compose)
 
 (defcustom mu4e-compose-keep-self-cc nil
-  "When non-nil. keep your e-mail address in Cc: when replying."
+  "When non-nil, keep your e-mail address in Cc: when replying."
   :type 'boolean
   :group 'mu4e-compose)
 

--- a/mu4e/mu4e-folders.el
+++ b/mu4e/mu4e-folders.el
@@ -116,7 +116,17 @@ designated shortcut character for the maildir.
 
 Unlike in search queries, folder names with spaces in them must
 NOT be quoted, since mu4e does this for you."
-  :type '(repeat (cons (string :tag "Maildir") character))
+  :type '(choice
+          (alist :key-type (string :tag "Maildir")
+                 :value-type character
+                 :tag "Alist (old format)")
+          (repeat (plist
+                   :key-type (choice (const :tag "Maildir" :maildir)
+                                     (const :tag "Shortcut" :key)
+                                     (const :tag "Name of maildir" :name)
+                                     (const :tag "Hide from main view" :hide)
+                                     (const :tag "Do not count" :hide-unread))
+                   :tag "Plist (new format)")))
   :version "1.3.9"
   :group 'mu4e-folders)
 

--- a/mu4e/mu4e-helpers.el
+++ b/mu4e/mu4e-helpers.el
@@ -38,7 +38,7 @@
 ;;; Customization
 
 (defcustom mu4e-debug nil
-  "When set to non-nil, log debug information to the mu4e log  buffer."
+  "When set to non-nil, log debug information to the mu4e log buffer."
   :type 'boolean
   :group 'mu4e)
 

--- a/mu4e/mu4e-query-items.el
+++ b/mu4e/mu4e-query-items.el
@@ -46,7 +46,7 @@ searching, and allows users to modify the query.
 For instance, we could change any instance of \"workmail\" into
 \"maildir:/long-path-to-work-related-emails\", by setting the function
 
-(setq mu4e-query-rewrite-function
+\\=(setq mu4e-query-rewrite-function
   (lambda(expr)
      (replace-regexp-in-string \"workmail\"
                    \"maildir:/long-path-to-work-related-emails\" expr)))

--- a/mu4e/mu4e-search.el
+++ b/mu4e/mu4e-search.el
@@ -105,13 +105,20 @@ one of: `:date', `:subject', `:size', `:prio', `:from', `:to.',
 Note that when threading is enabled (through
 `mu4e-search-threads'), the headers are exclusively sorted
 chronologically (`:date') by the newest message in the thread."
-  :type 'symbol
+  :type '(radio (const :date)
+                (const :subject)
+                (const :size)
+                (const :prio)
+                (const :from)
+                (const :to)
+                (const :list))
   :group 'mu4e-search)
 
 (defcustom mu4e-search-sort-direction 'descending
   "Direction to sort by; a symbol either `descending' (sorting
   Z->A) or `ascending' (sorting A->Z)."
-  :type 'symbol
+  :type '(radio (const ascending)
+                (const descending))
   :group 'mu4e-search)
 
 ;; mu4e-query-rewrite-function lives in mu4e-query-items.el

--- a/mu4e/mu4e-server.el
+++ b/mu4e/mu4e-server.el
@@ -45,7 +45,7 @@ session."
 
 Changes to this value only take effect after (re)starting the mu
 session."
-  :type 'file
+  :type '(file :must-match t)
   :group 'mu4e
   :safe 'stringp)
 

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -69,11 +69,11 @@ Note, you can use this to add fields that are not otherwise
 shown; you can further tweak the other fields using e.g.,
 `gnus-article-hide-boring-headers', `gnus-article-hide-headers'
 etc., see the gnus documentation for details."
-  :type (list 'symbol)
+  :type '(repeat symbol)
   :group 'mu4e-view)
 
 (defcustom mu4e-view-actions
-  (seq-filter 'identity
+  (seq-filter #'identity
               `( ("capture message"  . mu4e-action-capture-message)
                  ("view in browser"  . mu4e-action-view-in-browser)
                  ,(when (fboundp 'xwidget-webkit-browse-url)


### PR DESCRIPTION
So that the type definitions reflects the docstrings more closely.  In additon, fixed warnings from flymake about docstring.

* mu4e/mu4e-draft.el mu4e-compose-keep-self-cc: should be a comma

* mu4e/mu4e-folders.el mu4e-maildir-shortcuts: recognize new (plist) format

* mu4e/mu4e-helpers.el mu4e-debug: removed unnecessary double space in docstring

* mu4e/mu4e-query-items.el mu4e-query-rewrite-function: prepend "\\=" before column 0 "(" in docstring

* mu4e/mu4e-search.el mu4e-search-sort-field mu4e-search-sort-direction: used radio in types

* mu4e/mu4e-server.el mu4e-mu-binary: "mu" executable must exist

* mu4e/mu4e-view.el mu4e-view-fields: fixed type
mu4e-view-actions: for function refs, prefer "#'" rather than "'"