### PR TITLE
mu-move: remove debug print

### DIFF
--- a/mu/mu-cmd-move.cc
+++ b/mu/mu-cmd-move.cc
@@ -50,9 +50,6 @@ Mu::mu_cmd_move(Mu::Store& store, const Options& opts)
 			   "Must have at least one of destination and flags");
 	else if (!dest.empty()) {
 		const auto mdirs{store.maildirs()};
-		mu_printerrln("XXXX");
-		for (auto&& m:mdirs)
-			mu_printerrln("m:'{}'", m);
 
 		if (!seq_some(mdirs, [&](auto &&d){ return d == dest;}))
 			return Err(Error{Error::Code::InvalidArgument,


### PR DESCRIPTION
The `mu move` command always prints messages to `stderr` which seem like they were left over from some debugging session. These are hard to filter out without also potentially suppressing error messages. They're also present when giving the `--quiet` option. I don't think these serve any purpose at the moment, so I suggest to just remove them.