### PR TITLE
Quote Display Names which contain special characters

### DIFF
--- a/lib/message/mu-contact.cc
+++ b/lib/message/mu-contact.cc
@@ -29,13 +29,20 @@
 
 using namespace Mu;
 
+const std::string rfc822SpecialCharacters  = "()<>@,;:\\\".[]";
+
 std::string
 Contact::display_name() const
 {
 	auto needs_quoting= [](const std::string& n) {
-		for (auto& c: n)
-			if (c == ',' || c == '"')
+		for (auto& c: n){
+			// RFC 822 3.3 and RFC 5322 3.2.3 defines special characters, Ascii
+			// Control (CTL) characters (0-31), DEL (127), and space as requiring
+			// quoting.
+			if (c <=31 || c >= 127 || c == ' ' || rfc822SpecialCharacters.find(c) != std::string::npos){
 				return true;
+			}
+		}
 		return false;
 	};
 

--- a/lib/message/mu-contact.cc
+++ b/lib/message/mu-contact.cc
@@ -29,17 +29,16 @@
 
 using namespace Mu;
 
-const std::string rfc822SpecialCharacters  = "()<>@,;:\\\".[]";
+const std::string rfc5322SpecialCharacters  = "()<>@,;:\\\"[]";
 
 std::string
 Contact::display_name() const
 {
 	auto needs_quoting= [](const std::string& n) {
 		for (auto& c: n){
-			// RFC 822 3.3 and RFC 5322 3.2.3 defines special characters, Ascii
-			// Control (CTL) characters (0-31), DEL (127), and space as requiring
-			// quoting.
-			if (c <=31 || c >= 127 || c == ' ' || rfc822SpecialCharacters.find(c) != std::string::npos){
+			// RFC 5322 3.2.3 defines special characters, Ascii Control
+			// (CTL) characters (0-31), DEL (127) as requiring quoting.
+			if ((c >= 0 && c <=31) || c == 127 || rfc5322SpecialCharacters.find(c) != std::string::npos){
 				return true;
 			}
 		}


### PR DESCRIPTION
RFC 822 and RFC 5322 define characters which require an atom be quoted when included as a word in a mailbox.