### PR TITLE
scanner: don't skip directory entries with type `DT_UNKNOWN`

### DIFF
--- a/lib/mu-scanner.cc
+++ b/lib/mu-scanner.cc
@@ -215,9 +215,13 @@ Scanner::Private::process_dir(const std::string& path, bool is_maildir)
 	while (running_) {
 		errno = 0;
 		if (const auto& dentry{::readdir(dir)}; dentry) {
-#if HAVE_DIRENT_D_TYPE /* opttimization: filter out non-dirs early */
+#if HAVE_DIRENT_D_TYPE /* optimization: filter out non-dirs early.  NB not all file-systems support
+			* returning the file-type in `d_type`, so don't skip `DT_UNKNOWN`.
+			*/
 			if (maildirs_only_mode() &&
-			    dentry->d_type != DT_DIR && dentry->d_type != DT_LNK)
+			    dentry->d_type != DT_DIR &&
+			    dentry->d_type != DT_LNK &&
+			    dentry->d_type != DT_UNKNOWN)
 				continue;
 #endif /*HAVE_DIRENT_D_TYPE*/
 			dir_entries.emplace_back(dentry);


### PR DESCRIPTION
According to the readdir(2) man-page, not all file-systems support returning the entry's file-type in `d_type`.  For example, the reprotest reproducibility tool, uses the disorderfs FUSE file-system to shuffle the order in which directory entries are returned, and this does not set `d_type`.  Therefore, in addition to entries with type `DT_DIR` and `DT_LNK`, also process entries with type `DT_UNKNOWN`.

For example, install disorderfs:

	# apt-get install disorderfs

Mount mu over it:

	$ mkdir mu-disordered
	$ disorderfs mu mu-disordered
	disorderfs: reversing directory entries

Build mu:

	$ cd mu-disordered/
	$ meson setup build .
	The Meson build system
	Version: 1.4.0
	Source dir: /space/azazel/work/git/repos/github/a3a3el/mu-disordered
	Build dir: /space/azazel/work/git/repos/github/a3a3el/mu-disordered/build
	Build type: native build
	Project name: mu
	Project version: 1.12.4
	[snip]
	$ ninja -C build
	ninja: Entering directory `build'
	[snip]

Then run the test-suite:

	$ ninja -C build test
	ninja: Entering directory `build'
	[0/1] Running all tests.
	 1/46 test-sexp                     OK              0.11s
	 2/46 test-regex                    OK              0.11s
	 3/46 test-command-handler          OK              0.10s
	 4/46 test-utils-file               OK              0.10s
	 5/46 test-option                   OK              0.09s
	 6/46 test-lang-detector            OK              0.09s
	 7/46 test-html-to-text             OK              0.08s
	 8/46 test-error                    OK              0.07s
	 9/46 test-mu-utils                 OK              0.07s
	10/46 test-contact                  OK              0.06s
	11/46 test-fields                   OK              0.04s
	12/46 test-flags                    OK              0.03s
	13/46 test-priority                 OK              0.02s
	14/46 test-message                  OK              0.21s
	15/46 test-message-file             OK              0.20s
	16/46 test-message-part             OK              0.19s
	17/46 test-threads                  OK              0.18s
	18/46 test-contacts-cache           OK              0.17s
	19/46 test-config                   OK              0.16s
	20/46 test-query-macros             OK              0.15s
	21/46 test-query-processor          OK              0.14s
	22/46 test-query-parser             OK              0.13s
	23/46 test-maildir                  OK              0.24s
	24/46 test-query-xapianizer         OK              0.32s
	25/46 test-document                 OK              0.46s
	26/46 test-msg                      OK              0.23s
	27/46 test-cmd-mkdir                OK              0.07s
	28/46 test-cmd-verify               OK              0.05s
	29/46 test-cmd-extract              OK              0.26s
	30/46 test-xapian-db                OK              0.48s
	31/46 test-cmd-view                 OK              0.17s
	32/46 test-logger                   OK              1.01s
	33/46 test-scanner                  FAIL            0.80s   killed by signal 6 SIGABRT
	[snip]
	34/46 test-cmd-init                 OK              0.90s
	35/46 test-query                    OK              2.42s
	36/46 test-cmd-remove               OK              2.45s
	37/46 test-cmd-cfind                OK              2.99s
	38/46 test-cmd-find                 OK              3.29s
	39/46 test-cmd-add                  OK              3.77s
	40/46 test-store                    FAIL            8.67s   killed by signal 6 SIGABRT
	[snip]
	41/46 test-mu-guile                 OK              9.11s
	42/46 test-indexer                  OK             10.37s
	43/46 test-cmd-index                OK             10.45s
	44/46 test-cmd-move                 OK             10.89s
	45/46 test-cmd-query                OK             12.33s
	46/46 test-store-query              OK             18.12s

	Summary of Failures:

	33/46 test-scanner          FAIL            0.80s   killed by signal 6 SIGABRT
	40/46 test-store            FAIL            8.67s   killed by signal 6 SIGABRT

	Ok:                 44
	Expected Fail:      0
	Fail:               2
	Unexpected Pass:    0
	Skipped:            0
	Timeout:            0

	Full log written to /space/azazel/work/git/repos/github/a3a3el/mu-disordered/build/meson-logs/testlog.txt
	FAILED: meson-internal__test
	/usr/bin/meson test --no-rebuild --print-errorlogs
	ninja: build stopped: subcommand failed.

In both cases, scanning testdir2 returned no entries, e.g.:

	# mu-DEBUG: starting scan @ /space/azazel/work/git/repos/github/a3a3el/mu-disordered/testdata/testdir2
	# mu-DEBUG: finished scan of /space/azazel/work/git/repos/github/a3a3el/mu-disordered/testdata/testdir2 in 0 ms
	not ok /scanner/count-maildirs - ERROR:../lib/mu-scanner.cc:365:void test_count_maildirs(): assertion failed (dirs.size() == 3): (0 == 3)
	Bail out!

Here's an example Debian CI test failure: https://salsa.debian.org/emacsen-team/maildir-utils/-/jobs/5635549