### PR TITLE
mu4e-thread-message-folded-p: fix moving above first fold overlay

### DIFF
--- a/mu4e/mu4e-thread.el
+++ b/mu4e/mu4e-thread.el
@@ -87,7 +87,7 @@ There are COUNT hidden and UNREAD messages overall."
   (when-let* ((overlay (mu4e-thread-is-folded))
               (beg (overlay-start overlay))
               (end (overlay-end overlay)))
-    (and (>= (point) beg) (< (point) end))))
+    (and (>= (point) beg) (<= (point) end))))
 
 (declare-function 'mu4e~headers-thread-root-p "mu4e-headers")
 (defalias  'mu4e-thread-is-root 'mu4e~headers-thread-root-p)


### PR DESCRIPTION
In a \*mu4e-headers\* buffer containing:

```
6144  05/23/2023   Ⓛ      straight   danielkrajnik          [radian-software/straight.el] Allow to evaluate arbitrary .el file (that does not conform to package.el format). (Issue #1091)
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••• [4 hidden messages]
9500  06/06/2023   Ⓛ      straight   Ian Eure               [radian-software/straight.el] Incomplete recipe for emacsql (Issue #1098)
```

With point on the 3rd line (just below the folded thread overlay), invoking `mu4e-headers-prev` will not advance point before the first fold.

The following patch fixes the issue on my end.
