### PR TITLE
Fix mu4e-compose-mail and some warnings

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -844,7 +844,7 @@ they do not conflict with mu4e inner workings."
   ;; this case, but let's prepare for the re-edit case as well
   (mu4e--compose-setup
    'new
-   (lambda (_parent)
+   (lambda (_parent _orig)
      (message-mail to subject other-headers continue nil
                    yank-action send-actions return-action))
    switch-function))

--- a/mu4e/mu4e-contrib.el
+++ b/mu4e/mu4e-contrib.el
@@ -160,7 +160,7 @@ the file."
                                         (file-directory-p f))
                                     nil
                                   (expand-file-name f)))
-                    (eshell-flatten-list (reverse args))))))
+                    (mu4e--flatten-list (reverse args))))))
     ;; warn if user tries to attach without any files marked
     (if (null files-to-attach)
         (error "No files to attach")
@@ -189,7 +189,7 @@ the file."
                  (goto-char (point-max)) ; attach at end of buffer
                  (while files-to-attach
                    (mml-attach-file (car files-to-attach)
-                                    (or (mm-default-file-encoding
+                                    (or (mu4e--mm-default-file-type
                                          (car files-to-attach))
                                         "application/octet-stream") nil)
                    (setq files-to-attach (cdr files-to-attach)))


### PR DESCRIPTION
An argument was missing in the callback defined in `mu4e-compose-mail`.