### PR TITLE
mu4e--view-render-buffer: Disable Gnus bookmark-make-record-function

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -730,6 +730,8 @@ determine which browser function to use."
           (run-hooks 'gnus-article-decode-hook)
           (gnus-article-prepare-display)
           (mu4e--view-activate-urls)
+          ;; `gnus-summary-bookmark-make-record' does not work properly when "appeased."
+          (kill-local-variable 'bookmark-make-record-function)
           (setq mu4e~gnus-article-mime-handles gnus-article-mime-handles
                 gnus-article-decoded-p gnus-article-decode-hook)
           (set-buffer-modified-p nil)


### PR DESCRIPTION
The function 'gnus-summary-bookmark-make-record' does not work properly with the
faux "appeasement" summary buffer, causing undesired changes in the window
configuration when the message rendering buffer's bookmark function is
called (which some packages, like Activities, Burly, and Dogears do routinely).

See <https://github.com/alphapapa/activities.el/issues/55>.

Reported-by: Daniel Goldin <https://github.com/danielgoldin>