### PR TITLE
Fix guile_load_path to include build path

### DIFF
--- a/guile/tests/meson.build
+++ b/guile/tests/meson.build
@@ -21,6 +21,7 @@
 if get_option('b_sanitize') == 'none'
   guile_load_path=':'.join([
     join_paths(meson.project_source_root(), 'guile'),
+    join_paths(meson.project_build_root(), 'guile'),
     meson.current_build_dir()])
 
   test('test-mu-guile',


### PR DESCRIPTION
When meson is run in a build path that is different from source root, the generated shared library cannot be found under "<source_root>/guile".  This patch adds the corresponding path under build root to guile_root_path so that they continue to work.

This should fix https://github.com/djcb/mu/issues/2631.