### PR TITLE
build: Add a new "tests" option to disable building tests

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -94,74 +94,76 @@ list_maildirs = executable('list-maildirs', 'mu-scanner.cc',
 # unit tests
 #
 
-test('test-threads',
-     executable('test-threads',
-                'mu-query-threads.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_dep]))
-test('test-contacts-cache',
-     executable('test-contacts-cache',
-                'mu-contacts-cache.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_dep]))
+if not get_option('tests').disabled()
+    test('test-threads',
+         executable('test-threads',
+                    'mu-query-threads.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_dep]))
+    test('test-contacts-cache',
+         executable('test-contacts-cache',
+                    'mu-contacts-cache.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_dep]))
 
-test('test-config',
-     executable('test-config',
-                'mu-config.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_dep]))
+    test('test-config',
+         executable('test-config',
+                    'mu-config.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_dep]))
 
-test('test-query-macros',
-     executable('test-query-macros',
-                'mu-query-macros.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [lib_mu_dep]))
+    test('test-query-macros',
+         executable('test-query-macros',
+                    'mu-query-macros.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [lib_mu_dep]))
 
-test('test-query-processor',
-     executable('test-query-processor',
-                'mu-query-processor.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [lib_mu_dep]))
+    test('test-query-processor',
+         executable('test-query-processor',
+                    'mu-query-processor.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [lib_mu_dep]))
 
-test('test-query-parser',
-     executable('test-query-parser',
-                'mu-query-parser.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [lib_mu_dep]))
+    test('test-query-parser',
+         executable('test-query-parser',
+                    'mu-query-parser.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [lib_mu_dep]))
 
-test('test-query-xapianizer',
-     executable('test-query-xapianizer',
-                'mu-query-xapianizer.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [lib_mu_dep]))
-
-
-test('test-indexer',
-     executable('test-indexer', 'mu-indexer.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, config_h_dep,
-                               lib_mu_dep]))
-
-test('test-scanner',
-     executable('test-scanner', 'mu-scanner.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, config_h_dep,
-                               lib_mu_utils_dep]))
-
-test('test-xapian-db',
-     executable('test-xapian-db', 'mu-xapian-db.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [lib_mu_dep, config_h_dep]))
+    test('test-query-xapianizer',
+         executable('test-query-xapianizer',
+                    'mu-query-xapianizer.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [lib_mu_dep]))
 
 
-subdir('tests')
+    test('test-indexer',
+         executable('test-indexer', 'mu-indexer.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, config_h_dep,
+                                   lib_mu_dep]))
+
+    test('test-scanner',
+         executable('test-scanner', 'mu-scanner.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, config_h_dep,
+                                   lib_mu_utils_dep]))
+
+    test('test-xapian-db',
+         executable('test-xapian-db', 'mu-xapian-db.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [lib_mu_dep, config_h_dep]))
+
+
+    subdir('tests')
+endif

--- a/lib/message/meson.build
+++ b/lib/message/meson.build
@@ -46,57 +46,59 @@ lib_mu_message_dep = declare_dependency(
 # tests
 #
 
-test('test-contact',
-     executable('test-contact',
-                'mu-contact.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, gmime_dep, lib_mu_message_dep]))
+if not get_option('tests').disabled()
+    test('test-contact',
+         executable('test-contact',
+                    'mu-contact.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, gmime_dep, lib_mu_message_dep]))
 
-test('test-document',
-     executable('test-document',
-                'mu-document.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, gmime_dep, lib_mu_message_dep]))
+    test('test-document',
+         executable('test-document',
+                    'mu-document.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, gmime_dep, lib_mu_message_dep]))
 
-test('test-fields',
-     executable('test-fields',
-                'mu-fields.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, gmime_dep, lib_mu_message_dep]))
+    test('test-fields',
+         executable('test-fields',
+                    'mu-fields.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, gmime_dep, lib_mu_message_dep]))
 
-test('test-flags',
-     executable('test-flags',
-                'mu-flags.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, gmime_dep, lib_mu_message_dep]))
+    test('test-flags',
+         executable('test-flags',
+                    'mu-flags.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, gmime_dep, lib_mu_message_dep]))
 
-test('test-message',
-     executable('test-message',
-                'test-mu-message.cc',
-                install: false,
-                dependencies: [glib_dep, gmime_dep, lib_mu_message_dep]))
+    test('test-message',
+         executable('test-message',
+                    'test-mu-message.cc',
+                    install: false,
+                    dependencies: [glib_dep, gmime_dep, lib_mu_message_dep]))
 
-test('test-priority',
-     executable('test-priority',
-                'mu-priority.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, gmime_dep, lib_mu_message_dep]))
+    test('test-priority',
+         executable('test-priority',
+                    'mu-priority.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, gmime_dep, lib_mu_message_dep]))
 
-test('test-message-file',
-     executable('test-message-file',
-                'mu-message-file.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_message_dep]))
+    test('test-message-file',
+         executable('test-message-file',
+                    'mu-message-file.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_message_dep]))
 
-test('test-message-part',
-     executable('test-message-part',
-                'mu-message-part.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_message_dep]))
+    test('test-message-part',
+         executable('test-message-part',
+                    'mu-message-part.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_message_dep]))
+endif

--- a/lib/tests/meson.build
+++ b/lib/tests/meson.build
@@ -17,53 +17,56 @@
 #
 # tests
 #
-test('test-maildir',
-     executable('test-maildir',
-                'test-mu-maildir.cc',
-                install: false,
-                dependencies: [glib_dep, lib_mu_dep]))
-test('test-msg',
-     executable('test-msg',
-                'test-mu-msg.cc',
-                install: false,
-                dependencies: [glib_dep, lib_mu_dep]))
-test('test-store',
-     executable('test-store',
-                'test-mu-store.cc',
-                install: false,
-                dependencies: [glib_dep, lib_mu_dep]))
-test('test-query',
-     executable('test-query',
-                'test-query.cc',
-                install: false,
-                dependencies: [glib_dep, gmime_dep, lib_mu_dep]))
 
-test('test-store-query',
-     executable('test-store-query',
-                'test-mu-store-query.cc',
-                install: false,
-                dependencies: [glib_dep, gmime_dep, lib_mu_dep]))
-#
-# benchmarks
-#
-bench_maildirs=join_paths(meson.current_build_dir(), 'maildirs')
-bench_store=join_paths(meson.current_build_dir(), 'store')
-bench_indexer_exe = executable(
-  'bench-indexer',
-  'bench-indexer.cc',
-  install:false,
-  cpp_args:['-DBENCH_MAILDIRS="' + bench_maildirs + '"',
-            '-DBENCH_STORE="' + bench_store + '"',
-           ],
-  dependencies: [lib_mu_dep, glib_dep])
+if not get_option('tests').disabled()
+    test('test-maildir',
+         executable('test-maildir',
+                    'test-mu-maildir.cc',
+                    install: false,
+                    dependencies: [glib_dep, lib_mu_dep]))
+    test('test-msg',
+         executable('test-msg',
+                    'test-mu-msg.cc',
+                    install: false,
+                    dependencies: [glib_dep, lib_mu_dep]))
+    test('test-store',
+         executable('test-store',
+                    'test-mu-store.cc',
+                    install: false,
+                    dependencies: [glib_dep, lib_mu_dep]))
+    test('test-query',
+         executable('test-query',
+                    'test-query.cc',
+                    install: false,
+                    dependencies: [glib_dep, gmime_dep, lib_mu_dep]))
 
-benchmark('bench-indexer', bench_indexer_exe, args: ['-m', 'perf'])
+    test('test-store-query',
+         executable('test-store-query',
+                    'test-mu-store-query.cc',
+                    install: false,
+                    dependencies: [glib_dep, gmime_dep, lib_mu_dep]))
+    #
+    # benchmarks
+    #
+    bench_maildirs=join_paths(meson.current_build_dir(), 'maildirs')
+    bench_store=join_paths(meson.current_build_dir(), 'store')
+    bench_indexer_exe = executable(
+      'bench-indexer',
+      'bench-indexer.cc',
+      install:false,
+      cpp_args:['-DBENCH_MAILDIRS="' + bench_maildirs + '"',
+                '-DBENCH_STORE="' + bench_store + '"',
+               ],
+      dependencies: [lib_mu_dep, glib_dep])
 
-#
-# below does _not_ pass; it is believed that it's a false alarm.
-#    https://gitlab.gnome.org/GNOME/glib/-/issues/2662
+    benchmark('bench-indexer', bench_indexer_exe, args: ['-m', 'perf'])
 
-# also register benchmark as a normal test so it gets included for
-# valgrind/helgrind etc.
-# test('test-bench-indexer', bench_indexer_exe,
-#      args : ['-m', 'quick'], env: ['THREADNUM=16'])
+    #
+    # below does _not_ pass; it is believed that it's a false alarm.
+    #    https://gitlab.gnome.org/GNOME/glib/-/issues/2662
+
+    # also register benchmark as a normal test so it gets included for
+    # valgrind/helgrind etc.
+    # test('test-bench-indexer', bench_indexer_exe,
+    #      args : ['-m', 'quick'], env: ['THREADNUM=16'])
+endif

--- a/lib/utils/meson.build
+++ b/lib/utils/meson.build
@@ -57,59 +57,62 @@ html2text = executable('mu-html2text',
 #
 # tests
 #
-test('test-sexp',
-     executable('test-sexp', 'mu-sexp.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_utils_dep]))
 
-test('test-regex',
-     executable('test-regex', 'mu-regex.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_utils_dep]))
+if not get_option('tests').disabled()
+    test('test-sexp',
+         executable('test-sexp', 'mu-sexp.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_utils_dep]))
 
-test('test-command-handler',
-     executable('test-command-handler', 'mu-command-handler.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_utils_dep]))
+    test('test-regex',
+         executable('test-regex', 'mu-regex.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_utils_dep]))
 
-test('test-utils-file',
-     executable('test-utils-file', 'mu-utils-file.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, gio_unix_dep,config_h_dep, lib_mu_utils_dep]))
+    test('test-command-handler',
+         executable('test-command-handler', 'mu-command-handler.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_utils_dep]))
 
-test('test-logger',
-     executable('test-logger', 'mu-logger.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_utils_dep, thread_dep ]))
+    test('test-utils-file',
+         executable('test-utils-file', 'mu-utils-file.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, gio_unix_dep,config_h_dep, lib_mu_utils_dep]))
 
-test('test-option',
-     executable('test-option', 'mu-option.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_utils_dep ]))
+    test('test-logger',
+         executable('test-logger', 'mu-logger.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_utils_dep, thread_dep ]))
 
-test('test-lang-detector',
-     executable('test-lang-detector', 'mu-lang-detector.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [ config_h_dep, glib_dep, lib_mu_utils_dep ]))
+    test('test-option',
+         executable('test-option', 'mu-option.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_utils_dep ]))
 
-test('test-html-to-text',
-     executable('test-html-to-text', 'mu-html-to-text.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_utils_dep]))
+    test('test-lang-detector',
+         executable('test-lang-detector', 'mu-lang-detector.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [ config_h_dep, glib_dep, lib_mu_utils_dep ]))
 
-test('test-error',
-     executable('test-error', 'mu-error.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_utils_dep]))
+    test('test-html-to-text',
+         executable('test-html-to-text', 'mu-html-to-text.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_utils_dep]))
+
+    test('test-error',
+         executable('test-error', 'mu-error.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_utils_dep]))
 
 
-subdir('tests')
+    subdir('tests')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,6 +15,11 @@
 ## Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+option('tests',
+       type: 'feature',
+       value: 'auto',
+       description: 'build tests')
+
 option('guile',
        type : 'feature',
        value: 'auto',

--- a/mu/meson.build
+++ b/mu/meson.build
@@ -42,68 +42,70 @@ mu = executable(
 # tests
 #
 
-test('test-cmd-add',
-     executable('test-cmd-add',
-                'mu-cmd-add.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_dep]))
+if not get_option('tests').disabled()
+    test('test-cmd-add',
+         executable('test-cmd-add',
+                    'mu-cmd-add.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_dep]))
 
-test('test-cmd-cfind',
-     executable('test-cmd-cfind',
-                'mu-cmd-cfind.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_dep]))
+    test('test-cmd-cfind',
+         executable('test-cmd-cfind',
+                    'mu-cmd-cfind.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_dep]))
 
-test('test-cmd-extract',
-     executable('test-cmd-extract',
-                'mu-cmd-extract.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_dep]))
+    test('test-cmd-extract',
+         executable('test-cmd-extract',
+                    'mu-cmd-extract.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_dep]))
 
-test('test-cmd-find',
-     executable('test-cmd-find',
-                'mu-cmd-find.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_dep]))
+    test('test-cmd-find',
+         executable('test-cmd-find',
+                    'mu-cmd-find.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_dep]))
 
-test('test-cmd-mkdir',
-     executable('test-cmd-mkdir',
-                'mu-cmd-mkdir.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_dep]))
+    test('test-cmd-mkdir',
+         executable('test-cmd-mkdir',
+                    'mu-cmd-mkdir.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_dep]))
 
-test('test-cmd-move',
-     executable('test-cmd-move',
-                'mu-cmd-move.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_dep]))
+    test('test-cmd-move',
+         executable('test-cmd-move',
+                    'mu-cmd-move.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_dep]))
 
-test('test-cmd-remove',
-     executable('test-cmd-remove',
-                'mu-cmd-remove.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_dep]))
+    test('test-cmd-remove',
+         executable('test-cmd-remove',
+                    'mu-cmd-remove.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_dep]))
 
-test('test-cmd-verify',
-     executable('test-cmd-verify',
-                'mu-cmd-verify.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_dep]))
+    test('test-cmd-verify',
+         executable('test-cmd-verify',
+                    'mu-cmd-verify.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_dep]))
 
 
-test('test-cmd-view',
-     executable('test-cmd-view',
-                'mu-cmd-view.cc',
-                install: false,
-                cpp_args: ['-DBUILD_TESTS'],
-                dependencies: [glib_dep, lib_mu_dep]))
+    test('test-cmd-view',
+         executable('test-cmd-view',
+                    'mu-cmd-view.cc',
+                    install: false,
+                    cpp_args: ['-DBUILD_TESTS'],
+                    dependencies: [glib_dep, lib_mu_dep]))
 
-subdir('tests')
+    subdir('tests')
+endif


### PR DESCRIPTION
I have a script that rebuilds mu a few times, and during one of the stages I don't run tests, so I'd like to skip building them too. I'm a complete noob with meson: I kind of expected to be able to find a built-in way to skipping the build of tests, but I couldn't find any.

This adds a new "tests" feature option, which defaults to auto. When explicitly set to "disabled" it will skip the test definitions. It's kind of ugly IMHO, essentially moving all test definitions inside if blocks...

It was just an experiment on my side so I don't think much of this. Still, might be useful for packaging mu.