### PR TITLE
Fix more defcustom type errors and reworded docs

### DIFF
--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -40,18 +40,19 @@
 
 (defcustom mu4e-compose-reply-recipients 'ask
   "Which recipients to use when replying to a message.
-May be a symbol `ask', `all', `sender'. Note that that only
-applies to non-mailing-list message; for those, mu4e always
-asks."
-  :type '(choice ask
-                 all
-                 sender)
+May be a symbol `ask', `all', `sender'.  Note that this option
+only applies to non-mailing-list message; for mailing-list
+messages, mu4e always asks."
+  :type '(choice (const ask)
+                 (const all)
+                 (const sender))
   :group 'mu4e-compose)
 
 (defcustom mu4e-compose-reply-to-address nil
-  "The Reply-To address.
+  "When non-nil, the Reply-To address.
 Useful when this is not equal to the From: address."
-  :type 'string
+  :type '(choice (const :tag "Same as the \"From:\" address" nil)
+                 string)
   :group 'mu4e-compose)
 
 (defcustom mu4e-compose-forward-as-attachment nil

--- a/mu4e/mu4e-thread.el
+++ b/mu4e/mu4e-thread.el
@@ -53,10 +53,10 @@
   :group 'mu4e-headers)
 
 (defcustom mu4e-thread-fold-single-children nil
-  "If set to t fold even if there is only a single child.
+  "When non-nil, fold a thread even if there is only a single child.
 Otherwise, do not not fold single children since would simply
 hide the single child."
-  :type 'number
+  :type 'boolean
   :group 'mu4e-headers)
 
 (defface mu4e-thread-fold-face


### PR DESCRIPTION
* mu4e/mu4e-draft.el (mu4e-compose-reply-recipients): (mu4e-compose-reply-to-address):
* mu4e/mu4e-thread.el (mu4e-thread-fold-single-children): Clarify docstrings and fixed type definitions.

(Wrote a command that checks types for all options in a group, so all types should be good now.)