### PR TITLE
Ensure mu4e-thread-mode is only enabled in headers buffer

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -867,10 +867,10 @@ after the end of the search results."
           (setq mu4e--search-view-target nil
                 mu4e--search-msgid-target nil)
           (when (mu4e~headers-docid-at-point)
-            (mu4e~headers-highlight (mu4e~headers-docid-at-point)))))
-  ;; maybe enable thread folding
-  (when mu4e-search-threads
-    (mu4e-thread-mode))
+            (mu4e~headers-highlight (mu4e~headers-docid-at-point)))
+          ;; maybe enable thread folding
+          (when mu4e-search-threads
+            (mu4e-thread-mode))))
   ;; run-hooks
   (run-hooks 'mu4e-headers-found-hook))
 


### PR DESCRIPTION
This was run outside of the `with-current-buffer (mu4e-get-headers-buffer)` in `mu4e~headers-found-handler`, which could be anywhere.

I noticed it when `mu4e-thread-mode` was suddenly active in other buffers and shadowed my `C-tab` binding.