### PR TITLE
mu-find: return timestamps in json output instead of elisp time objects, add --format tests

### DIFF
--- a/lib/message/mu-fields.hh
+++ b/lib/message/mu-fields.hh
@@ -583,6 +583,17 @@ field_is_combi (const std::string& name)
 	return name == "recip" || name == "contact";
 }
 
+/**
+ * Check if a field name corresponds to a timestamp field.
+ *
+ * @param name field name
+ *
+ * @return true or false
+ */
+static inline bool field_is_timestamp(const std::string& name) {
+    auto fieldOpt = field_from_name(name);
+    return fieldOpt && fieldOpt->is_time_t();
+}
 
 /**
  * Get the Field::Id for some number, or nullopt if it does not match

--- a/lib/utils/mu-sexp.cc
+++ b/lib/utils/mu-sexp.cc
@@ -19,6 +19,7 @@
 
 
 #include "mu-sexp.hh"
+#include "message/mu-fields.hh"
 #include "mu-utils.hh"
 
 #include <atomic>
@@ -222,9 +223,15 @@ Sexp::to_json_string(Format fopts) const
 			auto it{list().begin()};
 			bool first{true};
 			while (it != list().end()) {
-				sstrm << (first ? "" : ",")  << quote(it->symbol().name) << ":";
+				const auto symbol = it->symbol();
+				sstrm << (first ? "" : ",")  << quote(symbol.name) << ":";
 				++it;
-				sstrm << it->to_json_string();
+				// For dates, convert elisp time into a unix timestamp
+				if(field_is_timestamp(symbol.asFieldName()) && it->etimep()) {
+					sstrm << it->etime();
+				} else {
+					sstrm << it->to_json_string();
+				}
 				++it;
 				first = false;
 			}


### PR DESCRIPTION
I was really confused by the format of the dates in the json output until I looked into the code and realized that they're in the crazy Elisp time object format. Doing `[ (.":date"[0] * 65536 + .":date"[1])` in `jq` does work but is not very intuitive. 

This PR adds support for checking during json generation if a symbol matches a known field with the type `TimeT` while being of the correct  `Sexp` structure to be an Elisp time object and converts it into a Unix timestamp. I also added some tests for the different output formats. 

Changes:
- **`Field::field_is_timestamp(string)`**: Checks if a name matches a known field with the `TimeT` type.
- **`Sexp::etimep` and `Sexp::etime`**: Check if Sexp is a valid Elisp time object and convert it to timestamp
- **`Sexp::Symbol::asFieldName`**: Strips leading colon from symbol names for field comparison.
- **`Sexp::to_json_string`**: Now returns Unix timestamps using the above functions
- **Tests**: Added XML, JSON, and SEXP format tests (`/cmd/find/xml|json|sexp`).
