### PR TITLE
Fix defcustom :type of mu4e-headers-leave-behavior

### DIFF
--- a/mu4e/mu4e-mark.el
+++ b/mu4e/mu4e-mark.el
@@ -45,9 +45,9 @@ Value is one of the following symbols:
 - `ask'     ask user whether to ignore the marks
 - `apply'   automatically apply the marks before doing anything else
 - `ignore'  automatically ignore the marks without asking"
-  :type '(choice (const :tag ask    "ask user whether to ignore marks")
-                 (const :tag apply  "apply marks without asking")
-                 (const :tag ignore "ignore marks without asking"))
+  :type '(choice (const :tag "ask user whether to ignore marks" ask)
+                 (const :tag "apply marks without asking"       apply)
+                 (const :tag "ignore marks without asking"      ignore))
   :group 'mu4e-headers)
 
 (defcustom mu4e-mark-execute-pre-hook nil


### PR DESCRIPTION
The `const` values of the choice had the wrong order `(const :tag <value> <text>)`.
The correct order is `(const :tag <text> <value>)`.

This resulted in the following warning when loading mu4e:

```
⛔ Warning (emacs): Value ‘apply’ does not match type (choice (const :tag ask ask user whether to ignore marks) (const :tag apply apply marks without asking) (const :tag ignore ignore marks without asking))
```