### PR TITLE
Connect `mu4e` on windows to `mu` in WSL

### DIFF
--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1397,24 +1397,25 @@ descendants."
 
 
 (defun mu4e-headers-view-message ()
-  "View message at point."
-  (interactive)
-  (unless (eq major-mode 'mu4e-headers-mode)
-    (mu4e-error "Must be in mu4e-headers-mode (%S)" major-mode))
-  (let* ((msg (mu4e-message-at-point))
-         (path (mu4e-message-field msg :path))
-         (_exists (or (file-readable-p  path)
-                      (mu4e-warn "No message at %s" path)))
-         (docid (or (mu4e-message-field msg :docid)
-                    (mu4e-warn "No message at point")))
-         (mark-as-read
-          (if (functionp mu4e-view-auto-mark-as-read)
-              (funcall mu4e-view-auto-mark-as-read msg)
-            mu4e-view-auto-mark-as-read)))
-    (when-let ((buf (mu4e-get-view-buffer (current-buffer) nil)))
-      (with-current-buffer buf
-        (mu4e-loading-mode 1)))
-    (mu4e--server-view docid mark-as-read)))
+       "View message at point."
+       (interactive)
+       (unless (eq major-mode 'mu4e-headers-mode)
+               (mu4e-error "Must be in mu4e-headers-mode (%S)" major-mode))
+       (let* ((msg (mu4e-message-at-point))
+              (path (mu4e-message-field msg :path))
+              (_exists ;; (or (file-readable-p  path)
+               ;;     (mu4e-warn "No message at %s" path))
+               t)
+              (docid (or (mu4e-message-field msg :docid)
+                         (mu4e-warn "No message at point")))
+              (mark-as-read
+               (if (functionp mu4e-view-auto-mark-as-read)
+                 (funcall mu4e-view-auto-mark-as-read msg)
+                 mu4e-view-auto-mark-as-read)))
+                 (when-let ((buf (mu4e-get-view-buffer (current-buffer) nil)))
+                           (with-current-buffer buf
+                             (mu4e-loading-mode 1)))
+                 (mu4e--server-view docid mark-as-read)))
 
 (defvar-local mu4e-headers-open-after-move t
   "If set to non-nil, open message after `mu4e-headers-next' and

--- a/mu4e/mu4e-helpers.el
+++ b/mu4e/mu4e-helpers.el
@@ -567,21 +567,25 @@ Or go to the top level if there is none."
 
 ;;; Misc
 (defun mu4e-join-paths (directory &rest components)
-  "Append COMPONENTS to DIRECTORY and return the resulting string.
+       "Append COMPONENTS to DIRECTORY and return the resulting string.
 
 This is mu4e's version of Emacs 28's `file-name-concat' with the
 difference it also handles slashes at the beginning of
 COMPONENTS."
-  (replace-regexp-in-string
-   "//+" "/"
-   (mapconcat (lambda (part) (if (stringp part) part ""))
-              (cons directory components) "/")))
+       (let ((double-slash (string-match "^//[^/]" directory))
+             (path (replace-regexp-in-string
+                    "//+" "/"
+                    (mapconcat (lambda (part) (if (stringp part) part ""))
+                               (cons directory components) "/"))))
+         (if double-slash
+             (concat "/" path)
+           path)))
 
 (defun mu4e-string-replace (from-string to-string in-string)
-  "Replace FROM-STRING with TO-STRING in IN-STRING each time it occurs.
+       "Replace FROM-STRING with TO-STRING in IN-STRING each time it occurs.
 Mu4e version of emacs 28's string-replace."
-  (replace-regexp-in-string (regexp-quote from-string)
-                            to-string in-string nil 'literal))
+       (replace-regexp-in-string (regexp-quote from-string)
+                                 to-string in-string nil 'literal))
 
 (defun mu4e-plistp (object)
   "Non-nil if and only if OBJECT is a valid plist.

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -187,18 +187,21 @@ A part would look something like:
 (defalias 'mu4e-msg-field 'mu4e-message-field)
 
 (defun mu4e-field-at-point (field)
-  "Get FIELD for the message at point.
+       "Get FIELD for the message at point.
 Either in the headers buffer or the view buffer. Field is a
 symbol, see `mu4e-header-info'."
-  (plist-get (mu4e-message-at-point) field))
+       (plist-get (mu4e-message-at-point) field))
 
 (defun mu4e-message-readable-path (&optional msg)
-  "Get a readable path to MSG or raise an error.
+       "Get a readable path to MSG or raise an error.
 If MSG is nil, use `mu4e-message-at-point'."
-  (let ((path (plist-get (or msg (mu4e-message-at-point)) :path)))
-    (unless (file-readable-p path)
-      (mu4e-error "No readable message at %s; database outdated?" path))
-    path))
+       (let ((path (plist-get (or msg (mu4e-message-at-point)) :path)))
+            ;; (unless (file-readable-p path)
+            ;;   (mu4e-error "No readable message at %s; database outdated?" path))
+            
+            (if mu4e-mu-through-wsl
+                (concat "//wsl.localhost/Ubuntu" path)
+              path)))
 
 (defun mu4e-copy-message-path ()
   "Copy the message-path of message at point to the kill ring."

--- a/mu4e/mu4e-server.el
+++ b/mu4e/mu4e-server.el
@@ -395,24 +395,25 @@ As per issue #2198."
                 ,(when mu4e-mu-home (format "--muhome=%s" mu4e-mu-home)))))
 
 (defun mu4e--version-check ()
-  ;; sanity-check 1
-  (let ((default-directory temporary-file-directory)) ;;ensure it's local.
-    (unless (and mu4e-mu-binary (file-executable-p mu4e-mu-binary))
-      (mu4e-error
-       "Cannot find mu, please set `mu4e-mu-binary' to the mu executable path"))
-    ;; sanity-check 2
-    (let ((version (let ((s (shell-command-to-string
-                             (concat mu4e-mu-binary " --version"))))
-                     (and (string-match "version \\([.0-9]+\\)" s)
-                          (match-string 1 s)))))
-      (if (not (string= version mu4e-mu-version))
-          (mu4e-error
-           (concat
-            "Found mu version %s, but mu4e needs version %s"
-            "; please set `mu4e-mu-binary' "
-            "accordingly")
-           version mu4e-mu-version)
-        (mu4e-message "Found mu version %s" version)))))
+       ;; sanity-check 1
+       (let ((default-directory temporary-file-directory)) ;;ensure it's local.
+         (unless (and mu4e-mu-binary ;; (file-executable-p mu4e-mu-binary)
+                      )
+                       (mu4e-error
+                        "Cannot find mu, please set `mu4e-mu-binary' to the mu executable path"))
+         ;; sanity-check 2
+         (let ((version (let ((s (shell-command-to-string
+                                  (concat mu4e-mu-binary " --version"))))
+                                  (and (string-match "version \\([.0-9]+\\)" s)
+                                       (match-string 1 s)))))
+                                       (if (not (string= version mu4e-mu-version))
+                                         (mu4e-error
+                                          (concat
+                                           "Found mu version %s, but mu4e needs version %s"
+                                           "; please set `mu4e-mu-binary' "
+                                           "accordingly")
+                                          version mu4e-mu-version)
+                                         (mu4e-message "Found mu version %s" version)))))
 
 (defun mu4e-server-repl ()
   "Start a mu4e-server repl.

--- a/mu4e/mu4e-server.el
+++ b/mu4e/mu4e-server.el
@@ -432,25 +432,27 @@ You cannot run the repl when mu4e is running (or vice-versa)."
         (message "invoked: '%s'" cmd)))))
 
 (defun mu4e--server-start ()
-  "Start the mu server process."
-  (mu4e--version-check)
-  ;; kill old/stale servers, if any.
-  (mu4e--kill-stale)
-  (let* ((process-connection-type nil) ;; use a pipe
-         (args (mu4e--server-args)))
-    (setq mu4e--server-buf "")
-    (mu4e-log 'misc "* invoking '%s' with parameters %s" mu4e-mu-binary
-              (mapconcat (lambda (arg) (format "'%s'" arg)) args " "))
-    (setq mu4e--server-process (apply 'start-process
-                                      mu4e--server-name mu4e--server-name
-                                      mu4e-mu-binary args))
-    ;; register a function for (:info ...) sexps
-    (unless mu4e--server-process
-      (mu4e-error "Failed to start the mu4e backend"))
-    (set-process-query-on-exit-flag mu4e--server-process nil)
-    (set-process-coding-system mu4e--server-process 'binary 'utf-8-unix)
-    (set-process-filter mu4e--server-process 'mu4e--server-filter)
-    (set-process-sentinel mu4e--server-process 'mu4e--server-sentinel)))
+       "Start the mu server process."
+       (mu4e--version-check)
+       ;; kill old/stale servers, if any.
+       (mu4e--kill-stale)
+       (let* ((process-connection-type nil) ;; use a pipe
+              (args (mu4e--server-args)))
+              (setq mu4e--server-buf "")
+              (mu4e-log 'misc "* invoking '%s' with parameters %s" mu4e-mu-binary
+                        (mapconcat (lambda (arg) (format "'%s'" arg)) args " "))
+              (setq mu4e--server-process ;; (apply 'start-process
+                    ;;        mu4e--server-name mu4e--server-name
+                    ;;        mu4e-mu-binary args)
+                    (start-process-shell-command mu4e--server-name mu4e--server-name (concat mu4e-mu-binary " " (mapconcat 'identity args " ")))
+                    )
+              ;; register a function for (:info ...) sexps
+              (unless mu4e--server-process
+                (mu4e-error "Failed to start the mu4e backend"))
+              (set-process-query-on-exit-flag mu4e--server-process nil)
+              (set-process-coding-system mu4e--server-process 'binary 'utf-8-unix)
+              (set-process-filter mu4e--server-process 'mu4e--server-filter)
+              (set-process-sentinel mu4e--server-process 'mu4e--server-sentinel)))
 
 (defun mu4e--server-kill ()
   "Kill the mu server process."

--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -84,7 +84,8 @@ is non-nil."
     (unless (string= (mu4e-server-version) mu4e-mu-version)
       (mu4e-error "The mu server has version %s, but we need %s"
                   (mu4e-server-version) mu4e-mu-version)))
-  (unless (and mu4e-mu-binary (file-executable-p mu4e-mu-binary))
+  (unless (and mu4e-mu-binary ;; (file-executable-p mu4e-mu-binary)
+               )
     (mu4e-error "Please set `mu4e-mu-binary' to the full path to the mu
     binary"))
   (dolist (var '(mu4e-sent-folder mu4e-drafts-folder


### PR DESCRIPTION
This PR tries to make `mu4e` on Windows work with `mu` running on WSL. I am connecting `mu4e` to an instance of `mu` running inside WSL. Basic navigation and reading emails works. Marking and deleting emails _kinda_ works. I keep running into this error.
![Screenshot 2023-09-17 140200](https://github.com/djcb/mu/assets/12583113/059a3d15-22f7-47f4-abc0-ae79a9b75630)
I tried looking around in the code to see who is calling this command so that I can add another `/` in front, but I couldn't find anything in `mu4e`. It may be being called internally from `mu`, but I'm not sure. I'm positive that what I've done may not be the best way to implement this feature and there are many other scenarios that are probably not working with this setup. Are you guys aware of this and is this feature on your roadmap? I'll be happy to help implement this feature if I receive guidance from someone who knows the codebase. 😄 I'm an Elisp newbie BTW.