### PR TITLE
man: fix unreproducible copyright years

### DIFF
--- a/man/meson.build
+++ b/man/meson.build
@@ -17,10 +17,9 @@
 #
 # generate org include files
 #
-year = run_command('date', '+%Y', check:true, capture:true)
 man_data=configuration_data()
 man_data.set('VERSION', meson.project_version())
-man_data.set('YEAR', year.stdout().strip())
+man_data.set('YEAR', mu_year)
 incs=[
   'author.inc',
   'bugs.inc',


### PR DESCRIPTION
967b724e7546 ("build: avoid dynamic dates for reproducibility") introduced the `mu_date` variable to hard-code a build-date.  This is used for the dates embedded in the texinfo documentation, but `date` is still called to set the copyright years in the man-pages.  Use `mu_date` there too.