### PR TITLE
mu4e: add support for macOS notifications

### DIFF
--- a/mu4e/mu4e-notification.el
+++ b/mu4e/mu4e-notification.el
@@ -67,6 +67,9 @@ support."
                             (if (= delta-unread 1) "" "s")
                             (plist-get fav :name))))
     (cond
+     ((fboundp 'do-applescript)
+      (do-applescript
+       (format "display notification %S with title %S" body title)))
      ((fboundp 'notifications-notify)
       ;; notifications available
       (setq mu4e--notification-id


### PR DESCRIPTION
Add support for alert.el to be used on systems that don't have native dbus functionality.

Question: is this something that can be applied to the 1.10 branch?

IMHO, this should be on 1.10 just to make 1.10 the release "where notifications work by default." Apologies for not catching this sooner.