### PR TITLE
Fix asking maildir reading completing candidate is text-property

### DIFF
--- a/mu4e/mu4e-folders.el
+++ b/mu4e/mu4e-folders.el
@@ -307,12 +307,13 @@ from all maildirs under `mu4e-maildir'."
            (mu4e-read-option prompt
                              (append options
                                      '(("oOther..." . other)))))))
-    (if (eq response 'other)
-        (progn
-          (funcall mu4e-completing-read-function prompt
-                   (mu4e-get-maildirs) nil nil
-                   mu4e-maildir-initial-input))
-      response)))
+    (substring-no-properties
+     (if (eq response 'other)
+         (progn
+           (funcall mu4e-completing-read-function prompt
+                    (mu4e-get-maildirs) nil nil
+                    mu4e-maildir-initial-input))
+       response))))
 
 (defun mu4e-ask-maildir-check-exists (prompt)
   "Like `mu4e-ask-maildir', PROMPT for existence of the maildir.


### PR DESCRIPTION
Some packages like `vertico-prescient` adding text-property to vertico candidates will break `mu4e-ask-maildir` response.

Here is the screenshot when text-property candidates caused error:

![Screenshot 2023-05-26 at 09 33 38@2x](https://github.com/djcb/mu/assets/378699/502ea4ad-7daa-48ec-8d80-425effe60601)
