### PR TITLE
mu4e: allow to disable the global mode-line items

### DIFF
--- a/mu4e/mu4e-modeline.el
+++ b/mu4e/mu4e-modeline.el
@@ -48,6 +48,14 @@ display the bookmark name rather than the query."
   :type 'boolean
   :group 'mu4e-modeline)
 
+(defcustom mu4e-modeline-show-global t
+  "Whether to populate global modeline segments.
+
+If non-nil, show both buffer-specific and global modeline items,
+otherwise only present buffer-specific information."
+  :type 'boolean
+  :group 'mu4e-modeline)
+
 (defvar-local mu4e--modeline-buffer-items nil
   "List of buffer-local items for the mu4e modeline.
 Each element is function that evaluates to a string.")
@@ -90,15 +98,17 @@ originate.")
             (mapconcat
              (lambda (func) (or (funcall func) "")) lst " ")))
          (global-string ;; global string is _cached_ as it may be expensive.
-          (or mu4e--modeline-global-string-cached
-              (setq mu4e--modeline-global-string-cached
-                    (funcall collect mu4e--modeline-global-items)))))
+          (and
+           mu4e-modeline-show-global
+           (or mu4e--modeline-global-string-cached
+               (setq mu4e--modeline-global-string-cached
+                     (funcall collect mu4e--modeline-global-items))))))
     (concat
      ;; (local) buffer items are _not_ cached, so they'll get update
      ;; automatically when leaving the buffer.
      (mu4e--modeline-quote-and-truncate
       (funcall collect mu4e--modeline-buffer-items))
-     " "
+     (and global-string " ")
      global-string)))
 
 (define-minor-mode mu4e-modeline-mode

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -3125,8 +3125,11 @@ To completely turn off the modeline support, set @code{mu4e-modeline-support} to
 @item global: information about the results for the ``favorite query''
 @end itemize
 
-All of the bookmark items provide more details in their @code{help-echo}, i.e.,
-their tooltip.
+The global indicators can be disabled by setting @code{mu4e-modeline-show-global}
+to @t{nil}.
+
+All of the bookmark items provide more details in their @code{help-echo},
+i.e., their tooltip.
 
 @subsection Query parameters bookmark item
 The query parameters in the modeline start with the various query flags (such as


### PR DESCRIPTION
This patch permits configuring mu4e so only buffer-specific modelines are displayed.

Contrary to the solution I initially suggested in <https://github.com/djcb/mu/issues/2463>, not registering the modeline is not enough. This is because somebody could have `mu4e-modeline-show-global` set to `t`, start `mu4e` (the global modeline is registered), then set it to `nil` and re-start `mu4e`. As there's nothing cleaning up `mu4e--modeline-global-items`, changing `mu4e-modeline-show-global` during an Emacs session that followed the path described wouldn't work.

The new way of fixing this is more resilient, allowing the global modeline to be registered but only adding the global bits to the return value of `mu4e--modeline-string` when configured to do so. This approach allows as well changing `mu4e-modeline-show-global` on the fly.

It has been tested with mu4e 1.10.1 + this patch.

Fixes #2463