### PR TITLE
Use named function, not lambda, for refresh timer

### DIFF
--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -131,8 +131,9 @@ Invoke FUNC if non-nil."
     (when (and mu4e-update-interval (null mu4e--update-timer))
       (setq mu4e--update-timer
             (run-at-time 0 mu4e-update-interval
-                         (lambda () (mu4e-update-mail-and-index
-                                     mu4e-index-update-in-background)))))))
+                         (defun mu4e--refresh-timer ()
+                           (mu4e-update-mail-and-index
+                            mu4e-index-update-in-background)))))))
 
 (defun mu4e--start (&optional func)
   "Start mu4e.


### PR DESCRIPTION
This change turns the mu4e refresh timer into a named function, making M-x list-timers output display a name having to do with mu4e instead of an inscrutable "anonymous lambda" line.