### PR TITLE
mu4e-actions: ensure empty tag removal on message retagging.

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -215,7 +215,7 @@ would add \"tag\" and \"long tag\", and remove \"oldtag\"."
        (t
         (setq taglist (push tag taglist)))))
 
-    (setq taglist (sort (delete-dups taglist) 'string<))
+    (setq taglist (delete "" (sort (delete-dups taglist) 'string<)))
     (setq tagstr (mapconcat 'identity taglist sep))
 
     (setq tagstr (replace-regexp-in-string "[\\&]" "\\\\\\&" tagstr))


### PR DESCRIPTION
Somehow, empty tags creep into the tag list; so now `, tag1, tag2` becomes `tag1, tag2`.