### PR TITLE
mu4e: make it conform with `package.el`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -194,7 +194,8 @@ endif
 
 # emacs -- needed for mu4e compilation
 emacs_name=get_option('emacs')
-emacs=find_program([emacs_name], version: '>=26.3', required:false)
+emacs_min_version='26.3'
+emacs=find_program([emacs_name], version: '>='+emacs_min_version, required:false)
 if not emacs.found()
   message('emacs not found; not pre-compiling mu4e sources')
 endif

--- a/mu4e/meson.build
+++ b/mu4e/meson.build
@@ -26,6 +26,16 @@ mu4e_meta = configure_file(
       'MU_DOC_DIR'      : join_paths(datadir, 'doc', 'mu'),
     })
 
+mu4e_pkg_desc = configure_file(
+  input: 'mu4e-pkg.el.in',
+  output: 'mu4e-pkg.el',
+  install: true,
+  install_dir: mu4e_lispdir,
+  configuration: {
+      'VERSION'           : meson.project_version(),
+      'EMACS_MIN_VERSION' : emacs_min_version,
+    })
+
 mu4e_srcs=[
   'mu4e-actions.el',
   'mu4e-bookmarks.el',

--- a/mu4e/meson.build
+++ b/mu4e/meson.build
@@ -83,6 +83,17 @@ foreach src : mu4e_srcs
                  install_mode: 'r--r--r--')
 endforeach
 
+# this depends on the above hack: all mu4e elisp files needs to be in builddir
+mu4e_autoloads = configure_file(
+  output: 'mu4e-autoloads.el',
+  install: true,
+  install_dir: mu4e_lispdir,
+  command: [emacs,
+            '--no-init-file',
+            '--batch',
+            '--load', 'package',
+            '--eval', '(package-generate-autoloads "mu4e" "' + meson.current_build_dir() + '" )'])
+
 foreach src : mu4e_srcs
   target_name= '@BASENAME@.elc'
   target_path = join_paths(meson.current_build_dir(), target_name)

--- a/mu4e/meson.build
+++ b/mu4e/meson.build
@@ -23,8 +23,6 @@ mu4e_meta = configure_file(
   install_dir: mu4e_lispdir,
   configuration: {
       'VERSION'         : meson.project_version(),
-      # project_build_root() with meson >= 0.56
-      'abs_top_builddir': join_paths(meson.current_build_dir()),
       'MU_DOC_DIR'      : join_paths(datadir, 'doc', 'mu'),
     })
 

--- a/mu4e/mu4e-config.el.in
+++ b/mu4e/mu4e-config.el.in
@@ -3,9 +3,6 @@
 (defconst mu4e-mu-version "@VERSION@"
   "Required mu binary version; mu4e's version must agree with this.")
 
-(defconst mu4e-builddir "@abs_top_builddir@"
-  "Top-level build directory.")
-
 (defconst mu4e-doc-dir "@MU_DOC_DIR@"
   "Mu4e's data-dir.")
 

--- a/mu4e/mu4e-pkg.el.in
+++ b/mu4e/mu4e-pkg.el.in
@@ -1,0 +1,7 @@
+;; -*- no-byte-compile: t; -*-
+(define-package "mu4e" "@VERSION@"
+  "part of mu4e, the mu mail user agent"
+  '((emacs "@EMACS_MIN_VERSION@"))
+  :authors '(("Dirk-Jan C. Binnema" . "djcb@djcbsoftware.nl"))
+  :maintainer '("Dirk-Jan C. Binnema" . "djcb@djcbsoftware.nl")
+  :keywords '("email"))


### PR DESCRIPTION
# Problem

`mu4e` does not conform with `pakcage.el`, which makes autoload commands, such as `(mu4e)`, not work.  Users have to `(require 'mu4e)` first.

# Cause

`(package-activate-all)` of `package.el` is responsible for loading `NAME-autoloads.el` of all packages when Emacs starts.  See `(elisp) Startup Summary`.

- The default installation dir does not conform with `package.el`.  `package.el` looks for packages in `package-user-dir` and `package-directory-list`.  Check the source of `package-load-all-descriptors`.
- Missing `mu4e-pkg.el` description file.  See https://www.gnu.org/software/emacs/manual/html_node/elisp/Multi_002dfile-Packages.html.
- Missing `mu4e-autoloads.el`.  If a package is installed using `package.el`, this file will be generated.  Since we do not use `package.el` to install `mu4e`, we generate it manully.