### PR TITLE
Ensure `User-Agent' is set

### DIFF
--- a/mu4e/mu4e-draft.el
+++ b/mu4e/mu4e-draft.el
@@ -723,7 +723,8 @@ Returns the new buffer."
   ;; compose-func
   (let ((draft-buffer)
         (oldframe (selected-frame))
-        (oldwinconf (current-window-configuration)))
+        (oldwinconf (current-window-configuration))
+        (message-newsreader mu4e-user-agent-string))
     (with-temp-buffer
       ;; provide a temp buffer so the compose-func can do its thing
       (setq draft-buffer (mu4e--validate-hidden-buffer (funcall compose-func)))


### PR DESCRIPTION
* Set `message-newsreader' before calling `mu4e--prepare-draft-buffer' so that `User-Agent' is properly set.

* Fixes #2750.

(Though I'm not very certain this is the best place to set this.  Please advice.)