### PR TITLE
Replace zero-width spaces in man pages with an empty string.

### DIFF
--- a/man/meson.build
+++ b/man/meson.build
@@ -80,10 +80,16 @@ foreach src : man_orgs
   configure_file(input: src, output:'@BASENAME@.org',
                  configuration: conf_data)
 
+  # (replace-regexp-in-string) removes zero-width spaces — added for
+  # text formatting purposes by the man-link macro — from the
+  # resulting man page.
   expr_tmpl = ''.join([
     '(progn',
     '  (require \'ox-man)',
     '  (setq org-export-with-sub-superscripts \'{})',
+    '  (add-to-list \'org-export-filter-plain-text-functions',
+    '    (lambda (text _backend _info)',
+    '      (replace-regexp-in-string "\u200b" "" text)))',
     '  (org-export-to-file \'man "@0@"))'])
   expr = expr_tmpl.format(org.substring(0,-4))
   sectiondir = join_paths(mandir, 'man' + section)


### PR DESCRIPTION
The zero-width spaces are added by the `man-link` macro to ensure bold text formatting when exporting from org, but they interfere with man page functionality in Emacs.

Fixes https://github.com/djcb/mu/issues/2753. Let me know if you'd like the comment to be more/less wordy.