### PR TITLE
Update mu-store-worker.hh, remove duplicate `;`

### DIFF
--- a/lib/mu-store-worker.hh
+++ b/lib/mu-store-worker.hh
@@ -159,7 +159,7 @@ private:
 	size_t cleanup_orphans();
 
 	QueueType q_;
-	Store& store_;;
+	Store& store_;
 	std::thread runner_;
 	std::atomic<bool> running_{};
 	SexpCommandHandler sexp_handler_{};


### PR DESCRIPTION
Fix gcc warning:
```
mu4e                           pre-build              [26/198] Compiling C++ object lib/libmu.a.p/mu-query-parser.cc.o               34.390111
mu4e                           pre-build              In file included from ../lib/mu-store.hh:34,                                   34.390132
mu4e                           pre-build                               from ../lib/mu-query-parser.hh:25,                            34.390140
mu4e                           pre-build                               from ../lib/mu-query-parser.cc:20:                            34.390146
mu4e                           pre-build              ../lib/mu-store-worker.hh:162:23: warning: extra ‘;’ [-Wpedantic]              34.390152
mu4e                           pre-build                162 |         Store& store_;;                                                34.390166
mu4e                           pre-build                    |                       ^                                                34.390172
mu4e                           pre-build                    |                       -                                                34.390177
mu4e                           pre-build              [27/198] Compiling C++ object lib/libmu.a.p/mu-contacts-cache.cc.o             34.538682
```