### PR TITLE
mu4e-notifications: add default action

### DIFF
--- a/mu4e/mu4e-notification.el
+++ b/mu4e/mu4e-notification.el
@@ -79,7 +79,8 @@ support."
              ;; :app-icon (ignore-errors
              ;;             (image-search-load-path
              ;;              "gnus/gnus.png"))
-             :actions '("Show" "Favorite bookmark")
+             :actions '("Show" "Favorite bookmark"
+                        "default" "Favorite bookmark")
              :on-action (lambda (_ _) (mu4e-jump-to-favorite)))))
      ;; ... TBI: other notifications ...
      (t ;; last resort


### PR DESCRIPTION
This PR adds a default notification action.

This is what the freedesktop.org specification says:

>  The default action (usually invoked by clicking the notification) should have a key named "default". The name can be anything, though implementations are free not to display it.
