### PR TITLE
mu4e-org: autoload org-link-set-parameters

### DIFF
--- a/mu4e/mu4e-org.el
+++ b/mu4e/mu4e-org.el
@@ -142,6 +142,7 @@ it with org)."
   (org-capture))
 
 ;; install mu4e-link support.
+;;;###autoload
 (org-link-set-parameters "mu4e"
                          :follow #'mu4e-org-open
                          :store  #'mu4e-org-store-link)


### PR DESCRIPTION
With this change, mu4e: links now load mu4e if it wasn't loaded already.