### PR TITLE
documentation typo: C-x w ^f places in new frame, not new tab

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -1510,7 +1510,7 @@ Detached messages are often useful for workflows involving lots of
 simultaneous messages.
 
 You can @emph{tear off} the window a message is in and place it in a
-new tab by typing @key{C-x w ^ f}. You can also detach a window and
+new frame by typing @key{C-x w ^ f}. You can also detach a window and
 put it in its own tab with @key{C-x w ^ t}.
 
 @node Editor view


### PR DESCRIPTION
A one word change to documentation: 
"place it in a new *tab* by typing C-x w ^ f"  -> "place it in a new *frame* by typing C-x w ^ f"
