### PR TITLE
Mu4e info manual typos fix

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -789,7 +789,7 @@ changes indeed. So it is mostly useful for tracking changes while you are
 @emph{not} using @t{mu4e}. For this reason, you can reset the baseline manually,
 e.g. by visiting the main view .
 
-By comparing current results with the baseline, you can quickly what new
+By comparing current results with the baseline, you can quickly see what new
 messages have arrived since the last time you looked.
 
 The baseline@footnote{For debugging, it can be useful to see the time for the

--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -793,7 +793,7 @@ By comparing current results with the baseline, you can quickly see what new
 messages have arrived since the last time you looked.
 
 The baseline@footnote{For debugging, it can be useful to see the time for the
-baseline - for that, there is the @code{mu4e-baseline-time} command} . is reset
+baseline - for that, there is the @code{mu4e-baseline-time} command.} is reset
 automatically when switching to the main view, or invoking @code{buffer-revert}
 (@kbd{g}) while in the main-view. Visiting the ``favorite'' bookmark does the
 same(explained below).


### PR DESCRIPTION
I think I found two typos in the Mu4e Info manual. Here is a fix.