### PR TITLE
Fix installation dir of mu.scm

### DIFF
--- a/guile/meson.build
+++ b/guile/meson.build
@@ -93,9 +93,12 @@ if makeinfo.found()
   endif
 endif
 
-guile_scm_dir=join_paths(datadir, 'guile', 'site', '3.0', 'mu')
-install_data(['mu.scm','mu/script.scm', 'mu/message.scm', 'mu/stats.scm', 'mu/plot.scm'],
-             install_dir: guile_scm_dir)
+guile_scm_root_dir=join_paths(datadir, 'guile', 'site', '3.0',)
+install_data(['mu.scm'], install_dir: guile_scm_root_dir)
+
+guile_scm_mu_dir=join_paths(datadir, 'guile', 'site', '3.0', 'mu')
+install_data(['mu/script.scm', 'mu/message.scm', 'mu/stats.scm', 'mu/plot.scm'],
+             install_dir: guile_scm_mu_dir)
 
 
 mu_guile_scripts=[


### PR DESCRIPTION
Hello,

This fixes loading of the `(mu)` module in Guile for me.

Guile expects the `(mu)` module to be installed in `.../share/guile/site/3.0/mu.scm`, but before this patch Meson installed it in `.../share/guile/site/3.0/mu/mu.scm` instead.

If you accept this pull request and if more releases will be made from the 1.10 branch, can I kindly ask that this commit be cherry-picked there as well?