### PR TITLE
mu4e: propertize thread prefix characters

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -329,17 +329,19 @@ into a string."
   (let ((get-prefix
          (lambda (cell)
            (if mu4e-use-fancy-chars (cdr cell) (car cell)))))
-    (cl-case type
-      (child         (funcall get-prefix mu4e-headers-thread-child-prefix))
-      (first-child   (funcall get-prefix mu4e-headers-thread-first-child-prefix))
-      (last-child    (funcall get-prefix mu4e-headers-thread-last-child-prefix))
-      (connection    (funcall get-prefix mu4e-headers-thread-connection-prefix))
-      (blank         (funcall get-prefix mu4e-headers-thread-blank-prefix))
-      (orphan        (funcall get-prefix mu4e-headers-thread-orphan-prefix))
-      (single-orphan (funcall get-prefix
-                              mu4e-headers-thread-single-orphan-prefix))
-      (duplicate     (funcall get-prefix mu4e-headers-thread-duplicate-prefix))
-      (t              "?"))))
+    (propertize
+     (cl-case type
+       (child         (funcall get-prefix mu4e-headers-thread-child-prefix))
+       (first-child   (funcall get-prefix mu4e-headers-thread-first-child-prefix))
+       (last-child    (funcall get-prefix mu4e-headers-thread-last-child-prefix))
+       (connection    (funcall get-prefix mu4e-headers-thread-connection-prefix))
+       (blank         (funcall get-prefix mu4e-headers-thread-blank-prefix))
+       (orphan        (funcall get-prefix mu4e-headers-thread-orphan-prefix))
+       (single-orphan (funcall get-prefix
+                               mu4e-headers-thread-single-orphan-prefix))
+       (duplicate     (funcall get-prefix mu4e-headers-thread-duplicate-prefix))
+       (t              "?"))
+     'face 'mu4e-thread-fold-face)))
 
 
 ;; headers in the buffer are prefixed by an invisible string with the docid


### PR DESCRIPTION
Brings visual consistency to unfolded threads.