### PR TITLE
return buf from mu4e--compose-setup

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -792,7 +792,8 @@ Optionally, SWITCH determines how to find a buffer for the message
         (setq-local ;;message-kill-actions actions
          message-return-actions actions
          message-send-actions actions
-         message-kill-actions actions)))))
+         message-kill-actions actions)))
+    buf))
 
 
 ;;;###autoload


### PR DESCRIPTION
This makes using `mu4e-compose-foo` easier to use programmatically 