### PR TITLE
Try to improve overall manual page typesetting

### DIFF
--- a/man/common-options.inc
+++ b/man/common-options.inc
@@ -1,30 +1,30 @@
 * COMMON OPTIONS
 
 ** -d, --debug
-makes mu generate extra debug information, useful for debugging the program
-itself. By default, debug information goes to the log file, ~/.cache/mu/mu.log.
-It can safely be deleted when mu is not running. When running with --debug
+Makes mu generate extra debug information, useful for debugging the program
+itself. By default, debug information goes to the log file, _~/.cache/mu/mu.log_.
+It can safely be deleted when mu is not running. When running with *--debug*
 option, the log file can grow rather quickly. See the note on logging below.
 
 ** -q, --quiet
-causes mu not to output informational messages and progress information to
+Causes mu not to output informational messages and progress information to
 standard output, but only to the log file. Error messages will still be sent to
-standard error. Note that mu index is much faster with --quiet, so it is
+standard error. Note that *mu index* is much faster with *--quiet*, so it is
 recommended you use this option when using mu from scripts etc.
 
 ** --log-stderr
-causes mu to not output log messages to standard error, in addition to sending
+Causes mu to not output log messages to standard error, in addition to sending
 them to the log file.
 
 ** --nocolor
-do not use ANSI colors. The environment variable ~NO_COLOR~ can be used as an
-alternative to ~--nocolor~.
+Do not use ANSI colors. The environment variable *NO_COLOR* can be used as an
+alternative to *--nocolor*.
 
 ** -V, --version
-prints mu version and copyright information.
+Prints *mu* version and copyright information.
 
 ** -h, --help
-lists the various command line options.
+Lists the various command line options.
 
 # Local Variables:
 # mode: org

--- a/man/common-options.inc
+++ b/man/common-options.inc
@@ -1,19 +1,19 @@
 * COMMON OPTIONS
 
 ** -d, --debug
-Makes mu generate extra debug information, useful for debugging the program
+Makes *mu* generate extra debug information, useful for debugging the program
 itself. By default, debug information goes to the log file, _~/.cache/mu/mu.log_.
-It can safely be deleted when mu is not running. When running with *--debug*
+It can safely be deleted when *mu* is not running. When running with *--debug*
 option, the log file can grow rather quickly. See the note on logging below.
 
 ** -q, --quiet
-Causes mu not to output informational messages and progress information to
+Causes *mu* not to output informational messages and progress information to
 standard output, but only to the log file. Error messages will still be sent to
 standard error. Note that *mu index* is much faster with *--quiet*, so it is
-recommended you use this option when using mu from scripts etc.
+recommended you use this option when using *mu* from scripts etc.
 
 ** --log-stderr
-Causes mu to not output log messages to standard error, in addition to sending
+Causes *mu* to not output log messages to standard error, in addition to sending
 them to the log file.
 
 ** --nocolor

--- a/man/copyright.inc.in
+++ b/man/copyright.inc.in
@@ -1,6 +1,6 @@
 * COPYRIGHT
 
-This manpage is part of ~mu~ @VERSION@.
+This manpage is part of *mu* @VERSION@.
 
 Copyright © 2008-@YEAR@ Dirk-Jan C. Binnema. License GPLv3+: GNU GPL version 3
 or later <https://gnu.org/licenses/gpl.html>. This is free software: you are

--- a/man/exit-code.inc
+++ b/man/exit-code.inc
@@ -5,8 +5,8 @@ otherwise.
 
     0. success
     2. no matches found. Try a different query
-   11. database schema mismatch. You need to re-initialize ~mu~, see *mu-init(1)*
-   19. failed to acquire lock. Some other program has exclusive access to the mu database
+   11. database schema mismatch. You need to re-initialize *mu*, see *mu-init(1)*
+   19. failed to acquire lock. Some other program has exclusive access to the *mu* database
    99. caught an exception
 
 # Local Variables:

--- a/man/exit-code.inc
+++ b/man/exit-code.inc
@@ -1,3 +1,5 @@
+#+include: macros.inc
+
 * EXIT CODE
 
 This command returns 0 upon successful completion, or a non-zero exit code
@@ -5,7 +7,7 @@ otherwise.
 
     0. success
     2. no matches found. Try a different query
-   11. database schema mismatch. You need to re-initialize *mu*, see *mu-init(1)*
+   11. database schema mismatch. You need to re-initialize *mu*, see {{{man-link(mu-init,1)}}}
    19. failed to acquire lock. Some other program has exclusive access to the *mu* database
    99. caught an exception
 

--- a/man/macros.inc
+++ b/man/macros.inc
@@ -1,0 +1,5 @@
+#+MACRO: man-link *$1*​($2)
+
+# Local Variables:
+# mode: org
+# End:

--- a/man/meson.build
+++ b/man/meson.build
@@ -26,6 +26,7 @@ incs=[
   'common-options.inc',
   'copyright.inc.in',
   'exit-code.inc',
+  'macros.inc',
   'muhome.inc',
   'prefooter.inc',
 ]

--- a/man/mu-add.1.org
+++ b/man/mu-add.1.org
@@ -7,7 +7,7 @@ mu-add - add one or more messages to the database
 
 * SYNOPSIS
 
-*mu [common-options] add [options] <file> [<files>]*
+*mu* [​_COMMON-OPTIONS_​] *add* [​_OPTIONS_​] _FILE_...
 
 * DESCRIPTION
 

--- a/man/mu-add.1.org
+++ b/man/mu-add.1.org
@@ -11,7 +11,7 @@ mu-add - add one or more messages to the database
 
 * DESCRIPTION
 
-~mu add~ is the command to add specific message files to the database. Each file
+*mu add* is the command to add specific message files to the database. Each file
 must be specified with an absolute path.
 
 * ADD OPTIONS

--- a/man/mu-add.1.org
+++ b/man/mu-add.1.org
@@ -1,5 +1,6 @@
 #+TITLE: MU ADD
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -26,4 +27,6 @@ must be specified with an absolute path.
 
 * SEE ALSO
 
-*mu(1)*, *mu-index(1)*, *mu-remove(1)*
+{{{man-link(mu,1)}}},
+{{{man-link(mu-index,1)}}},
+{{{man-link(mu-remove,1)}}}

--- a/man/mu-bookmarks.5.org
+++ b/man/mu-bookmarks.5.org
@@ -12,8 +12,8 @@ Bookmarks are named shortcuts for search queries. They allow using a convenient
 name for often-used queries. The bookmarks are also visible as shortcuts in the
 *mu* experimental user interfaces, =mug= and =mug2=.
 
-The bookmarks file is read from =<muhome>/bookmarks=. On Unix this would typically
-be =~/.config/mu/bookmarks=, but this can be influenced using the *--muhome*
+The bookmarks file is read from _<muhome>/bookmarks_. On Unix this would typically
+be _~/.config/mu/bookmarks_, but this can be influenced using the *--muhome*
 parameter for {{{man-link(mu-find,1)}}}.
 
 The bookmarks file is a typical key=value *.ini*-file, which is best shown by

--- a/man/mu-bookmarks.5.org
+++ b/man/mu-bookmarks.5.org
@@ -3,16 +3,16 @@
 
 * NAME
 
-mu-bookmarks - file with bookmarks (shortcuts) for mu search expressions
+mu-bookmarks - file with bookmarks (shortcuts) for *mu* search expressions
 
 * DESCRIPTION
 
 Bookmarks are named shortcuts for search queries. They allow using a convenient
 name for often-used queries. The bookmarks are also visible as shortcuts in the
-mu experimental user interfaces, =mug= and =mug2=.
+*mu* experimental user interfaces, =mug= and =mug2=.
 
 The bookmarks file is read from =<muhome>/bookmarks=. On Unix this would typically
-be w be =~/.config/mu/bookmarks=, but this can be influenced using the ~--muhome~
+be w be =~/.config/mu/bookmarks=, but this can be influenced using the *--muhome*
 parameter for *mu-find(1)*.
 
 The bookmarks file is a typical key=value *.ini*-file, which is best shown by

--- a/man/mu-bookmarks.5.org
+++ b/man/mu-bookmarks.5.org
@@ -1,5 +1,6 @@
 #+TITLE: MU BOOKMARKS
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -13,7 +14,7 @@ name for often-used queries. The bookmarks are also visible as shortcuts in the
 
 The bookmarks file is read from =<muhome>/bookmarks=. On Unix this would typically
 be w be =~/.config/mu/bookmarks=, but this can be influenced using the *--muhome*
-parameter for *mu-find(1)*.
+parameter for {{{man-link(mu-find,1)}}}.
 
 The bookmarks file is a typical key=value *.ini*-file, which is best shown by
 means of an example:
@@ -25,7 +26,7 @@ oldhat=maildir:/archive subject:hat   # archived with subject containing 'hat'
 #+end_example
 
 The *[mu]* group header is required. For practical uses of bookmarks, see
-*mu-find(1)*.
+{{{man-link(mu-find,1)}}}.
 
 #+include: "author.inc" :minlevel 1
 
@@ -33,4 +34,5 @@ The *[mu]* group header is required. For practical uses of bookmarks, see
 
 * SEE ALSO
 
-*mu(1)*, *mu-find(1)*
+{{{man-link(mu,1)}}},
+{{{man-link(mu-find,1)}}}

--- a/man/mu-bookmarks.5.org
+++ b/man/mu-bookmarks.5.org
@@ -13,7 +13,7 @@ name for often-used queries. The bookmarks are also visible as shortcuts in the
 *mu* experimental user interfaces, =mug= and =mug2=.
 
 The bookmarks file is read from =<muhome>/bookmarks=. On Unix this would typically
-be w be =~/.config/mu/bookmarks=, but this can be influenced using the *--muhome*
+be =~/.config/mu/bookmarks=, but this can be influenced using the *--muhome*
 parameter for {{{man-link(mu-find,1)}}}.
 
 The bookmarks file is a typical key=value *.ini*-file, which is best shown by

