### PR TITLE
Use <DEL> for scroll-down in mu4e-view-mode like in Gnus

### DIFF
--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -930,6 +930,7 @@ This is useful for advising some Gnus-functionality that does not work in mu4e."
 
     ;; intra-message navigation
     (define-key map (kbd "S-SPC") #'scroll-down)
+    (define-key map (kbd "<DEL>") #'scroll-down)
     (define-key map (kbd "SPC") #'mu4e-view-scroll-up-or-next)
     (define-key map (kbd "RET")  #'mu4e-scroll-up)
     (define-key map (kbd "<backspace>") #'mu4e-scroll-down)


### PR DESCRIPTION
* It looks like `<DEL>` does not work in mu4e-view-mode, while it does in mu4e-raw-view-mode which inherits keybindings from view-mode.
* "S-SPC" does not seem to work reliably under terminal either.
* Adding `<DEL>` make it more consistent with existing paging as in info, Gnus, etc.