### PR TITLE
When re-tagging, force `replace-match' to preserve case

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -169,7 +169,7 @@ Otherwise return nil."
     (save-excursion
       (goto-char (point-min))
       (if (re-search-forward regexp nil t)
-          (replace-match to-string nil nil)))))
+          (replace-match to-string t nil)))))
 
 (declare-function mu4e--server-add "mu4e-server")
 (defun mu4e--refresh-message (path)


### PR DESCRIPTION
Sets the second parameter to `replace-match' to t, thus forcing it to not attempt to auto-adjust the case of any tags.

Addresses #2574 .