--- a/man/mu-cfind.1.org
+++ b/man/mu-cfind.1.org
@@ -69,7 +69,7 @@ should only apply to name fields.
 
 ** --personal,-p only show addresses seen in messages where one of `my' e-mail
 addresses was seen in one of the address fields; this is to exclude addresses
-only seen in mailing-list messages. See the ~--my-address~ parameter to *mu init*.
+only seen in mailing-list messages. See the *--my-address* parameter to *mu init*.
 
 ** --after=<timestamp> only show addresses last seen after
 =<timestamp>=. =<timestamp>= is a UNIX *time_t* value, the number of
@@ -87,7 +87,7 @@ example, only consider addresses last seen after 2020-06-01, you could specify
 
 * JSON FORMAT
 
-With ~--format=json~, the matching contacts come out as a JSON array, e.g.,
+With *--format=json*, the matching contacts come out as a JSON array, e.g.,
 #+begin_example
 [
   {

--- a/man/mu-cfind.1.org
+++ b/man/mu-cfind.1.org
@@ -1,5 +1,6 @@
 #+TITLE: MU CFIND
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -42,7 +43,7 @@ If you do not specify a search expression, *mu cfind* returns the full list of
 contacts. Note, *mu cfind* uses a cache with the e-mail information, which is
 populated during the indexing process.
 
-The regular expressions are basic case-insensitive PCRE, see *pcre(3)*.
+The regular expressions are basic case-insensitive PCRE, see {{{man-link(pcre,3)}}}.
 
 * CFIND OPTIONS
 
@@ -124,7 +125,7 @@ Each contact has the following fields:
 | ~personal~      | whether the email was seen in a message together with a personal address |
 | ~frequency~     | approximation of the number of times this contact was seen in messages   |
 
-The JSON format is useful for further processing, e.g. using the *jq(1)* tool:
+The JSON format is useful for further processing, e.g. using the {{{man-link(jq,1)}}} tool:
 
 List display names, sorted by their last-seen date:
 #+begin_example
@@ -146,7 +147,7 @@ which is (by default) accessible by pressing *Q*.
 * ENCODING
 
 *mu cfind* output is encoded according to the current locale except for
-=--format=bbdb=. This is hard-coded to UTF-8, and as such specified in the
+*--format=bbdb*. This is hard-coded to UTF-8, and as such specified in the
 output-file, so emacs/bbdb can handle things correctly, without guessing.
 
 #+include: "exit-code.inc" :minlevel 1
@@ -158,4 +159,9 @@ output-file, so emacs/bbdb can handle things correctly, without guessing.
 #+include: "copyright.inc" :minlevel 1
 
 * SEE ALSO
-*mu(1)*, *mu-index(1)*, *mu-find(1)*, *pcre(3)*, *jq(1)*
+
+{{{man-link(mu,1)}}},
+{{{man-link(mu-index,1)}}},
+{{{man-link(mu-find,1)}}},
+{{{man-link(pcre,3)}}},
+{{{man-link(jq,1)}}}

--- a/man/mu-cfind.1.org
+++ b/man/mu-cfind.1.org
@@ -47,8 +47,8 @@ The regular expressions are basic case-insensitive PCRE, see {{{man-link(pcre,3)
 
 * CFIND OPTIONS
 
-** --format=plain|mutt-alias|mutt-ab|wl|org-contact|bbdb|csv
-sets the output format to the given value. The following are available:
+** --format plain|mutt-alias|mutt-ab|wl|org-contact|bbdb|csv
+Sets the output format to the given value. The following are available:
 
 #+ATTR_MAN: :disable-caption t
 | --format=   | description                       |
@@ -68,13 +68,14 @@ any double-quote is replaced by a double-double quote (thus, "hello" become
 ""hello"", and fields with commas are put in double-quotes. Normally, this
 should only apply to name fields.
 
-** --personal,-p only show addresses seen in messages where one of `my' e-mail
+** -p, --personal
+Only show addresses seen in messages where one of `my' e-mail
 addresses was seen in one of the address fields; this is to exclude addresses
 only seen in mailing-list messages. See the *--my-address* parameter to *mu init*.
 
-** --after=<timestamp> only show addresses last seen after
-=<timestamp>=. =<timestamp>= is a UNIX *time_t* value, the number of
-seconds since 1970-01-01 (in UTC).
+** --after _timestamp_
+Only show addresses last seen after _timestamp_. _timestamp_ is a UNIX
+*time_t* value, the number of seconds since 1970-01-01 (in UTC).
 
 From the command line, you can use the *date* command to get this value. For
 example, only consider addresses last seen after 2020-06-01, you could specify

--- a/man/mu-cfind.1.org
+++ b/man/mu-cfind.1.org
@@ -135,7 +135,7 @@ $ mu cfind --format=json --personal | jq -r '.[] | ."last-seen-iso" + " " + .dis
 * INTEGRATION WITH MUTT
 
 You can use *mu cfind* as an external address book server for *mutt*.
-For this to work, add the following to your =muttrc=:
+For this to work, add the following to your _muttrc_:
 
 #+begin_example
 set query_command = "mu cfind --format=mutt-ab '%s'"

--- a/man/mu-cfind.1.org
+++ b/man/mu-cfind.1.org
@@ -8,7 +8,7 @@ for use in other programs.
 
 * SYNOPSIS
 
-*mu [common-options] cfind [options] [<pattern>]*
+*mu* [​_COMMON-OPTIONS_​] *cfind* [​_OPTIONS_​] [​_PATTERN_​]
 
 * DESCRIPTION
 

--- a/man/mu-easy.7.org
+++ b/man/mu-easy.7.org
@@ -56,7 +56,7 @@ processed. See the {{{man-link(mu-index,1)}}} man page for more details.
 
 Normally, *mu index* visits all the directories under the top-level Maildir;
 however, you can exclude certain directories (say, the `trash' or `spam'
-folders) by creating a file called =.noindex= in the directory. When *mu* sees such
+folders) by creating a file called _.noindex_ in the directory. When *mu* sees such
 a file, it will exclude this directory and its sub-directories from indexing.
 Also see *.noupdate* in the {{{man-link(mu-index,1)}}} manpage.
 
@@ -106,8 +106,8 @@ Julius Caesar <jc@example.com> Fere libenter homines id quod volunt credunt
 This is the same message found before, only with some different fields
 displayed.
 
-By default, *mu* uses the logical ~AND~ for the search parameters -- that is, it
-displays messages that match all the parameters. However, we can use logical ~OR~
+By default, *mu* uses the logical _AND_ for the search parameters -- that is, it
+displays messages that match all the parameters. However, we can use logical _OR_
 as well:
 
 #+begin_example
@@ -141,7 +141,7 @@ The summary consists of the first /n/ lines of the message with all superfluous
 whitespace removed.
 
 Also note the *m:/archive* parameter in the query. This means that we only match
-messages in a maildir called ~'/archive'~.
+messages in a maildir called _'/archive'_.
 
 * MORE QUERIES
 
@@ -296,7 +296,7 @@ $ mu cfind --format=mutt-alias > ~/mutt-aliases
 #+end_example
 
 Then, you can use them in *mutt* if you add something like *source ~/mutt-aliases*
-to your =muttrc=.
+to your _muttrc_.
 
 #+include: "prefooter.inc" :minlevel 1
 

--- a/man/mu-easy.7.org
+++ b/man/mu-easy.7.org
@@ -1,5 +1,6 @@
 #+TITLE: MU EASY
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -12,8 +13,8 @@ many options, which are all described in the man pages for the various
 sub-commands. This man pages jumps over all of the details and gives examples of
 some common use cases. If the use cases described here do not precisely do what
 you want, please check the more extensive information in the man page about the
-sub-command you are using -- for example, the *mu-index(1)* or *mu-find(1)* man
-pages.
+sub-command you are using -- for example, the {{{man-link(mu-index,1)}}} or
+{{{man-link(mu-find,1)}}} man pages.
 
 *NOTE*: the *index* command (and therefore, the ones that depend on that, such as
 *find*), require that you store your mail in the Maildir-format. If you don't do
@@ -34,7 +35,7 @@ with the *init* command.
 $ mu init
 #+end_example
 
-This uses the defaults (see *mu-init(1)* for details on how to change that).
+This uses the defaults (see {{{man-link(mu-init,1)}}} for details on how to change that).
 
 
 * INDEXING YOUR E-MAIL
@@ -50,23 +51,23 @@ the speed of your computer, hard drive etc. Usually, indexing should be able to
 reach a speed of a few hundred messages per second.
 
 *mu index* guesses the top-level Maildir to do its job; if it guesses wrong, you
-can use the =--maildir= option to specify the top-level directory that should be
-processed. See the *mu-index(1)* man page for more details.
+can use the *--maildir* option to specify the top-level directory that should be
+processed. See the {{{man-link(mu-index,1)}}} man page for more details.
 
 Normally, *mu index* visits all the directories under the top-level Maildir;
 however, you can exclude certain directories (say, the `trash' or `spam'
 folders) by creating a file called =.noindex= in the directory. When *mu* sees such
 a file, it will exclude this directory and its sub-directories from indexing.
-Also see *.noupdate* in the *mu-index(1)* manpage.
+Also see *.noupdate* in the {{{man-link(mu-index,1)}}} manpage.
 
 * SEARCHING YOUR E-MAIL
 
 After you have indexed your mail, you can start searching it. By default, the
 search results are printed on standard output. Alternatively, the output can
 take the form of Maildir with symbolic links to the found messages. This enables
-integration with e-mail clients; see the *mu-find(1)* man page for details, the
-syntax of the search parameters and so on. Here, we just give some examples for
-common cases.
+integration with e-mail clients; see the {{{man-link(mu-find,1)}}} man page for
+details, the syntax of the search parameters and so on. Here, we just give some
+examples for common cases.
 
 You can use the *mu fields* command to get information about all possible fields
 and flags.
@@ -89,7 +90,7 @@ on your the language/locale you are using.
 
 How do we know that the message was sent to Julius Caesar? Well, it's not
 visible from the results above, because the default fields that are shown are
-date/sender/subject. However, we can change this using the =--fields= parameter
+date/sender/subject. However, we can change this using the *--fields* parameter
 (try *mu fields* to see all the details):
 
 #+begin_example
@@ -122,7 +123,7 @@ from Socrates. This could return something like:
 #+end_example
 
 What if we want to see some of the body of the message? You can get a `summary'
-of the first lines of the message using the =--summary-len= option, which will
+of the first lines of the message using the *--summary-len* option, which will
 `summarize' the first =n= lines of the message:
 
 #+begin_example
@@ -283,9 +284,9 @@ $ mu cfind julius
 #+end_example
 
 will find all contacts with `julius' in either name or e-mail address. Note that
-*mu cfind* accepts a =regular expression= (as per *pcre(3)*)
+*mu cfind* accepts a =regular expression= (as per {{{man-link(pcre,3)}}}
 
-*mu cfind* also supports a =--format==-parameter, which sets the output to some
+*mu cfind* also supports a *--format=*-parameter, which sets the output to some
 specific format, so the results can be imported into another program. For
 example, to export your contact information to a *mutt* address book file, you can
 use something like:
@@ -300,4 +301,12 @@ to your =muttrc=.
 #+include: "prefooter.inc" :minlevel 1
 
 * SEE ALSO
-*mu(1)*, *mu-init(1)*, *mu-index(1)*, *mu-find(1)*, *mu-mfind(1)*, *mu-mkdir(1)*, *mu-view(1)*, *mu-extract(1)*
+
+{{{man-link(mu,1)}}},
+{{{man-link(mu-init,1)}}},
+{{{man-link(mu-index,1)}}},
+{{{man-link(mu-find,1)}}},
+{{{man-link(mu-mfind,1)}}},
+{{{man-link(mu-mkdir,1)}}},
+{{{man-link(mu-view,1)}}},
+{{{man-link(mu-extract,1)}}}

--- a/man/mu-easy.7.org
+++ b/man/mu-easy.7.org
@@ -3,7 +3,7 @@
 
 * NAME
 
-mu-easy - a quick introduction to mu
+mu-easy - a quick introduction to *mu*
 
 * DESCRIPTION
 
@@ -27,7 +27,7 @@ non-empty.
 
 * SETTING THINGS UP
 
-The first time you run the mu commands, you need to initialize it. This is done
+The first time you run the *mu* commands, you need to initialize it. This is done
 with the *init* command.
 
 #+begin_example
@@ -145,7 +145,7 @@ messages in a maildir called ~'/archive'~.
 * MORE QUERIES
 
 Let's list a few more queries that may be interesting; please note that
-searches for message flags, priority and date ranges are only available in mu
+searches for message flags, priority and date ranges are only available in *mu*
 version 0.9 or later.
 
 Get all important messages which are signed:
@@ -180,7 +180,7 @@ which is equivalent to:
 #+begin_example
   *$ mu find subject:angstrom flag:unread*
 #+end_example
-because does mu is case-insensitive and accent-insensitive.
+because does *mu* is case-insensitive and accent-insensitive.
 
 Get all unread messages between March 2002 and August 2003 about some bird (or
 a Swedish rock band):

--- a/man/mu-extract.1.org
+++ b/man/mu-extract.1.org
@@ -1,5 +1,6 @@
 #+TITLE: MU EXTRACT
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -24,7 +25,7 @@ MIME-parts, a name is derived from the message-id of the message.
 
 If you specify a regular express pattern as the second argument, all attachments
 with filenames matching that pattern will be extracted. The regular expressions
-are basic PCRE, and are case-sensitive by default; see *pcre(3)* for more details.
+are basic PCRE, and are case-sensitive by default; see {{{man-link(pcre,3)}}} for more details.
 
 Without any options, *mu extract* simply outputs the list of leaf MIME-parts in
 the message. Only `leaf' MIME-parts (including RFC822 attachments) are
