### PR TITLE
mu4e-util: allow ESC to exit a choice selection

### DIFF
--- a/mu4e/mu4e-helpers.el
+++ b/mu4e/mu4e-helpers.el
@@ -262,6 +262,10 @@ Return the matching choice value (cdr of the cell)."
     (while (not chosen)
       (message nil) ;; this seems needed...
       (when-let ((kar (read-char-exclusive prompt)))
+        (when (eq kar ?\e) (keyboard-quit)) ;; `read-char-exclusive' is a C
+                                            ;; function and doesn't check for
+                                            ;; `keyboard-quit', there we need to
+                                            ;; check if ESC is pressed
         (setq chosen (mu4e--matching-choice choices kar))))
     chosen))
 


### PR DESCRIPTION
I occasionally find myself pressing escape to exit a menu choice in mu4e
and it's a bit unfortunate that nothing happens. As best I could tell,
since this is a C call, none of the keymaps are checked for
`(keyboard-quit)' so we need to explicitly check for ESC here

This was previously fixed in 02b5bc805c9b5b7876d7302e172fd1ff9b1ba4aa
but was inadvertently removed in
0354fa4fac08a2799ee50396a035863384303a3c, so more detail was added to
the comment.