### PR TITLE
lib: use time_t_max for empty datetime

### DIFF
--- a/lib/utils/mu-utils.cc
+++ b/lib/utils/mu-utils.cc
@@ -493,7 +493,7 @@ Mu::parse_date_time(const std::string& dstr, bool is_first, bool utc)
 
 	/* one-sided dates */
 	if (dstr.empty())
-		return is_first ? 0 : G_MAXINT64;
+		return is_first ? time_t_min : time_t_max;
 	else if (dstr == "today" || dstr == "now")
 		return special_date_time(dstr, is_first);
 	else if (dstr.find_first_of("ymdwhMs") != std::string::npos)


### PR DESCRIPTION
In Mu::parse_date_time, when provided with an empty string, return time_t_max instead of G_MAXINT64. For systems with a 64-bit time_t, there is no difference. With a 32-bit time_t it caused a test to fail:

    not ok /utils/date-basic - ERROR:../mu-1.12.4/lib/utils/tests/test-utils.cc:92
    void test_date_basic(): assertion failed
    (parse_date_time(std::get<0>(test), std::get<1>(test)).value_or(-1)
      == std::get<2>(test)): (18446744073709551615 == 2147483647)

This edge case probably only affected the test, as when other parts of the application call parse_date_time (e.g. mu-server.cc and mu-query-processor.cc), they check if the input string is empty first.