### PR TITLE
mu4e: use special-mode for mu4e-last-update-buffer

### DIFF
--- a/mu4e/mu4e-update.el
+++ b/mu4e/mu4e-update.el
@@ -257,6 +257,7 @@ To override this behavior, customize `display-buffer-alist'."
     (when (get-buffer mu4e-last-update-buffer)
       (kill-buffer mu4e-last-update-buffer))
     (with-current-buffer mu4e--update-buffer
+      (special-mode)
       (clone-buffer mu4e-last-update-buffer))
     ;; and kill the buffer itself; the cloning is needed
     ;; so the temp window handling works as expected.


### PR DESCRIPTION
This buffer is not intended to be edited.
Special mode also allows quickly dismissing via the quit-window binding.