### PR TITLE
mu4e-compose: add new line while replying above the cited message

### DIFF
--- a/mu4e/mu4e-compose.el
+++ b/mu4e/mu4e-compose.el
@@ -846,7 +846,7 @@ replied to or forwarded, etc."
     (if (not (message-field-value "Subject"))
         (message-goto-subject)
       (pcase message-cite-reply-position
-        ((or 'above 'traditional) (message-goto-body))
+        ((or 'above 'traditional) (message-goto-body) (open-line 1))
         (_ (when (message-goto-signature) (forward-line -2))))))
   ;; buffer is not user-modified yet
   (set-buffer-modified-p nil)


### PR DESCRIPTION
I think this pull request could be a mistake.

Because when I was a child, when I was reading an email with mu4e, and pressed `R`, the buffer would turn into something like this:

```markdown
To: "Jack" <jack@example.com>
Subject: Re: Jack's Nonsense
From: Vito Van <mememe@example.com>
Date: Sun, 31 Mar 2024 08:42:50 +0200
Message-ID: <m2h0lnm7sx.fsf@example.com>
--text follows this line--

"Jack" <jack@example.com> writes:

> this is Jack's nonsense
>
> [4. application/x-zip-compressed; nonsense.zip]...
``` 

and the cursor would be located just under the line of `--text follows this line--`, which is fantastic.

But after the latest update, which I didn't update anything on my computer unless it's more than two years old or I was feeling very lucky, after I pressed the magic reply key `R`, the buffer turned into something like this:

```markdown
To: "Jack" <jack@example.com>
Subject: Re: Jack's Nonsense
From: Vito Van <mememe@example.com>
Date: Sun, 31 Mar 2024 08:42:50 +0200
Message-ID: <m2h0lnm7sx.fsf@example.com>
--text follows this line--
"Jack" <jack@example.com> writes:

> this is Jack's nonsense
>
> [4. application/x-zip-compressed; nonsense.zip]...
``` 

**No new line anymore!**

And I got many letters to reply, I have to press `C-o` every time I pressed `R`, this delivered some huge mental and muscle burden. Oh, I like mu4e so! I can't switch to any other email client, please don't do this to me. I said. But after I dived into my messed-up-but-still-working Emacs configuration and git-blamed the source code of mu4e-compose.el, I gave up, and added this damn `open-line` here.

Please tell me that I'm wrong, dear djcb.