### PR TITLE
Don't use the original message `To` for a reply `To` field

### DIFF
--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -350,10 +350,8 @@ address is set, use that, otherwise use the From address. Note,
 whatever was in the To: field before, goes to the Cc:-list (if
 we're doing a reply-to-all). Special case: if we were the sender
 of the original, we simple copy the list form the original."
-  (let* ((reply-to
-         (append
-          (plist-get origmsg :to)
-          (or (plist-get origmsg :reply-to) (plist-get origmsg :from))))
+  (let* ((reply-to (or (plist-get origmsg :reply-to)
+                       (plist-get origmsg :from)))
          (reply-to (cl-delete-duplicates reply-to
                                          :test #'mu4e~draft-address-cell-equal)))
     (if mu4e-compose-dont-reply-to-self


### PR DESCRIPTION
Fixes https://github.com/djcb/mu/issues/2535