@@ -62,8 +63,8 @@ a legal filename in the target directory.
 
 ** --matches=<pattern>
 Attachments with filenames matching the pattern will be extracted. The regular
-expressions are basic PCRE, and are case-sensitive by default; see *pcre(3)* for
-more details.
+expressions are basic PCRE, and are case-sensitive by default; see
+{{{man-link(pcre,3)}}} for more details.
 
 ** --play
 Try to `play' (open) the attachment with the default application for the
@@ -105,4 +106,4 @@ $ cat msgfile | mu extract --play --matches 'whoopsididitagain.mp3'
 
 * SEE ALSO
 
-*mu(1)*
+{{{man-link(mu,1)}}}

--- a/man/mu-extract.1.org
+++ b/man/mu-extract.1.org
@@ -8,9 +8,9 @@ mu-extract - display and save message parts
 
 * SYNOPSIS
 
-*mu [common-options] extract [options] [<file>]*
+*mu* [​_COMMON-OPTIONS_​] *extract* [​_OPTIONS_​] [​_FILE_​]
 
-*mu [common-options] extract [options] <file> <pattern>*
+*mu* [​_COMMON-OPTIONS_​] *extract* [​_OPTIONS_​] _FILE_ _PATTERN_
 
 * DESCRIPTION
 

--- a/man/mu-extract.1.org
+++ b/man/mu-extract.1.org
@@ -32,37 +32,36 @@ the message. Only `leaf' MIME-parts (including RFC822 attachments) are
 considered, *multipart/** etc. are ignored.
 
 Without a filename parameter, *mu extract* reads a message from standard-input. In
-that case, you cannot use the second, ~<pattern>~ parameter as this would be
+that case, you cannot use the second, _PATTERN_ parameter as this would be
 ambiguous; instead, use the *--matches* option.
 
 * EXTRACT OPTIONS
 
 ** -a, --save-attachments
-save all MIME-parts that look like attachments.
+Save all MIME-parts that look like attachments.
 
 ** --save-all
-save all non-multipart MIME-parts.
+Save all non-multipart MIME-parts.
 
-** --parts=<parts>
-only consider the following numbered parts (comma-separated list). The numbers
+** --parts _parts_
+Only consider the following numbered _parts_ (comma-separated list). The numbers
 for the parts can be seen from running *mu extract* without any options but only
 the message file.
 
-** --target-dir=<dir>
-save the parts in the target directory rather than the current working
-directory.
+** --target-dir _dir_
+Save the parts in _dir_ rather than the current working directory.
 
 ** --overwrite
-overwrite existing files with the same name; by default overwriting is not
+Overwrite existing files with the same name; by default overwriting is not
 allowed.
 
 ** -u,--uncooked
-by default, *mu* transforms the attachment filenames a bit (such as by replacing
+By default, *mu* transforms the attachment filenames a bit (such as by replacing
 spaces by dashes); with this option, leave that to the minimum for creating
 a legal filename in the target directory.
 
-** --matches=<pattern>
-Attachments with filenames matching the pattern will be extracted. The regular
+** --matches _pattern_
+Attachments with filenames matching _pattern_ will be extracted. The regular
 expressions are basic PCRE, and are case-sensitive by default; see
 {{{man-link(pcre,3)}}} for more details.
 

--- a/man/mu-extract.1.org
+++ b/man/mu-extract.1.org
@@ -30,9 +30,9 @@ Without any options, *mu extract* simply outputs the list of leaf MIME-parts in
 the message. Only `leaf' MIME-parts (including RFC822 attachments) are
 considered, *multipart/** etc. are ignored.
 
-Without a filename parameter, ~mu extract~ reads a message from standard-input. In
+Without a filename parameter, *mu extract* reads a message from standard-input. In
 that case, you cannot use the second, ~<pattern>~ parameter as this would be
-ambiguous; instead, use the ~--matches~ option.
+ambiguous; instead, use the *--matches* option.
 
 * EXTRACT OPTIONS
 
@@ -56,7 +56,7 @@ overwrite existing files with the same name; by default overwriting is not
 allowed.
 
 ** -u,--uncooked
-by default, ~mu~ transforms the attachment filenames a bit (such as by replacing
+by default, *mu* transforms the attachment filenames a bit (such as by replacing
 spaces by dashes); with this option, leave that to the minimum for creating
 a legal filename in the target directory.
 
@@ -96,7 +96,7 @@ To extract an mp3-file, and play it in the default mp3-playing application:
 $ mu extract --play msgfile 'whoopsididitagain.mp3'
 #+end_example
 
-when reading from standard-input, you need ~--matches~, so:
+when reading from standard-input, you need *--matches*, so:
 #+begin_example
 $ cat msgfile | mu extract --play --matches 'whoopsididitagain.mp3'
 #+end_example

--- a/man/mu-find.1.org
+++ b/man/mu-find.1.org
@@ -145,9 +145,9 @@ will delete any symlink it finds, so be careful.
 $ mu find grolsch --format=links --linksdir=~/Maildir/search --clearlinks
 #+end_example
 
-stores links to found messages in =~/Maildir/search=. If the directory does not
+stores links to found messages in _~/Maildir/search_. If the directory does not
 exist yet, it will be created. Note: when *mu* creates a Maildir for these links,
-it automatically inserts a =.noindex= file, to exclude the directory from *mu
+it automatically inserts a _.noindex_ file, to exclude the directory from *mu
 index*.
 
 ** --after=<timestamp>
@@ -232,7 +232,7 @@ It is possible to integrate *mu find* with some mail clients
 
 ** *mutt*
 
-For *mutt* you can use the following in your =muttrc=; pressing the F8 key will
+For *mutt* you can use the following in your *muttrc*; pressing the F8 key will
 start a search, and F9 will take you to the results.
 
 #+begin_example
@@ -263,7 +263,7 @@ your Wanderlust configuration file:
 
 Now, you can search using the *g* key binding; you can also create permanent
 virtual folders when the messages matching some expression by adding something
-like the following to your =folders= file.
+like the following to your _folders_ file.
 
 #+begin_example
 VFolders {

--- a/man/mu-find.1.org
+++ b/man/mu-find.1.org
@@ -45,15 +45,15 @@ For details on the possible queries, see {{{man-link(mu-query,7)}}}.
 
 * FIND OPTIONS
 
-Note, some of the important options are described in the {{{man-link(mu*,1)}}}
+Note, some of the important options are described in the {{{man-link(mu,1)}}}
 manual page and not here, as they apply to multiple *mu* commands.
 
 The *find*-command has various options that influence the way *mu* displays the
 results. If you don't specify anything, the defaults are *--fields="d f s"*,
 *--sortfield=date* and *--reverse*.
 
-** -f, --fields=<fields>
-specifies a string that determines which fields are shown in the output. This
+** -f, --fields _fields_
+Specifies a string that determines which fields are shown in the output. This
 string consists of a number of characters (such as 's' for subject or 'f' for
 from), which will replace with the actual field in the output. Fields that are
 not known will be output as-is, allowing for some simple formatting.
@@ -86,8 +86,8 @@ The message flags are described in {{{man-link(mu-query,7)}}}. As an example, a
 message which is `seen', has an attachment and is signed would have `asz' as its
 corresponding output string, while an encrypted new message would have `nx'.
 
-** -s, --sortfield=<field> and -z,--reverse
-specify the field to sort the search results by and the direction (i.e.,
+** -s, --sortfield _field_ and -z,--reverse
+Specify the field to sort the search results by and the direction (i.e.,
 `reverse' means that the sort should be reverted - Z-A). Examples include:
 
 #+begin_example
@@ -113,16 +113,16 @@ Note, if you specify a sortfield, by default, messages are sorted in reverse
 (descending) order (e.g., from lowest to highest). This is usually a good
 choice, but for dates it may be more useful to sort in the opposite direction.
 
-** -n, --maxnum=<number>
-If > 0, display maximally that number of entries. If not specified, all matching
-entries are displayed.
+** -n, --maxnum _number_
+If _number_ > 0, display maximally that number of entries. If not specified, all
+matching entries are displayed.
 
-** --summary-len=<number>
-If > 0, use that number of lines of the message to provide a summary.
+** --summary-len _number_
+If _number_ > 0, use that number of lines of the message to provide a summary.
 
-** --format=<plain|links|xml|sexp>
+** --format plain|links|xml|sexp
 
-output results in the specified format:
+Output results in the specified format.
 
 - The default is *plain*, i.e normal output with one line per message.
 - *links* outputs the results as a maildir with symbolic links to the found
@@ -130,10 +130,10 @@ output results in the specified format:
   information).
 - *xml* formats the search results as XML.
 - *sexp* formats the search results as an s-expression as used in Lisp programming
-  environments
+  environments.
 
-** --linksdir=<dir> and -c, --clearlinks
-when using *-format=links*, output the results as a maildir with symbolic links to
+** --linksdir _dir_ and -c, --clearlinks
+When using *--format=links*, output the results as a maildir with symbolic links to
 the found messages. This enables easy integration with mail-clients (see below
 for more information). *mu* will create the maildir if it does not exist yet.
 
@@ -150,9 +150,9 @@ exist yet, it will be created. Note: when *mu* creates a Maildir for these links
 it automatically inserts a _.noindex_ file, to exclude the directory from *mu
 index*.
 
-** --after=<timestamp>
-only show messages whose message files were last modified (*mtime*) after
-=<timestamp>=. =<timestamp>= is a UNIX *time_t* value, the number of seconds since
+** --after _timestamp_
+Only show messages whose message files were last modified (*mtime*) after
+_timestamp_. _timestamp_ is a UNIX *time_t* value, the number of seconds since
 1970-01-01 (in UTC).
 
 From the command line, you can use the *date* command to get this value. For
@@ -163,8 +163,8 @@ could specify
 #+end_example
 This is assuming the GNU *date* command.
 
-** --exec=<command>
-the *--exec* coption causes the =command= to be executed on each matched message;
+** --exec _command_
+The *--exec* coption causes _command_ to be executed on each matched message;
 for example, to see the raw text of all messages matching `milkshake', you could
 use:
 #+begin_example
@@ -175,24 +175,23 @@ which is roughly equivalent to:
 $ mu find milkshake --fields="l" | xargs less
 #+end_example
 
-** -b, --bookmark=<bookmark>
-use a bookmarked search query. Using this option, a query from your bookmark
+** -b, --bookmark _bookmark_
+Use a bookmarked search query. Using this option, a query from your bookmark
 file will be prepended to other search queries. See
 {{{man-link(mu-bookmarks,5)}}} for the details of the bookmarks file.
 
-
 ** -u, --skip-dups
-whenever there are multiple messages with the same message-id field, only show
+Whenever there are multiple messages with the same message-id field, only show
 the first one. This is useful if you have copies of the same message, which is a
 common occurrence when using e.g. Gmail together with *offlineimap*.
 
 ** -r, --include-related
-include messages being referred to by the matched messages -- i.e.. include
+Include messages being referred to by the matched messages -- i.e.. include
 messages that are part of the same message thread as some matched messages. This
 is useful if you want Gmail-style `conversations'.
 
 ** -t, --threads
-show messages in a `threaded' format -- that is, with indentation and arrows
+Show messages in a `threaded' format -- that is, with indentation and arrows
 showing the conversation threads in the list of matching messages. When using
 this, sorting is chronological (by date), based on the newest message in a
 thread.
@@ -215,7 +214,7 @@ The algorithm used for determining the threads is based on Jamie Zawinksi's
 description: http://www.jwz.org/doc/threading.html
 
 ** -a,--analyze
-instead of executing the query, analyze it by show the parse-tree s-expression
+Instead of executing the query, analyze it by show the parse-tree s-expression
 and a stringified version of the Xapian query. This can help users to determine
 how *mu* interprets some query.
 

--- a/man/mu-find.1.org
+++ b/man/mu-find.1.org
@@ -45,11 +45,11 @@ For details on the possible queries, see *mu-query(7)*.
 * FIND OPTIONS
 
 Note, some of the important options are described in the *mu*(1) man-page
-and not here, as they apply to multiple mu-commands.
+and not here, as they apply to multiple *mu* commands.
 
 The *find*-command has various options that influence the way *mu* displays the
-results. If you don't specify anything, the defaults are ~fields="d f s"~,
-~--sortfield=date~ and ~--reverse~.
+results. If you don't specify anything, the defaults are *--fields="d f s"*,
+*--sortfield=date* and *--reverse*.
 
 ** -f, --fields=<fields>
 specifies a string that determines which fields are shown in the output. This
@@ -79,7 +79,7 @@ parameters, such as:
 	m       *m*aildir
 #+end_example
 
-For the complete list, try the command: ~mu info fields~.
+For the complete list, try the command: *mu info fields*.
 
 The message flags are described in *mu-query(7)*. As an example, a message which
 is `seen', has an attachment and is signed would have `asz' as its corresponding
@@ -100,7 +100,7 @@ specify the field to sort the search results by and the direction (i.e.,
 	to,t            To:-recipient(s)
 #+end_example
 
-For the complete list, try the command: ~mu info fields~.
+For the complete list, try the command: *mu info fields*.
 
 Thus, for example, to sort messages by date, you could specify:
 
@@ -132,11 +132,11 @@ output results in the specified format:
   environments
 
 ** --linksdir=<dir> and -c, --clearlinks
-when using ~-format=links~, output the results as a maildir with symbolic links to
+when using *-format=links*, output the results as a maildir with symbolic links to
 the found messages. This enables easy integration with mail-clients (see below
 for more information). *mu* will create the maildir if it does not exist yet.
 
-If you specify ~--clearlinks~, existing symlinks will be cleared from the target
+If you specify *--clearlinks*, existing symlinks will be cleared from the target
 directories; this allows for re-use of the same maildir. However, this option
 will delete any symlink it finds, so be careful.
 
@@ -163,7 +163,7 @@ could specify
 This is assuming the GNU *date* command.
 
 ** --exec=<command>
-the ~--exec~ coption causes the =command= to be executed on each matched message;
+the *--exec* coption causes the =command= to be executed on each matched message;
 for example, to see the raw text of all messages matching `milkshake', you could
 use:
 #+begin_example
@@ -216,7 +216,7 @@ description: http://www.jwz.org/doc/threading.html
 ** -a,--analyze
 instead of executing the query, analyze it by show the parse-tree s-expression
 and a stringified version of the Xapian query. This can help users to determine
-how ~mu~ interprets some query.
+how *mu* interprets some query.
 
 The output of this command are differ between versions, but should be helpful
 nevertheless.

--- a/man/mu-find.1.org
+++ b/man/mu-find.1.org
@@ -7,7 +7,7 @@ mu-find - find e-mail messages in the *mu* database.
 
 * SYNOPSIS
 
-*mu [common-options] find [options] <search expression>*
+*mu* [​_COMMON-OPTIONS_​] *find* [​_OPTIONS_​] _SEARCH_EXPRESSION_
 
 * DESCRIPTION
 

--- a/man/mu-find.1.org
+++ b/man/mu-find.1.org
@@ -1,5 +1,6 @@
 #+TITLE: MU FIND
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -12,12 +13,12 @@ mu-find - find e-mail messages in the *mu* database.
 * DESCRIPTION
 
 *mu find* is the *mu* command for searching e-mail message that were stored earlier
-using *mu index(1)*.
+using {{{man-link(mu index,1)}}}.
 
 * SEARCHING MAIL
 
 *mu find* starts a search for messages in the database that match some search
-pattern. The search patterns are described in detail in *mu-query(7)*.
+pattern. The search patterns are described in detail in {{{man-link(mu-query,7)}}}.
 
 For example:
 
@@ -40,12 +41,12 @@ The search pattern is taken as a command-line parameter. If the search
 parameter consists of multiple parts (as in the example) they are
 treated as if there were a logical *and* between them.
 
-For details on the possible queries, see *mu-query(7)*.
+For details on the possible queries, see {{{man-link(mu-query,7)}}}.
 
 * FIND OPTIONS
 
-Note, some of the important options are described in the *mu*(1) man-page
-and not here, as they apply to multiple *mu* commands.
+Note, some of the important options are described in the {{{man-link(mu*,1)}}}
+manual page and not here, as they apply to multiple *mu* commands.
 
 The *find*-command has various options that influence the way *mu* displays the
 results. If you don't specify anything, the defaults are *--fields="d f s"*,
@@ -81,9 +82,9 @@ parameters, such as:
 
 For the complete list, try the command: *mu info fields*.
 
-The message flags are described in *mu-query(7)*. As an example, a message which
-is `seen', has an attachment and is signed would have `asz' as its corresponding
-output string, while an encrypted new message would have `nx'.
+The message flags are described in {{{man-link(mu-query,7)}}}. As an example, a
+message which is `seen', has an attachment and is signed would have `asz' as its
+corresponding output string, while an encrypted new message would have `nx'.
 
 ** -s, --sortfield=<field> and -z,--reverse
 specify the field to sort the search results by and the direction (i.e.,
@@ -176,8 +177,8 @@ $ mu find milkshake --fields="l" | xargs less
 
 ** -b, --bookmark=<bookmark>
 use a bookmarked search query. Using this option, a query from your bookmark
-file will be prepended to other search queries. See *mu-bookmarks(5)* for the
-details of the bookmarks file.
+file will be prepended to other search queries. See
+{{{man-link(mu-bookmarks,5)}}} for the details of the bookmarks file.
 
 
 ** -u, --skip-dups
@@ -276,7 +277,7 @@ After restarting Wanderlust, the virtual folders should appear.
 
 * ENCODING
 
-*mu find* output is encoded according to the locale for =--format=plain= (the
+*mu find* output is encoded according to the locale for *--format=plain* (the
 default format), and UTF-8 for all other formats (=sexp=, =xml=).
 
 
@@ -311,4 +312,7 @@ taking the total number for 10 test runs.
 
 * SEE ALSO
 
-*mu(1)*, *mu-index(1)*, *mu-query(7)*, *mu-info(1)*
+{{{man-link(mu,1)}}},
+{{{man-link(mu-index,1)}}},
+{{{man-link(mu-query,7)}}},
+{{{man-link(mu-info,1)}}}

--- a/man/mu-help.1.org
+++ b/man/mu-help.1.org
@@ -7,7 +7,7 @@ mu-help - show help information about mu commands.
 
 * SYNOPSIS
 
-*mu [common-options] help [<command>]*
+*mu* [​_COMMON-OPTIONS_​] *help* [​_COMMAND_​]
 
 * DESCRIPTION
 

--- a/man/mu-help.1.org
+++ b/man/mu-help.1.org
@@ -11,7 +11,7 @@ mu-help - show help information about mu commands.
 
 * DESCRIPTION
 
-*mu help* provides help information about mu commands.
+*mu help* provides help information about *mu* commands.
 
 #+include: "common-options.inc" :minlevel 1
 

--- a/man/mu-index.1.org
+++ b/man/mu-index.1.org
@@ -7,7 +7,7 @@ mu-index - index e-mail messages stored in Maildirs
 
 * SYNOPSIS
 
-*mu [common-options] index*
+*mu* [​_COMMON-OPTIONS_​] *index*
 
 * DESCRIPTION
 

--- a/man/mu-index.1.org
+++ b/man/mu-index.1.org
@@ -22,27 +22,27 @@ database.
 *index* understands Maildirs as defined by Daniel Bernstein for
 {{{man-link(qmail,7)}}}. In addition, it understands recursive Maildirs
 (Maildirs within Maildirs), Maildir++. It also supports VFAT-based Maildirs
-which use =!= or =;= as the separators instead of =:=.
+which use *!* or *;* as the separators instead of *:*.
 
 E-mail messages which are not stored in something resembling a maildir
-leaf-directory (=cur= and =new=) are ignored, as are the cache directories for
-=notmuch= and =gnus=, and any dot-directory.
+leaf-directory (_cur_ and _new_) are ignored, as are the cache directories for
+_notmuch_ and _gnus_, and any dot-directory.
 
 Symlinks are followed, and the directories can be spread over multiple
 filesystems; however note that moving files around is much faster when multiple
 filesystems are not involved. Be careful to avoid self-referential symlinks!
 
-If there is a file called =.noindex= in a directory, the contents of that
+If there is a file called _.noindex_ in a directory, the contents of that
 directory and all of its subdirectories will be ignored. This can be useful to
 exclude certain directories from the indexing process, for example directories
 with spam-messages.
 
-If there is a file called =.noupdate= in a directory, the contents of that
+If there is a file called _.noupdate_ in a directory, the contents of that
 directory and all of its subdirectories will be ignored. This can be useful to
 speed up things you have some maildirs that never change.
 
-=.noupdate= does not affect already-indexed message: you can still search for
-them. =.noupdate= is ignored when you start indexing with an empty database (such
+_.noupdate_ does not affect already-indexed message: you can still search for
+them. _.noupdate_ is ignored when you start indexing with an empty database (such
 as directly after *mu init*).
 
 There also the option *--lazy-check* which can greatly speed up indexing; see

--- a/man/mu-index.1.org
+++ b/man/mu-index.1.org
@@ -1,5 +1,6 @@
 #+TITLE: MU INDEX
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -13,15 +14,15 @@ mu-index - index e-mail messages stored in Maildirs
 
 *mu index* is the *mu* command for scanning the contents of Maildir directories and
 storing the results in a Xapian database. The data can then be queried using
-*mu-find(1)*.
+{{{man-link(mu-find,1)}}}.
 
 Before the first time you run *mu index*, you must run *mu init* to initialize the
 database.
 
-*index* understands Maildirs as defined by Daniel Bernstein for *qmail(7)*. In
-addition, it understands recursive Maildirs (Maildirs within Maildirs),
-Maildir++. It also supports VFAT-based Maildirs which use =!= or =;= as the
-separators instead of =:=.
+*index* understands Maildirs as defined by Daniel Bernstein for
+{{{man-link(qmail,7)}}}. In addition, it understands recursive Maildirs
+(Maildirs within Maildirs), Maildir++. It also supports VFAT-based Maildirs
+which use =!= or =;= as the separators instead of =:=.
 
 E-mail messages which are not stored in something resembling a maildir
 leaf-directory (=cur= and =new=) are ignored, as are the cache directories for
@@ -215,4 +216,8 @@ least for now, the latest code is both the fastest and the most featureful!
 
 * SEE ALSO
 
-*maildir(5)*, *mu(1)*, *mu-init(1)*, *mu-find(1)*, *mu-cfind(1)*
+{{{man-link(maildir,5)}}},
+{{{man-link(mu,1)}}},
+{{{man-link(mu-init,1)}}},
+{{{man-link(mu-find,1)}}},
+{{{man-link(mu-cfind,1)}}}

--- a/man/mu-index.1.org
+++ b/man/mu-index.1.org
@@ -42,7 +42,7 @@ speed up things you have some maildirs that never change.
 
 =.noupdate= does not affect already-indexed message: you can still search for
 them. =.noupdate= is ignored when you start indexing with an empty database (such
-as directly after =mu init=).
+as directly after *mu init*).
 
 There also the option *--lazy-check* which can greatly speed up indexing; see
 below for details.
@@ -54,7 +54,7 @@ the `PERFORMANCE (i,ii,iii)' below for more information.
 
 The optional `phase two' of the indexing-process is the removal of messages from
 the database for which there is no longer a corresponding file in the Maildir.
-If you do not want this, you can use ~-n~, ~--nocleanup~.
+If you do not want this, you can use *-n*, *--nocleanup*.
 
 When *mu index* catches one of the signals *SIGINT*, *SIGHUP* or *SIGTERM* (e.g., when
 you press Ctrl-C during the indexing process), it attempts to shutdown
@@ -71,7 +71,7 @@ in lazy-check mode, *mu* does not consider messages for which the time-stamp
 indexing run. This is much faster than the non-lazy check, but won't update
 messages that have change (rather than having been added or removed), since
 merely editing a message does not update the directory time-stamp. Of course,
-you can run *mu-index* occasionally without ~--lazy-check~, to pick up such
+you can run *mu-index* occasionally without *--lazy-check*, to pick up such
 messages.
 
 ** --nocleanup

--- a/man/mu-index.1.org
+++ b/man/mu-index.1.org
@@ -66,8 +66,7 @@ terminate immediately.
 * INDEX OPTIONS
 
 ** --lazy-check
-
-in lazy-check mode, *mu* does not consider messages for which the time-stamp
+In lazy-check mode, *mu* does not consider messages for which the time-stamp
 (ctime) of the directory they reside in has not changed since the previous
 indexing run. This is much faster than the non-lazy check, but won't update
 messages that have change (rather than having been added or removed), since
@@ -76,12 +75,10 @@ you can run *mu-index* occasionally without *--lazy-check*, to pick up such
 messages.
 
 ** --nocleanup
-
-disable the database cleanup that *mu* does by default after indexing.
+Disable the database cleanup that *mu* does by default after indexing.
 
 ** --reindex
-
-perform a complete reindexing of all the messages in the maildir.
+Perform a complete reindexing of all the messages in the maildir.
 
 #+include: "muhome.inc" :minlevel 2
 

--- a/man/mu-info.1.org
+++ b/man/mu-info.1.org
@@ -1,5 +1,6 @@
 #+TITLE: MU INFO
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -29,4 +30,4 @@ delayed due to database caching.
 
 * SEE ALSO
 
-*mu(1)*
+{{{man-link(mu,1)}}}

--- a/man/mu-info.1.org
+++ b/man/mu-info.1.org
@@ -7,7 +7,7 @@ mu-info  - show information
 
 * SYNOPSIS
 
-*mu [common options] info [<topic>]*
+*mu* [​_COMMON OPTIONS_​] *info* [​_TOPIC_​]
 
 * DESCRIPTION
 

--- a/man/mu-info.1.org
+++ b/man/mu-info.1.org
@@ -11,14 +11,14 @@ mu-info  - show information
 
 * DESCRIPTION
 
-~mu info~ is the ~mu~ command for getting information about various topics:
+*mu info* is the *mu* command for getting information about various topics:
 
-- *mu*: general mu build information (default)
+- *mu*: general *mu* build information (default)
 - *store*: information about the message store
 - *fields*: table with all the query fields and flags
 - *maildirs*: list all maildirs under the store's root-maildir
 
-Note that while running (e.g. ~mu4e~), some of the ~store~ information can be
+Note that while running (e.g. ~mu4e~), some of the *store* information can be
 delayed due to database caching.
 
 #+include: "common-options.inc" :minlevel 1

--- a/man/mu-init.1.org
+++ b/man/mu-init.1.org
@@ -1,5 +1,6 @@
 #+TITLE: MU INIT
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -30,19 +31,20 @@ performed).
 specifies that some e-mail address is `my-address' (the option can be used
 multiple times). Any message in which at least one of the contact fields
 contains such an address is considered a `personal' messages; this can then be
-used for filtering in *mu-find(1)*, *mu-cfind(1)* and *mu4e*, e.g. to filter-out
-mailing list messages.
+used for filtering in {{{man-link(mu-find,1)}}}, {{{man-link(mu-cfind,1)}}} and
+*mu4e*, e.g. to filter-out mailing list messages.
 
 =<email-address-or-regex>= can be either a plain e-mail address (such as
-*foo@example.com*), or a basic PCRE regular-expression (see *pcre(3)* for details),
-wrapped in */* (such as =/foo-.*@example\\.com/=). Depending on your shell, the
-argument may need to be quoted.
+*foo@example.com*), or a basic PCRE regular-expression (see
+{{{man-link(pcre,3)}}} for details), wrapped in */* (such as
+=/foo-.*@example\\.com/=). Depending on your shell, the argument may need to be
+quoted.
 
 ** --ignored-address=<email-address-or-regex>
 
 specifies that some e-mail address is to be ignored from the contacts-cache (the
 option can be used multiple times). Such addresses then cannot be found with
-*mu-cfind(1)* or in the Mu4e contacts cache.
+{{{man-link(mu-cfind,1)}}} or in the Mu4e contacts cache.
 
 =<my-email-address>= can be either a plain e-mail address or a regexp, just like
 for the =--my-address= option.
@@ -97,4 +99,7 @@ $ mu init --maildir=~/Maildir --my-address=alice@example.com --my-address=bob@ex
 
 * SEE ALSO
 
-*mu-index(1)*, *mu-find(1)*, *mu-cfind(1)*, *pcre(3)*
+{{{man-link(mu-index,1)}}},
+{{{man-link(mu-find,1)}}},
+{{{man-link(mu-cfind,1)}}},
+{{{man-link(pcre,3)}}}

--- a/man/mu-init.1.org
+++ b/man/mu-init.1.org
@@ -3,7 +3,7 @@
 
 * NAME
 
-mu-init - initialize the mu message database
+mu-init - initialize the *mu* message database
 
 * SYNOPSIS
 
@@ -11,7 +11,7 @@ mu-init - initialize the mu message database
 
 * DESCRIPTION
 
-*mu init* is the subcommand for setting up the mu message database. After *mu init*
+*mu init* is the subcommand for setting up the *mu* message database. After *mu init*
 has completed, you can run *mu index*
 
 * INIT OPTIONS
@@ -21,7 +21,7 @@ has completed, you can run *mu index*
 use =<maildir>= as the root-maildir.
 
 By default, *mu* uses the *MAILDIR* environment; if it is not set, it uses =~/Maildir=
-if it is an existing directory. If neither of those can be used, the ~--maildir~
+if it is an existing directory. If neither of those can be used, the *--maildir*
 option is required; it must be an absolute path (but ~~/~ expansion is
 performed).
 
@@ -69,7 +69,7 @@ Chinese/Japanese/Korean. See *NGRAM SUPPORT* below for details.
 ** --reinit
 
 reinitialize the database from an earlier version; that is, create a new empty
-database with the existing settings. This cannot be combined with the other ~init~
+database with the existing settings. This cannot be combined with the other *init*
 options.
 
 #+include: "muhome.inc" :minlevel 2

--- a/man/mu-init.1.org
+++ b/man/mu-init.1.org
@@ -7,7 +7,7 @@ mu-init - initialize the mu message database
 
 * SYNOPSIS
 
-*mu [common-options] init [options]*
+*mu* [​_COMMON-OPTIONS_​] *init* [​_OPTIONS_​]
 
 * DESCRIPTION
 

--- a/man/mu-init.1.org
+++ b/man/mu-init.1.org
@@ -21,7 +21,7 @@ has completed, you can run *mu index*
 
 use =<maildir>= as the root-maildir.
 
-By default, *mu* uses the *MAILDIR* environment; if it is not set, it uses =~/Maildir=
+By default, *mu* uses the *MAILDIR* environment; if it is not set, it uses _~/Maildir_
 if it is an existing directory. If neither of those can be used, the *--maildir*
 option is required; it must be an absolute path (but ~~/~ expansion is
 performed).
@@ -47,7 +47,7 @@ option can be used multiple times). Such addresses then cannot be found with
 {{{man-link(mu-cfind,1)}}} or in the Mu4e contacts cache.
 
 =<my-email-address>= can be either a plain e-mail address or a regexp, just like
-for the =--my-address= option.
+for the *--my-address* option.
 
 ** --max-message-size=<size>
 
@@ -85,7 +85,7 @@ query-parsing; it is not enabled by default, and is recommended only if you need
 to search for messages written in such languages.
 
 When enabled, *mu* automatically uses ngrams automatically. Xapian environment
-variables such as ~XAPIAN_CJK_NGRAM~ are ignored.
+variables such as *XAPIAN_CJK_NGRAM* are ignored.
 
 #+include: "exit-code.inc" :minlevel 1
 

--- a/man/mu-init.1.org
+++ b/man/mu-init.1.org
@@ -17,60 +17,53 @@ has completed, you can run *mu index*
 
 * INIT OPTIONS
 
-** -m, --maildir=<maildir>
-
-use =<maildir>= as the root-maildir.
+** -m, --maildir _maildir_
+Use _maildir_ as the root-maildir.
 
 By default, *mu* uses the *MAILDIR* environment; if it is not set, it uses _~/Maildir_
 if it is an existing directory. If neither of those can be used, the *--maildir*
 option is required; it must be an absolute path (but ~~/~ expansion is
 performed).
 
-** --my-address=<email-address-or-regex>
-
-specifies that some e-mail address is `my-address' (the option can be used
+** --my-address _email-address-or-regex_
+Specifies that some e-mail address is `my-address' (the option can be used
 multiple times). Any message in which at least one of the contact fields
 contains such an address is considered a `personal' messages; this can then be
 used for filtering in {{{man-link(mu-find,1)}}}, {{{man-link(mu-cfind,1)}}} and
 *mu4e*, e.g. to filter-out mailing list messages.
 
-=<email-address-or-regex>= can be either a plain e-mail address (such as
+_email-address-or-regex_ can be either a plain e-mail address (such as
 *foo@example.com*), or a basic PCRE regular-expression (see
 {{{man-link(pcre,3)}}} for details), wrapped in */* (such as
 =/foo-.*@example\\.com/=). Depending on your shell, the argument may need to be
 quoted.
 
