### PR TITLE
Canonicalize init --maildir argument after expanding

### DIFF
--- a/mu/mu-options.cc
+++ b/mu/mu-options.cc
@@ -459,7 +459,8 @@ sub_init(CLI::App& sub, Options& opts)
 	sub.add_option("--maildir,-m", opts.init.maildir, "Top of the maildir")
 		->type_name("<maildir>")
 		->default_val(default_mdir)
-		->transform(ExpandPath, "expand maildir path");
+		->transform(ExpandPath, "expand maildir path")
+		->transform(CanonicalizePath, "canonicalize maildir path");
 	sub.add_option("--my-address", opts.init.my_addresses,
 		       "Personal e-mail address or regexp")
 		->type_name("<address>");


### PR DESCRIPTION
Hey,
when I tried to set up `mu` I ran into the following issue:
I ran `mu init --maildir ~/mail` which worked fine but when I tried to do `mu index`
no mails where found. After some investigating I noticed `mu` stores my maildir as `/home/USER//mail` but then disregards mails with the canonical path `/home/USER/mail/...` because they don't have this exact prefix.

I thought it would make sense to store the maildir (which is already ensured to be absolute) as canonical path too and therefore canonicalize the `mu init --maildir` argument after expanding.

This fixes my problem, I hope it doesn't break something else. Feedback is appreciated. :)