### PR TITLE
don't call switch-to-buffer

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -782,7 +782,7 @@ Optionally, SWITCH determines how to find a buffer for the message
          (mu4e--draft-message-path (mu4e--message-basename) parent)))
       (mu4e--compose-setup-post compose-type parent)
       (setq buf (current-buffer))
-      (switch-to-buffer buf)
+      (display-buffer buf)
       (let* ((msgframe (selected-frame))
              (actions (list
                        (lambda () ;; kill frame when it was created for this


### PR DESCRIPTION
I'm basing this off:

> Now Emacs treats manual buffer switching the same as programmatic switching. However, it also guards against (some) misbehaving commands you may encounter: those that call out to switch-to-buffer programmatically. That is “against the rules”, as switch-to-buffer is a user-facing command.

https://www.masteringemacs.org/article/demystifying-emacs-window-manager