-** --ignored-address=<email-address-or-regex>
-
-specifies that some e-mail address is to be ignored from the contacts-cache (the
+** --ignored-address _email-address-or-regex_
+Specifies that some e-mail address is to be ignored from the contacts-cache (the
 option can be used multiple times). Such addresses then cannot be found with
 {{{man-link(mu-cfind,1)}}} or in the Mu4e contacts cache.
 
-=<my-email-address>= can be either a plain e-mail address or a regexp, just like
+_my-email-address_ can be either a plain e-mail address or a regexp, just like
 for the *--my-address* option.
 
-** --max-message-size=<size>
-
-specifies the maximum size for an e-mail message. Usually, the default of
+** --max-message-size _size_
+Specifies the maximum size for an e-mail message. Usually, the default of
 100000000 bytes should be fine.
 
-** --batch-size=<size>
-
-the number of changes after which they are committed to the database; decreasing
+** --batch-size _size_
+The number of changes after which they are committed to the database; decreasing
 the value reduces the memory requirements, at the cost of make indexing
 substantially slower. Usually, the default of 250000 should be fine.
 
 Batch-size 0 is interpreted as `use the default'.
 
 ** --support-ngrams
-
-whether to enable support for using ngrams in indexing and query parsing; this
+Whether to enable support for using ngrams in indexing and query parsing; this
 can be useful for languages without explicit word breaks, such as
 Chinese/Japanese/Korean. See *NGRAM SUPPORT* below for details.
 
 ** --reinit
-
-reinitialize the database from an earlier version; that is, create a new empty
+Reinitialize the database from an earlier version; that is, create a new empty
 database with the existing settings. This cannot be combined with the other *init*
 options.
 

--- a/man/mu-mkdir.1.org
+++ b/man/mu-mkdir.1.org
@@ -14,7 +14,7 @@ mu-mkdir - create a new Maildir
 *mu mkdir* is the command for creating Maildirs as per *maildir(5)*. A maildir is a
 a directory with subdirectories ~new~, ~cur~ and ~tmp~.
 
-The command does not use the mu database.
+The command does not use the *mu* database.
 
 If creation fails for any reason, *no* attempt is made to remove any parts that
 were created. This is for safety reasons.

--- a/man/mu-mkdir.1.org
+++ b/man/mu-mkdir.1.org
@@ -23,8 +23,8 @@ were created. This is for safety reasons.
 
 * MKDIR OPTIONS
 
-** --mode=<mode>
-set the file access mode for the new maildir(s) as in
+** --mode _mode_
+Set the file access mode for the new maildir(s) as in
 {{{man-link(chmod,1)}}}. The default is 0755.
 
 #+include: "common-options.inc" :minlevel 1

--- a/man/mu-mkdir.1.org
+++ b/man/mu-mkdir.1.org
@@ -1,5 +1,6 @@
 #+TITLE: MU MKDIR
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -11,8 +12,9 @@ mu-mkdir - create a new Maildir
 
 * DESCRIPTION
 
-*mu mkdir* is the command for creating Maildirs as per *maildir(5)*. A maildir is a
-a directory with subdirectories ~new~, ~cur~ and ~tmp~.
+*mu mkdir* is the command for creating Maildirs as per
+{{{man-link(maildir,5)}}}. A maildir is a a directory with subdirectories ~new~,
+~cur~ and ~tmp~.
 
 The command does not use the *mu* database.
 
@@ -22,8 +24,8 @@ were created. This is for safety reasons.
 * MKDIR OPTIONS
 
 ** --mode=<mode>
-set the file access mode for the new maildir(s) as in *chmod(1)*. The default
-is 0755.
+set the file access mode for the new maildir(s) as in
+{{{man-link(chmod,1)}}}. The default is 0755.
 
 #+include: "common-options.inc" :minlevel 1
 
@@ -39,4 +41,5 @@ creates three maildirs, =tom=, =dick= and =harry=.
 
 * SEE ALSO
 
-*maildir(5)*, *chmod(1)*
+{{{man-link(maildir,5)}}},
+{{{man-link(chmod,1)}}}

--- a/man/mu-mkdir.1.org
+++ b/man/mu-mkdir.1.org
@@ -13,8 +13,8 @@ mu-mkdir - create a new Maildir
 * DESCRIPTION
 
 *mu mkdir* is the command for creating Maildirs as per
-{{{man-link(maildir,5)}}}. A maildir is a a directory with subdirectories ~new~,
-~cur~ and ~tmp~.
+{{{man-link(maildir,5)}}}. A maildir is a a directory with subdirectories _new_,
+_cur_ and _tmp_.
 
 The command does not use the *mu* database.
 
@@ -35,7 +35,7 @@ set the file access mode for the new maildir(s) as in
 $ mu mkdir tom dick harry
 #+end_example
 
-creates three maildirs, =tom=, =dick= and =harry=.
+creates three maildirs, _tom_, _dick_ and _harry_.
 
 #+include: "prefooter.inc" :minlevel 1
 

--- a/man/mu-mkdir.1.org
+++ b/man/mu-mkdir.1.org
@@ -7,7 +7,7 @@ mu-mkdir - create a new Maildir
 
 * SYNOPSIS
 
-*mu [common-options] mkdir [options] <dir> [<dirs>]*
+*mu* [​_COMMON-OPTIONS_​] *mkdir* [​_OPTIONS_​] _DIR_...
 
 * DESCRIPTION
 

--- a/man/mu-move.1.org
+++ b/man/mu-move.1.org
@@ -1,5 +1,6 @@
 #+TITLE: MU MOVE
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -28,7 +29,8 @@ specify the new message flags. See *FLAGS* for details.
 ** --change-name
 
 change the basename of the message file when moving; this can be useful when
-using some external tools such as *mbsync(1)* which otherwise get confused
+using some external tools such as {{{man-link(mbsync,1)}}} which otherwise get
+confused
 
 ** --update-dups
 
@@ -48,8 +50,8 @@ use a dry-run to predict the exact name when doing a `real' run.
 
 * FLAGS
 
-(Note: if you are not familiar with Maildirs, please refer to the *maildir(5)*
-man-page, or see http://cr.yp.to/proto/maildir.html)
+(Note: if you are not familiar with Maildirs, please refer to the
+{{{man-link(maildir,5)}}} man-page, or see http://cr.yp.to/proto/maildir.html)
 
 The message flags specify the Maildir-metadata for a message and are represented
 by uppercase letters at the end of the message file name for all `non-new'
@@ -114,4 +116,4 @@ $ mu move /home/user/Maildir/project1/cur/1695559560.a73985881f4611ac2.hostname!
 
 * SEE ALSO
 
-*maildir(5)*
+{{{man-link(maildir,5)}}}

--- a/man/mu-move.1.org
+++ b/man/mu-move.1.org
@@ -7,7 +7,7 @@ mu-move - move a message file or change its flags
 
 * SYNOPSIS
 
-*mu [common-options] move [options] <src> [--flags=<flags>] [<target>]*
+*mu* [​_COMMON-OPTIONS_​] *move* [​_OPTIONS_​] _SRC_ [--flags=​_FLAGS_​] [​_TARGET_​]
 
 * DESCRIPTION
 

--- a/man/mu-move.1.org
+++ b/man/mu-move.1.org
@@ -17,7 +17,7 @@ For any change, both the message file in the file system as well as its
 representation in the database are updated accordingly.
 
 The source message file and target-maildir must reside under the root-maildir
-for mu's database (see *mu info store*).
+for *mu*'s database (see *mu info store*).
 
 * MOVE OPTIONS
 
@@ -41,7 +41,7 @@ the source message.
 
 print the target filename(s), but don't change anything.
 
-Note that with the ~--change-name~, the target name is not constant, so you cannot
+Note that with the *--change-name*, the target name is not constant, so you cannot
 use a dry-run to predict the exact name when doing a `real' run.
 
 #+include: "common-options.inc" :minlevel 1
@@ -66,7 +66,7 @@ messages, i.e. messages that live in the ~cur/~ sub-directory of a Maildir.
 | T    | Trashed; to be deleted later       |
 
 New messages (in the ~new/~ sub-directory) do not have flags encoded in their
-file-name; but we *mu* uses `N' in the ~--flags~ to represent that:
+file-name; but we *mu* uses `N' in the *--flags* to represent that:
 
 #+ATTR_MAN: :disable-caption t
 | Flag | Meaning |
@@ -81,18 +81,18 @@ flags.
 
 * ABSOLUTE AND RELATIVE FLAGS
 
-You can specify the flags with the ~--flags~ parameter, and do either with either
+You can specify the flags with the *--flags* parameter, and do either with either
 *absolute* or *relative* flags.
 
 Absolute flags just specify the new flags by their letters; e.g. to specify a
-/Trashed/, /Seen/, /Replied/ message, you'd use ~--flags STR~.
+/Trashed/, /Seen/, /Replied/ message, you'd use *--flags STR*.
 #+end_example
 
 Relative flags are relative to the current flags for some message, and each of
 the flags is prefixed with either ~+~ ("add this flag") or ~-~ ("remove this flag").
 
 So to add the /Seen/ flag and remove the /Draft/ flag from whatever the message
-already has, ~--flags +S-D~.
+already has, *--flags +S-D*.
 
 You cannot combine relative and relative flags.
 

--- a/man/mu-move.1.org
+++ b/man/mu-move.1.org
@@ -55,7 +55,7 @@ use a dry-run to predict the exact name when doing a `real' run.
 
 The message flags specify the Maildir-metadata for a message and are represented
 by uppercase letters at the end of the message file name for all `non-new'
-messages, i.e. messages that live in the ~cur/~ sub-directory of a Maildir.
+messages, i.e. messages that live in the _cur/_ sub-directory of a Maildir.
 
 #+ATTR_MAN: :disable-caption t
 | Flag | Meaning                            |
@@ -67,7 +67,7 @@ messages, i.e. messages that live in the ~cur/~ sub-directory of a Maildir.
 | S    | Seen message                       |
 | T    | Trashed; to be deleted later       |
 
-New messages (in the ~new/~ sub-directory) do not have flags encoded in their
+New messages (in the _new/_ sub-directory) do not have flags encoded in their
 file-name; but we *mu* uses `N' in the *--flags* to represent that:
 
 #+ATTR_MAN: :disable-caption t
@@ -77,7 +77,7 @@ file-name; but we *mu* uses `N' in the *--flags* to represent that:
 
 Thus, changing flags means changing the letters at the end of the message
 file-name, except when setting or removing the `N' (new) flag. Setting or
-un-setting the New flag causes the message is to be moved from ~cur/~ to ~new/~ or
+un-setting the New flag causes the message is to be moved from _cur/_ to _new/_ or
 vice-versa, respectively. When marking a message as New, it looses the other
 flags.
 
@@ -91,7 +91,7 @@ Absolute flags just specify the new flags by their letters; e.g. to specify a
 #+end_example
 
 Relative flags are relative to the current flags for some message, and each of
-the flags is prefixed with either ~+~ ("add this flag") or ~-~ ("remove this flag").
+the flags is prefixed with either *+* ("add this flag") or *-* ("remove this flag").
 
 So to add the /Seen/ flag and remove the /Draft/ flag from whatever the message
 already has, *--flags +S-D*.

--- a/man/mu-move.1.org
+++ b/man/mu-move.1.org
@@ -22,26 +22,22 @@ for *mu*'s database (see *mu info store*).
 
 * MOVE OPTIONS
 
-** --flags=<flags>
-
-specify the new message flags. See *FLAGS* for details.
+** --flags _flags_
+Specify the new message flags. See *FLAGS* for details.
 
 ** --change-name
-
-change the basename of the message file when moving; this can be useful when
+Change the basename of the message file when moving; this can be useful when
 using some external tools such as {{{man-link(mbsync,1)}}} which otherwise get
 confused
 
 ** --update-dups
-
-update the flags of duplicate messages too, where "duplicate messages" are
+Update the flags of duplicate messages too, where "duplicate messages" are
 defined as all message that share the same message-id. Note that the
 Draft/Flagged/Trashed flags are deliberately _not_ changed if you change those on
 the source message.
 
-** --dry-run,-n
-
-print the target filename(s), but don't change anything.
+** -n, --dry-run
+Print the target filename(s), but don't change anything.
 
 Note that with the *--change-name*, the target name is not constant, so you cannot
 use a dry-run to predict the exact name when doing a `real' run.

--- a/man/mu-query.7.org
+++ b/man/mu-query.7.org
@@ -7,7 +7,7 @@ mu-query - a language for finding messages in *mu* databases.
 
 * DESCRIPTION
 
-The mu query language is the language used by *mu find* and *mu4e* to find messages
+The *mu* query language is the language used by *mu find* and *mu4e* to find messages
 in *mu*'s Xapian database. The language is quite similar to Xapian's default
 query-parser, but is an independent implementation that is customized for the
 mu/mu4e use-case.
@@ -16,7 +16,7 @@ Here, we give a structured but informal overview of the query language and
 provide examples. As a companion to this, we recommend the *mu fields* and *mu
 flags* commands to get an up-to-date list of the available fields and flags.
 
-Furthermore, *mu find* provides the ~--analyze~ option, which shows how *mu*
+Furthermore, *mu find* provides the *--analyze* option, which shows how *mu*
 interprets your query; see the *ANALYZING QUERIES* section below.
 
 *NOTE:* if you use queries on the command-line (say, for *mu find*), you need to
@@ -116,7 +116,7 @@ Regular expressions can be useful, but are relatively slow.
 
 We already saw a number of search fields, such as *subject:* and *body:*. For the
 full table with all details, including single-char shortcuts, try the command:
-~mu info fields~.
+*mu info fields*.
 
 #+ATTR_MAN: :disable-caption t
 #+begin_example
@@ -153,7 +153,7 @@ full table with all details, including single-char shortcuts, try the command:
 +-----------+----------+----------+-----------------------------+
 #+end_example
 
-(*) The language code for the text-body if found. This works only if ~mu~ was
+(*) The language code for the text-body if found. This works only if *mu* was
 built with CLD2 support.
 
 There are also the special fields *contact:*, which matches all contact-fields
@@ -360,10 +360,10 @@ for "cld2-support*.
 * ANALZYING QUERIES
 
 Despite all the excellent documentation, in some cases it can be non-obvious how
-~mu~ interprets your query. For that, you can ask ~mu~ to analyze the query -- that
-is, show how ~mu~ interprets the query.
+*mu* interprets your query. For that, you can ask *mu* to analyze the query -- that
+is, show how *mu* interprets the query.
 
-This uses the the ~--analyze~ option to *mu find*.
+This uses the the *--analyze* option to *mu find*.
 #+begin_example
 $ mu find subject:wombat AND date:3m.. size:..2000  --analyze
 ,* query:

--- a/man/mu-query.7.org
+++ b/man/mu-query.7.org
@@ -1,5 +1,6 @@
 #+TITLE: MU QUERY
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -84,7 +85,7 @@ Note that a =pure not= - e.g. searching for *not apples* is quite a `heavy' quer
 
 * REGULAR EXPRESSIONS AND WILDCARDS
 
-The language supports matching basic PCRE regular expressions, see *pcre(3)*.
+The language supports matching basic PCRE regular expressions, see {{{man-link(pcre,3)}}}.
 
 Regular expressions are enclosed in *//*. Some examples:
 
@@ -381,4 +382,6 @@ interprets your query.
 
 * SEE ALSO
 
-*mu-find(1)*, *mu-info(1), *pcre(3)*
+{{{man-link(mu-find,1)}}},
+{{{man-link(mu-info,1)}}},
+{{{man-link(pcre,3)}}}

--- a/man/mu-query.7.org
+++ b/man/mu-query.7.org
@@ -281,7 +281,7 @@ prio:high
 
 The Maildir field describes the directory path starting *after* the Maildir root
 directory, and before the =/cur/= or =/new/= part. So, for example, if there's a
-message with the file name =~/Maildir/lists/running/cur/1234.213:2,=, you could
+message with the file name _~/Maildir/lists/running/cur/1234.213:2,_, you could
 find it (and all the other messages in that same maildir) with:
 #+begin_example
 maildir:/lists/running

--- a/man/mu-remove.1.org
+++ b/man/mu-remove.1.org
@@ -1,5 +1,6 @@
 #+TITLE: MU REMOVE
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -24,4 +25,6 @@ their filename. The files do not have to exist in the file system.
 
 * SEE ALSO
 
-*mu(1)*, *mu-index(1)*, *mu-add(1)*
+{{{man-link(mu,1)}}},
+{{{man-link(mu-index,1)}}},
+{{{man-link(mu-add,1)}}}

--- a/man/mu-remove.1.org
+++ b/man/mu-remove.1.org
@@ -7,7 +7,7 @@ mu-remove - remove messages from the database.
 
 * SYNOPSIS
 
-*mu [common-options] remove [options] <file> [<files>]*
+*mu* [​_COMMON-OPTIONS_​] *remove* [​_OPTIONS_​] _FILE_...
 
 * DESCRIPTION
 

--- a/man/mu-server.1.org
+++ b/man/mu-server.1.org
@@ -1,5 +1,6 @@
 #+TITLE:  MU-SERVER
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -88,4 +89,5 @@ time build/mu/mu server --allow-temp-file --eval '(find :query "\"\"" :include-r
 #+include: "prefooter.inc" :minlevel 1
 
 * SEE ALSO
-*mu(1)*
+
+{{{man-link(mu,1)}}}

--- a/man/mu-server.1.org
+++ b/man/mu-server.1.org
@@ -50,15 +50,12 @@ UTF-8 (in which the s-expressions are encoded).
 * SERVER OPTIONS
 
 ** --commands
+List available commands (and try with *--verbose*).
 
-List available commands (and try with *--verbose*)
-
-** --eval <expression>
-
-Evaluate a mu4e server s-expression
+** --eval _expression_
+Evaluate a mu4e server s-expression.
 
 ** --allow-temp-file
-
 If set, allow for the output of some commands to use temp-files rather than
 directly through the emacs process input/output. This is noticeably faster for
 commands with a lot of output, esp. when the the temp-file uses a in-memory

--- a/man/mu-server.1.org
+++ b/man/mu-server.1.org
@@ -3,7 +3,7 @@
 
 * NAME
 
-mu-server - the mu backend for the mu4e e-mail client
+mu-server - the *mu* backend for the mu4e e-mail client
 
 * SYNOPSIS
 
@@ -11,7 +11,7 @@ mu-server - the mu backend for the mu4e e-mail client
 
 * DESCRIPTION
 
-*mu server* starts a simple shell in which one can query and manipulate the mu
+*mu server* starts a simple shell in which one can query and manipulate the *mu*
 database. The output uses s-expressions. *mu server* is not meant for use by
 humans, except for debugging purposes. Instead, it is designed specifically for
 the *mu4e* e-mail client.
@@ -50,7 +50,7 @@ UTF-8 (in which the s-expressions are encoded).
 
 ** --commands
 
-List available commands (and try with ~--verbose~)
+List available commands (and try with *--verbose*)
 
 ** --eval <expression>
 
@@ -71,7 +71,7 @@ does; we take overall time of 50 such requests:
 #+begin_src sh
 time build/mu/mu server --allow-temp-file --eval '(find :query "\"\"" :include-related t :threads t :maxnum 50000)' >/dev/null
 #+end_src
-(and ~--allow-temp-file~ for 1.11)
+(and *--allow-temp-file* for 1.11)
 
 #+ATTR_MAN: :disable-caption t
 |       release | time (sec) |

--- a/man/mu-server.1.org
+++ b/man/mu-server.1.org
@@ -7,7 +7,7 @@ mu-server - the mu backend for the mu4e e-mail client
 
 * SYNOPSIS
 
-mu [common-options] server
+*mu* [​_COMMON-OPTIONS_​] *server*
 
 * DESCRIPTION
 

--- a/man/mu-verify.1.org
+++ b/man/mu-verify.1.org
@@ -1,5 +1,6 @@
 #+TITLE: MU VERIFY
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -21,8 +22,8 @@ standard-input.
 * VERIFY OPTIONS
 
 ** -r, --auto-retrieve
-attempt to find keys online (see the *auto-key-retrieve* option in the *gnupg(1)*
-documentation).
+attempt to find keys online (see the *auto-key-retrieve* option in the
+{{{man-link(gnupg,1)}}} documentation).
 
 ** decrypt
 attempt to decrypt the message
@@ -52,4 +53,4 @@ which does not give any output unless there is an error.
 
 * SEE ALSO
 
-*mu(1)*
+{{{man-link(mu,1)}}}

--- a/man/mu-verify.1.org
+++ b/man/mu-verify.1.org
@@ -22,11 +22,11 @@ standard-input.
 * VERIFY OPTIONS
 
 ** -r, --auto-retrieve
-attempt to find keys online (see the *auto-key-retrieve* option in the
+Attempt to find keys online (see the *auto-key-retrieve* option in the
 {{{man-link(gnupg,1)}}} documentation).
 
-** decrypt
-attempt to decrypt the message
+** --decrypt
+Attempt to decrypt the message.
 
 #+include: "common-options.inc" :minlevel 1
 

--- a/man/mu-verify.1.org
+++ b/man/mu-verify.1.org
@@ -7,7 +7,7 @@ mu-verify - verify message signatures and display information about them
 
 * SYNOPSIS
 
-*mu [common-options] verify [options] [<file> ... ]*
+*mu* [​_COMMON-OPTIONS_​] *verify* [​_OPTIONS_​] [​_FILE_...]
 
 * DESCRIPTION
 

--- a/man/mu-view.1.org
+++ b/man/mu-view.1.org
@@ -1,5 +1,6 @@
 #+TITLE: MU VIEW
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -51,4 +52,4 @@ attempt to retrieve crypto-keys automatically from the network, when needed.
 
 * SEE ALSO
 
-*mu(1)*
+{{{man-link(mu,1)}}}

--- a/man/mu-view.1.org
+++ b/man/mu-view.1.org
@@ -24,27 +24,27 @@ standard-input.
 
 * VIEW OPTIONS
 
-** --format,-o  = <format>
-use the given output format, one of:
+** -o, --format _format_
+Use the given output format, one of:
 
-- *plain* - use the plain-text body; this is the default
-- *html* - use the HTML body
-- *sexp* - show the S-expression representation of the message
+- *plain*: use the plain-text body; this is the default,
+- *html*: use the HTML body,
+- *sexp*: show the S-expression representation of the message.
 
-** --summary-len=<number>
-instead of displaying the full message, output a summary based upon the first
-=<number>= lines of the message.
+** --summary-len _number_
+Instead of displaying the full message, output a summary based upon the first
+_number_ lines of the message.
 
 ** --terminate
-terminate messages with \\​f (=form-feed=) characters when displaying them. This is
+Terminate messages with \\​f (=form-feed=) characters when displaying them. This is
 useful when you want to further process them.
 
 ** --decrypt
-attempt to decrypt encrypted message bodies. This is only possible if *mu*
+Attempt to decrypt encrypted message bodies. This is only possible if *mu*
 was built with crypto-support.
 
 ** --auto-retrieve
-attempt to retrieve crypto-keys automatically from the network, when needed.
+Attempt to retrieve crypto-keys automatically from the network, when needed.
 
 #+include: "common-options.inc" :minlevel 1
 

--- a/man/mu-view.1.org
+++ b/man/mu-view.1.org
@@ -48,7 +48,7 @@ attempt to retrieve crypto-keys automatically from the network, when needed.
 
 #+include: "common-options.inc" :minlevel 1
 
-* BUGS
+#+include: "bugs.inc" :minlevel 1
 
 * SEE ALSO
 

--- a/man/mu-view.1.org
+++ b/man/mu-view.1.org
@@ -26,9 +26,9 @@ standard-input.
 ** --format,-o  = <format>
 use the given output format, one of:
 
-- ~plain~ - use the plain-text body; this is the default
-- ~html~ - use the HTML body
-- ~sexp~ - show the S-expression representation of the message
+- *plain* - use the plain-text body; this is the default
+- *html* - use the HTML body
+- *sexp* - show the S-expression representation of the message
 
 ** --summary-len=<number>
 instead of displaying the full message, output a summary based upon the first

--- a/man/mu-view.1.org
+++ b/man/mu-view.1.org
@@ -7,7 +7,7 @@ mu-view - display an e-mail message file
 
 * SYNOPSIS
 
-mu [common options] view [options] [<file> ...]
+*mu* [​_COMMON OPTIONS_​] *view* [​_OPTIONS_​] [​_FILE_...]
 
 * DESCRIPTION
 

--- a/man/mu-view.1.org
+++ b/man/mu-view.1.org
@@ -48,7 +48,7 @@ attempt to retrieve crypto-keys automatically from the network, when needed.
 
 #+include: "common-options.inc" :minlevel 1
 
-#+include: "bugs.inc" :minlevel 1
+#+include: "prefooter.inc" :minlevel 1
 
 * SEE ALSO
 

--- a/man/mu-view.1.org
+++ b/man/mu-view.1.org
@@ -13,7 +13,7 @@ mu-view - display an e-mail message file
 * DESCRIPTION
 
 *mu view* is the *mu* command for displaying e-mail message files. It works on
-message files and does =not= require the message to be indexed in the database.
+message files and does _not_ require the message to be indexed in the database.
 
 The command shows some common headers (From:, To:, Cc:, Bcc:, Subject: and
 Date:), the list of attachments and either the plain-text or html body of the

--- a/man/mu.1.org
+++ b/man/mu.1.org
@@ -8,7 +8,7 @@ index and search e-mail messages.
 
 * SYNOPSIS
 
-~mu~ [COMMON-OPTIONS] [[COMMAND] [COMMAND-OPTIONS]]
+*mu* [​_COMMON-OPTIONS_​] [[​_COMMAND_​] [​_COMMAND-OPTIONS_​]]
 
 For information about the common options, see *COMMON OPTIONS*.
 

--- a/man/mu.1.org
+++ b/man/mu.1.org
@@ -14,69 +14,69 @@ For information about the common options, see *COMMON OPTIONS*.
 
 * DESCRIPTION
 
-~mu~ is the general command that shows help about the specific commands:
+*mu* is the general command that shows help about the specific commands:
 
-- ~add~:  add specific messages to the database.
-- ~cfind~: find contacts
-- ~extract~: extract attachments and other MIME-parts
-- ~find~: find messages in the database
-- ~help~: get help for some command
-- ~index~: (re)index the messages in a Maildir
-- ~info~: show information about the mu database
-- ~init~: initialize the mu database
-- ~mkdir~: create a new Maildir
-- ~remove~: remove specific messages from the database
-- ~server~: start a server process (for ~mu4e~-internal use)
-- ~view~: view a specific message
+- *add*:  add specific messages to the database.
+- *cfind*: find contacts
+- *extract*: extract attachments and other MIME-parts
+- *find*: find messages in the database
+- *help*: get help for some command
+- *index*: (re)index the messages in a Maildir
+- *info*: show information about the *mu* database
+- *init*: initialize the *mu* database
+- *mkdir*: create a new Maildir
+- *remove*: remove specific messages from the database
+- *server*: start a server process (for ~mu4e~-internal use)
+- *view*: view a specific message
 
-Each of the commands have their own manpage ~mu-<command>~.
+Each of the commands have their own manpage *mu-<command>*.
 
-~mu~ is a set of tools for dealing with Maildirs and the e-mail messages
+*mu* is a set of tools for dealing with Maildirs and the e-mail messages
 in them.
 
-~mu~'s main purpose is to enable searching of e-mail messages. It
+*mu*'s main purpose is to enable searching of e-mail messages. It
 does so by periodically scanning a Maildir directory tree and
 analyzing the e-mail messages found (this is called `indexing'). The
 results of this analysis are stored in a database, which can then be
 queried.
 
-In addition to indexing and searching, ~mu~ also offers
+In addition to indexing and searching, *mu* also offers
 functionality for viewing messages, extracting attachments and
 creating maildirs, and searching and exporting contact information.
 
-~mu~ can be used from the command line or can be integrated with various
+*mu* can be used from the command line or can be integrated with various
 e-mail clients.
 
 This manpage gives a general overview of the available commands
-(~index~, ~find~, etc.); each ~mu~ command has its own
+(*index*, *find*, etc.); each *mu* command has its own
 man-page as well.
 
 * COLORS
 
-Some ~mu~ commands support colorized output, and do so by default. If you don't
-want colors, you can use ~--nocolor~.
+Some *mu* commands support colorized output, and do so by default. If you don't
+want colors, you can use *--nocolor*.
 
 * ENCODING
 
-~mu~'s output is in the current locale, with the exceptions of the output
+*mu*'s output is in the current locale, with the exceptions of the output
 specifically meant for output to UTF8-encoded files. In practice, this means
-that the output of commands ~index~, ~view~, ~extract~ is always encoded according to
+that the output of commands *index*, *view*, *extract* is always encoded according to
 the current locale.
 
-The same is true for ~find~ and ~cfind~, with some exceptions, where
+The same is true for *find* and *cfind*, with some exceptions, where
 the output is always UTF-8, regardless of the locale:
 
-- For ~cfind~ the exception is ~--format=bbdb~. This is hard-coded to UTF-8, and as
+- For *cfind* the exception is *--format=bbdb*. This is hard-coded to UTF-8, and as
   such specified in the output-file, so emacs/bbdb can handle it correctly
   without guessing.
-- For ~find~ the output is encoded according the locale for ~--format=plain~ (the
+- For *find* the output is encoded according the locale for *--format=plain* (the
   default), and UTF-8 for all other formats.
 
 * DATABASE AND FILE
 
-The ~index~, ~find~, and ~cfind~ commands work with the database, while the other
-ones work on individual mail files. Hence, running ~view~, ~mkdir~ and ~extract~ does
-not require the mu database.
+The *index*, *find*, and *cfind* commands work with the database, while the other
+ones work on individual mail files. Hence, running *view*, *mkdir* and *extract* does
+not require the *mu* database.
 
 #+include: "common-options.inc" :minlevel 1
 

--- a/man/mu.1.org
+++ b/man/mu.1.org
@@ -1,5 +1,6 @@
 #+TITLE: MU
 #+MAN_CLASS_OPTIONS: :section-id "@SECTION_ID@" :date "@MAN_DATE@"
+#+include: macros.inc
 
 * NAME
 
@@ -85,6 +86,18 @@ not require the *mu* database.
 #+include: "prefooter.inc" :minlevel 1
 
 * SEE ALSO
-~mu-add(1)~, ~mu-cfind(1)~, ~mu-extract(1)~, ~mu-find(1)~, ~mu-help(1)~, ~mu-index(1)~,
-~mu-info(1)~, ~mu-init(1)~, ~mu-mkdir(1)~, ~mu-remove(1)~, ~mu-server(1)~, ~mu-view(1)~,
-~mu-query(7)~, ~mu-easy(1)~
+
+{{{man-link(mu-add,1)}}},
+{{{man-link(mu-cfind,1)}}},
+{{{man-link(mu-extract,1)}}},
+{{{man-link(mu-find,1)}}},
+{{{man-link(mu-help,1)}}},
+{{{man-link(mu-index,1)}}},
+{{{man-link(mu-info,1)}}},
+{{{man-link(mu-init,1)}}},
+{{{man-link(mu-mkdir,1)}}},
+{{{man-link(mu-remove,1)}}},
+{{{man-link(mu-server,1)}}},
+{{{man-link(mu-view,1)}}},
+{{{man-link(mu-query,7)}}},
+{{{man-link(mu-easy,1)}}}

--- a/man/muhome.inc
+++ b/man/muhome.inc
@@ -2,7 +2,7 @@
 use a non-default directory to store and read the database, write the logs, etc.
 By default, *mu* uses the XDG Base Directory Specification (e.g. on GNU/Linux this
 defaults to =~/.cache/mu= and =~/.config/mu=). Earlier versions of *mu* defaulted to
-=~/.mu=, which now requires =--muhome=~/.mu=.
+=~/.mu=, which now requires *--muhome=~/.mu*.
 
 The environment variable ~MUHOME~ can be used as an alternative to *--muhome*. The
 latter has precedence.

--- a/man/muhome.inc
+++ b/man/muhome.inc
@@ -1,10 +1,10 @@
 ** --muhome
 use a non-default directory to store and read the database, write the logs, etc.
-By default, ~mu~ uses the XDG Base Directory Specification (e.g. on GNU/Linux this
-defaults to =~/.cache/mu= and =~/.config/mu=). Earlier versions of ~mu~ defaulted to
+By default, *mu* uses the XDG Base Directory Specification (e.g. on GNU/Linux this
+defaults to =~/.cache/mu= and =~/.config/mu=). Earlier versions of *mu* defaulted to
 =~/.mu=, which now requires =--muhome=~/.mu=.
 
-The environment variable ~MUHOME~ can be used as an alternative to ~--muhome~. The
+The environment variable ~MUHOME~ can be used as an alternative to *--muhome*. The
 latter has precedence.
 
 # Local Variables:

--- a/man/muhome.inc
+++ b/man/muhome.inc
@@ -1,5 +1,5 @@
 ** --muhome
-use a non-default directory to store and read the database, write the logs, etc.
+Use a non-default directory to store and read the database, write the logs, etc.
 By default, *mu* uses the XDG Base Directory Specification (e.g. on GNU/Linux this
 defaults to _~/.cache/mu_ and _~/.config/mu_). Earlier versions of *mu* defaulted to
 _~/.mu_, which now requires *--muhome=~/.mu*.

--- a/man/muhome.inc
+++ b/man/muhome.inc
@@ -1,10 +1,10 @@
 ** --muhome
 use a non-default directory to store and read the database, write the logs, etc.
 By default, *mu* uses the XDG Base Directory Specification (e.g. on GNU/Linux this
-defaults to =~/.cache/mu= and =~/.config/mu=). Earlier versions of *mu* defaulted to
-=~/.mu=, which now requires *--muhome=~/.mu*.
+defaults to _~/.cache/mu_ and _~/.config/mu_). Earlier versions of *mu* defaulted to
+_~/.mu_, which now requires *--muhome=~/.mu*.
 
-The environment variable ~MUHOME~ can be used as an alternative to *--muhome*. The
+The environment variable *MUHOME* can be used as an alternative to *--muhome*. The
 latter has precedence.
 
 # Local Variables:


### PR DESCRIPTION
I tried to make the typesetting of the numerous manual pages more consistent and
more compliant to the standards described in man-pages(7). There are quite a lot
of changes I think, hence I tried to scatter them in different commits to make
it easier to figure out what is going on and to allow picking only certain
changes, in case some of them are not wanted.

There is one major thing to notice. In order to get the proper output for
manual pages references, and synopses, I used *zero width spaces* which I
learned about [here](https://orgmode.org/manual/Emphasis-and-Monospace.html).
This is admittedly a little hacky, there might be a better way to get the same
outputs. It renders fine in standard manual pages, but if you plan to export the
Org sources to other formats, I do not know what it may look like.
