### PR TITLE
Avoid claiming copyright for future years

### DIFF
--- a/man/copyright.inc.in
+++ b/man/copyright.inc.in
@@ -2,7 +2,7 @@
 
 This manpage is part of ~mu~ @VERSION@.
 
-Copyright © 2008-@YEAR@ Dirk-Jan C. Binnema. License GPLv3+: GNU GPL version 3
+Copyright © 2008-2023 Dirk-Jan C. Binnema. License GPLv3+: GNU GPL version 3
 or later <https://gnu.org/licenses/gpl.html>. This is free software: you are
 free to change and redistribute it. There is NO WARRANTY, to the extent
 permitted by law.


### PR DESCRIPTION
Avoid claiming copyright for future years

When compiling today's version in 2039,
the man-pages would state

Copyright © 2022-2039 Dirk-Jan C. Binnema. License GPLv3+: GNU GPL version 3 or later

which cannot be correct, since nobody did any copyrightable work in 2039 in that version.

Additionally, a copyright from 2023 will usually be valid for 70 years
after death of the author, so even if you forget to update it later,
there is no harm.

This patch was done while working on reproducible builds for openSUSE.