### PR TITLE
mu4e-compose-reply: account for nil REPLY-TYPE in assertion

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -803,7 +803,7 @@ of message."
   "Reply to the message at point with REPLY-TYPE.
 REPLY-TYPE is either nil (normal reply), \='wide or \='supersede."
   (interactive)
-  (cl-assert (when reply-type (member reply-type '(wide supersede))))
+  (cl-assert (member reply-type '(wide supersede nil)))
   (mu4e--compose-setup
    'reply
    (lambda (parent)


### PR DESCRIPTION
Previous assertion would fail when REPLY-TYPE is nil, but nil is a valid value for the argument.

See: https://github.com/djcb/mu/issues/2601