### PR TITLE
Add a new maildir section in the homepage.

### DIFF
--- a/mu4e/mu4e-bookmarks.el
+++ b/mu4e/mu4e-bookmarks.el
@@ -44,7 +44,6 @@
       :key ?t)
     ( :name "Last 7 days"
       :query "date:7d..now"
-      :hide-unread t
       :key ?w)
     ( :name "Messages with images"
       :query "mime:image/*"

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -91,7 +91,14 @@ This multiplexes the `message-mode' hooks `message-send-actions',
   :type 'hook
   :group 'mu4e-compose)
 
+(defcustom mu4e-allow-edit-any-message nil
+  "Whether to allow to edit any message or just the draft messages.
+Setting this to t allows any message to be edited, not just the draft messages.
 
+Changes to this value only take effect after (re)starting the mu
+session."
+  :type 'boolean
+  :group 'mu4e)
 
 (defvar mu4e-captured-message)
 (defun mu4e-compose-attach-captured-message ()
@@ -445,7 +452,8 @@ variables ‘message-forward-as-mime’ and
   "Edit an existing draft message."
   (interactive)
   (let* ((msg (mu4e-message-at-point)))
-    (unless  (member 'draft (mu4e-message-field msg :flags))
+    (unless (or (member 'draft (mu4e-message-field msg :flags))
+                (eq mu4e-allow-edit-any-message 't))
       (mu4e-warn "Cannot edit non-draft messages"))
     (mu4e--draft
      'edit

--- a/mu4e/mu4e-folders.el
+++ b/mu4e/mu4e-folders.el
@@ -86,6 +86,12 @@ nil otherwise."
           (function :tag "Function return folder name"))
   :group 'mu4e-folders)
 
+(defcustom mu4e-maildirs nil
+  "A custom list of maildirs"
+  :type '(repeat string)
+  :version "1.3.9"
+  :group 'mu4e-folders)
+
 (defcustom mu4e-maildir-shortcuts nil
   "A list of maildir shortcuts.
 This makes it possible to quickly go to a particular
@@ -163,6 +169,12 @@ mime-type are nil."
   "Cached list of maildirs.")
 
 
+(defun mu4e-maildirs ()
+  "Get `mu4e-maildirs'."
+  (seq-map (lambda (item)
+             `(:maildir  ,item :key ,?.))
+  mu4e-maildirs))
+
 (defun mu4e-maildir-shortcuts ()
   "Get `mu4e-maildir-shortcuts' in the (new) format.
 Converts from the old format if needed."

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -228,7 +228,7 @@ for aligning them."
                 ;; note, we have a function for the binding,
                 ;; and perhaps a different one for the lambda.
                 (cond
-                 ((eq item-type 'maildirs)
+                 ((or (eq item-type 'maildirs) (eq item-type 'maildirs-with-shortcut))
                   (list #'mu4e-search-maildir #'mu4e-search
                         query))
                  ((eq item-type 'bookmarks)
@@ -239,11 +239,17 @@ for aligning them."
            (concat
             (mu4e--main-action
              ;; main title
-             (format "\t* [@] %s "
-                     (propertize
-                      name
-                      'face (if favorite 'mu4e-header-key-face nil)
-                      'help-echo query))
+             (if (eq item-type 'maildirs)
+                 (format "\t* %s "
+                         (propertize
+                          name
+                          'face (if favorite 'mu4e-header-key-face nil)
+                          'help-echo query))
+               (format "\t* [@] %s "
+                       (propertize
+                        name
+                        'face (if favorite 'mu4e-header-key-face nil)
+                        'help-echo query)))
              ;; function to call when activated
              (lambda () (interactive)
                (funcall (nth 1 item-info)
@@ -314,8 +320,19 @@ Otherwise, do nothing."
          (propertize "  Bookmarks\n\n" 'face 'mu4e-title-face)
          (mu4e--main-items 'bookmarks max-length)
          "\n"
-         (propertize "  Maildirs\n\n" 'face 'mu4e-title-face)
-         (mu4e--main-items 'maildirs max-length)
+         (if (eq mu4e-maildir-shortcuts nil)
+             ""
+           (concat
+            (propertize "  Quick access maildirs\n\n" 'face 'mu4e-title-face)
+            (mu4e--main-items 'maildirs-with-shortcut max-length)
+            "\n"))
+
+         (if (eq mu4e-maildirs nil)
+             ""
+           (concat
+            (propertize "  Other maildirs\n\n" 'face 'mu4e-title-face)
+            (mu4e--main-items 'maildirs max-length)
+            "\n"))
          "\n"
          (propertize "  Misc\n\n" 'face 'mu4e-title-face)
          (mu4e--main-action "\t* [@]Choose query\n"

--- a/mu4e/mu4e-query-items.el
+++ b/mu4e/mu4e-query-items.el
@@ -92,10 +92,12 @@ If ITEMS does not yet have a favorite item, pick the first."
   items)
 
 (defvar mu4e--bookmark-items-cached nil "Cached bookmarks query items.")
+(defvar mu4e--maildir-with-shortcut-items-cached nil "Cached maildirs query items.")
 (defvar mu4e--maildir-items-cached nil "Cached maildirs query items.")
 
 (declare-function mu4e-bookmarks "mu4e-bookmarks")
 (declare-function mu4e-maildir-shortcuts "mu4e-folders")
+(declare-function mu4e-maildirs "mu4e-folders")
 
 (defun mu4e--query-item-display-counts (item)
   "Get the count display string for some query-data ITEM."
@@ -123,6 +125,7 @@ With RESET-BASELINE, reset the baseline first."
     (setq mu4e--query-items-baseline nil
           mu4e--query-items-baseline-tstamp nil
           mu4e--bookmark-items-cached nil
+          mu4e--maildir-with-shortcut-items-cached nil
           mu4e--maildir-items-cached nil
           mu4e--last-delta-unread 0))
   (mu4e--server-queries
@@ -146,6 +149,7 @@ I.e. what we get in response to mu4e--query-items-refresh."
           mu4e--query-items-baseline-tstamp (current-time)))
 
   (setq mu4e--bookmark-items-cached nil
+        mu4e--maildir-with-shortcut-items-cached nil
         mu4e--maildir-items-cached nil)
   (mu4e-query-items) ;; for side-effects
   ;; tell the world.
@@ -254,12 +258,15 @@ please refer to info node `(mu4e) Bookmarks and Maildirs'."
         (setq mu4e--bookmark-items-cached
               (mu4e--query-items-pick-favorite
                (mu4e--make-query-items (mu4e-bookmarks) 'bookmarks)))))
+   ((equal type 'maildirs-with-shortcut)
+    (or mu4e--maildir-with-shortcut-items-cached
+        (setq mu4e--maildir-with-shortcut-items-cached (mu4e--make-query-items (mu4e-maildir-shortcuts) 'maildirs))))
    ((equal type 'maildirs)
     (or mu4e--maildir-items-cached
-        (setq mu4e--maildir-items-cached
-              (mu4e--make-query-items (mu4e-maildir-shortcuts) 'maildirs))))
+        (setq mu4e--maildir-items-cached (mu4e--make-query-items (mu4e-maildirs) 'maildirs))))
    ((not type)
     (append (mu4e-query-items 'bookmarks)
+            (mu4e-query-items 'maildirs-with-shortcut)
             (mu4e-query-items 'maildirs)))
    (t
     (mu4e-error "No such type %s" type))))


### PR DESCRIPTION
Since not all the maildirs have a shortcut defined, and the user might want to see more than the maildirs with a shortcut in their home, we add a new maildir section in the homepage to see all the defined maildirs to show. The list of maildirs to be shown are defined in the new custm mu4e-maildirs variable.