### PR TITLE
Make toggling search properties easier to discover

### DIFF
--- a/mu4e/mu4e-search.el
+++ b/mu4e/mu4e-search.el
@@ -628,7 +628,9 @@ query before submitting it."
     ["Next query" mu4e-search-next
      :help "Run next query"]
     ["Narrow search" mu4e-search-narrow
-     :help "Narrow the search query"])
+     :help "Narrow the search query"]
+    ["Search properties" mu4e-search-toggle-property
+     :help "Toggle some search properties"])
   "Easy menu items for search.")
 
 (provide 'mu4e-search)


### PR DESCRIPTION
For some reason (probably because I don't use it so often), I forget how to toggle the search properties.  Adding a menu entry makes it easier to (re)discover.