### PR TITLE
`mu4e` on windows with `mu` in WSL

### DIFF
--- a/mu4e/mu4e-server.el
+++ b/mu4e/mu4e-server.el
@@ -480,9 +480,9 @@ You cannot run the repl when mu4e is running (or vice-versa)."
     (setq mu4e--server-buf "")
     (mu4e-log 'misc "* invoking '%s' with parameters %s" mu4e-mu-binary
               (mapconcat (lambda (arg) (format "'%s'" arg)) args " "))
-    (setq mu4e--server-process (apply 'start-process
-                                      mu4e--server-name mu4e--server-name
-                                      mu4e-mu-binary args))
+    (setq mu4e--server-process (start-process-shell-command
+                                mu4e--server-name mu4e--server-name
+                                (concat mu4e-mu-binary " " (mapconcat 'identity args " "))))
     ;; register a function for (:info ...) sexps
     (unless mu4e--server-process
       (mu4e-error "Failed to start the mu4e backend"))

--- a/mu4e/mu4e-server.el
+++ b/mu4e/mu4e-server.el
@@ -436,7 +436,7 @@ As per issue #2198."
 (defun mu4e--version-check ()
   ;; sanity-check 1
   (let ((default-directory temporary-file-directory)) ;;ensure it's local.
-    (unless (and mu4e-mu-binary (file-executable-p mu4e-mu-binary))
+    (unless mu4e-mu-binary
       (mu4e-error
        "Cannot find mu, please set `mu4e-mu-binary' to the mu executable path"))
     ;; sanity-check 2

--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -94,7 +94,7 @@ Otherwise, completely quit mu4e, including automatic updating."
     (unless (string= (mu4e-server-version) mu4e-mu-version)
       (mu4e-error "The mu server has version %s, but we need %s"
                   (mu4e-server-version) mu4e-mu-version)))
-  (unless (and mu4e-mu-binary (file-executable-p mu4e-mu-binary))
+  (unless mu4e-mu-binary
     (mu4e-error "Please set `mu4e-mu-binary' to the full path to the mu
     binary"))
   (dolist (var '(mu4e-sent-folder mu4e-drafts-folder


### PR DESCRIPTION
I'm back with another approach to make `mu4e` on windows work with `mu` in WSL. I was playing with `mu4e` with the intention to define an advice around `mu4e--server-call-mu` to translate whatever paths are being returned from `mu`. However, I discovered a really useful behavior of `insert-file-contents` on windows, making it unnecessary to transform any paths. My interaction on Emacs mailing list is [here](https://lists.gnu.org/archive/html/help-gnu-emacs/2024-01/msg00062.html). I'm reproducing the email here as the email text will explain it better.

> > From: samvid mistry <mistrysamvid@gmail.com>
> > Date: Sat, 20 Jan 2024 12:00:46 +0530
> > 
> > I was playing with some code and found an unusual behaviour of
> > insert-file-contents. I am running GNU Emacs 29.1 *on Windows*. When I am
> > in a file/buffer that is within WSL, accessed using
> > `//wsl.localhost/Ubuntu/...`, I can open WSL paths without the prefix,
> > i.e., I can write `(insert-file-contents "/home/samvid/davmail.log")`
> > instead of `(insert-file-contents
> > "//wsl.localhost/Ubuntu/home/samvid/davmail.log")` and it will open the
> > correct file. However, running `(insert-file-contents
> > "/home/samvid/davmail.log")` when I am in a buffer/file on windows
> > filesystem, it will run into this error
> > 
> > `(file-missing "Opening input file" "No such file or directory"
> > "c:/home/samvid/davmail.log")`
> 
> Isn't this just normal prepending of the drive letter to a file name
> that lacks it?  I'm guessing that when you are in a buffer whose name
> begins with //wsl.localhost/Ubuntu/... Emacs prepends that to a file
> name without a drive letter, whereas in a buffer on the C: drive, it
> prepends C:/ instead.
> 
> 
> Emacs on Windows doesn't consider file names that begin with a slash
> as absolute file names, unless they have are in UNC format and begin
> with two slashes.

Basically, if you start `mu4e` from any buffer within `//wsl.localhost/Ubuntu/...`, `insert-file-contents` will prepend the drive letter, in this case `//wsl.localhost/Ubuntu/` to all paths, pointing it to the right file. The whole thing works transparently as far as mu4e is concerned. 

Then why am I relaxing the validations?

`mu` is not a windows native program. It is available in WSL. Hence `(file-executable-p mu4e-mu-binary)` will always return false. Moreover, we need to start `mu` in WSL, which can be done by setting

```elisp
(setq mu4e-mu-binary "wsl mu")
```
and running `mu` as a shell command instead of a windows native process. Is there a way to incorporate these changes in `mu4e`? We can then maybe explain in the README how one can get this setup working on Windows.