### PR TITLE
Fix missing or incorrect descriptions in file headers

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -1,4 +1,4 @@
-;;; mu4e-actions.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
+;;; mu4e-actions.el --- Actions for messages and attachments in mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2023 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-bookmarks.el
+++ b/mu4e/mu4e-bookmarks.el
@@ -1,4 +1,4 @@
-;;; mu4e-bookmarks.el -- part of mu4e -*- lexical-binding: t -*-
+;;; mu4e-bookmarks.el --- Bookmarks for mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2023 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -1,4 +1,4 @@
-;;; mu4e-compose.el -- part of mu4e -*- lexical-binding: t -*-
+;;; mu4e-compose.el --- Various functions to compose/send messages from mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2022 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-context.el
+++ b/mu4e/mu4e-context.el
@@ -1,4 +1,4 @@
-;;; mu4e-context.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
+;;; mu4e-context.el --- Contexts to switch between accounts in mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2015-2023 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-contrib.el
+++ b/mu4e/mu4e-contrib.el
@@ -1,4 +1,4 @@
-;;; mu4e-contrib.el -- part of mu4e -*- lexical-binding: t -*-
+;;; mu4e-contrib.el --- Some user-contributed functions for mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013-2022 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -1,4 +1,4 @@
-;;; mu4e-draft.el -- part of mu4e, the mu mail user agent for emacs -*- lexical-binding: t -*-
+;;; mu4e-draft.el --- various functions to create draft messages in mu4e -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2011-2022 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-folders.el
+++ b/mu4e/mu4e-folders.el
@@ -1,4 +1,4 @@
-;;; mu4e-folders.el -- part of mu4e -*- lexical-binding: t -*-
+;;; mu4e-folders.el --- Dealing with maildirs & folders in mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021-2023 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-headers.el
+++ b/mu4e/mu4e-headers.el
@@ -1,4 +1,4 @@
-;;; mu4e-headers.el -- part of mu4e -*- lexical-binding: t; coding:utf-8 -*-
+;;; mu4e-headers.el --- Functions related to mu4e-headers-mode -*- lexical-binding: t; coding:utf-8 -*-
 
 ;; Copyright (C) 2011-2023 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-helpers.el
+++ b/mu4e/mu4e-helpers.el
@@ -1,4 +1,4 @@
-;;; mu4e-helpers.el -- part of mu4e -*- lexical-binding: t -*-
+;;; mu4e-helpers.el --- Helper functions used in mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2022-2023  Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-icalendar.el
+++ b/mu4e/mu4e-icalendar.el
@@ -1,4 +1,4 @@
-;;; mu4e-icalendar.el --- reply to iCalendar meeting requests (part of mu4e)  -*- lexical-binding: t; -*-
+;;; mu4e-icalendar.el --- Icalendar and diary integration in mu4e -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2019-2023 Christophe Troestler
 

--- a/mu4e/mu4e-lists.el
+++ b/mu4e/mu4e-lists.el
@@ -1,4 +1,4 @@
-;;; mu4e-lists.el -- part of mu4e -*- lexical-binding: t -*-
+;;; mu4e-lists.el --- Create tables of list-id -> shortname for mailing lists in mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2023 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-main.el
+++ b/mu4e/mu4e-main.el
@@ -1,4 +1,4 @@
-;;; mu4e-main.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
+;;; mu4e-main.el --- The Main interface for mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2023 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -1,4 +1,4 @@
-;;; mu4e-mark.el -- part of mu4e  -*- lexical-binding: t -*-
+;;; mu4e-mark.el --- functions related to marking messages in mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2022 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-message.el
+++ b/mu4e/mu4e-message.el
@@ -1,4 +1,4 @@
-;;; mu4e-message.el -- part of mu4e -*- lexical-binding: t -*-
+;;; mu4e-message.el --- Functions to get data from mu4e-message plist structure -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2012-2022 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-mime-parts.el
+++ b/mu4e/mu4e-mime-parts.el
@@ -1,4 +1,4 @@
-;;; mu4e-mime-parts.el -- part of mu4e -*- lexical-binding: t -*-
+;;; mu4e-mime-parts.el --- Implements functions and variables for dealing with MIME-parts and URLs -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2023 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-modeline.el
+++ b/mu4e/mu4e-modeline.el
@@ -1,4 +1,4 @@
-;;; mu4e-modeline.el -- part of mu4e  -*- lexical-binding: t -*-
+;;; mu4e-modeline.el --- Modeline for mu4e  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2023 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-notification.el
+++ b/mu4e/mu4e-notification.el
@@ -1,4 +1,4 @@
-;;; mu4e-notification.el --- -*- coding: utf-8; lexical-binding: t -*-
+;;; mu4e-notification.el --- Generic support for showing new-mail notifications from mu4e -*- coding: utf-8; lexical-binding: t -*-
 ;;
 ;; Copyright (C) 1996-2023 Dirk-Jan C. Binnema <djcb@djcbsoftware.nl>
 

--- a/mu4e/mu4e-obsolete.el
+++ b/mu4e/mu4e-obsolete.el
@@ -1,4 +1,4 @@
-;;; mu4e-obsolete-vars.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
+;;; mu4e-obsolete-vars.el --- Obsolete variables and functions aliases for mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2022 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-org.el
+++ b/mu4e/mu4e-org.el
@@ -1,4 +1,4 @@
-;;; mu4e-org -- Org-links to mu4e messages/queries -*- lexical-binding: t -*-
+;;; mu4e-org --- Org-links to mu4e messages/queries -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2012-2022 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-query-items.el
+++ b/mu4e/mu4e-query-items.el
@@ -1,4 +1,4 @@
-;;; mu4e-query-items.el -- part of mu4e -*- lexical-binding: t -*-
+;;; mu4e-query-items.el --- Queries for bookmarks and items for mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2023 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-search.el
+++ b/mu4e/mu4e-search.el
@@ -1,4 +1,4 @@
-;;; mu4e-search.el -- part of mu4e -*- lexical-binding: t -*-
+;;; mu4e-search.el --- Search-related functions for mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021,2022 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-server.el
+++ b/mu4e/mu4e-server.el
@@ -1,4 +1,4 @@
-;;; mu4e-server.el -- part of mu4e -*- lexical-binding: t -*-
+;;; mu4e-server.el --- Control mu server from mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2023 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-update.el
+++ b/mu4e/mu4e-update.el
@@ -1,4 +1,4 @@
-;;; mu4e-update.el -- part of mu4e, -*- lexical-binding: t -*-
+;;; mu4e-update.el --- Update the mu4e message store -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2023 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-vars.el
+++ b/mu4e/mu4e-vars.el
@@ -1,4 +1,4 @@
-;;; mu4e-vars.el -- part of mu4e, the mu mail user agent -*- lexical-binding: t -*-
+;;; mu4e-vars.el --- Variables and faces for mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2023 Dirk-Jan C. Binnema
 

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -1,4 +1,4 @@
-;;; mu4e-view.el -- part of mu4et -*- lexical-binding: t -*-
+;;; mu4e-view.el --- Define mu4e-view-mode for viewing e-mail messages in mu4e -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021-2023 Dirk-Jan C. Binnema
 


### PR DESCRIPTION
Try to make useful descriptions and use conventional --- to separate filename from description.

No code changes in this PR.