### PR TITLE
mu4e-icalendar: Fix getting the organizer from the message

### DIFF
--- a/mu4e/mu4e-icalendar.el
+++ b/mu4e/mu4e-icalendar.el
@@ -130,10 +130,11 @@
                    (organizer (when (and organizer
                                          (not (string-empty-p organizer)))
                                 organizer))
-                   (organizer (or organizer
-                                  (car (plist-get msg :reply-to))
-                                  (car (plist-get msg :from))
-                                  (mu4e-warn "Cannot find organizer"))))
+                   (organizer
+                    (or organizer
+                        (plist-get (car (plist-get msg :reply-to)) :email)
+                        (plist-get (car (plist-get msg :from)) :email)
+                        (mu4e-warn "Cannot find organizer"))))
               (mu4e--compose-setup
                'reply
                (lambda (_parent)


### PR DESCRIPTION
I did additional tests and this is the only problem I found.

Fixes https://github.com/djcb/mu/issues/2583.