### PR TITLE
Remove unwanted comment in Info manual

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -1560,8 +1560,8 @@ E-mail messages can be though as a series of ``MIME-parts'', which are sections
 of the message. The most prominent is the 'body', that is the main message your
 are reading. Many e-mail messages also contains @emph{attachments}, which
 MIME-parts that contain files@footnote{Attachments come in two flavors:
-@c{inline} and @c{attachment}. @t{mu4e} does not distinguish between them when
-operating on them; everything that specifies a filename is considered an
+@emph{inline} and @emph{attachment}. @t{mu4e} does not distinguish between them
+when operating on them; everything that specifies a filename is considered an
 attachment}.
 
 To save such attachments as files on your file systems, @t{mu4e}'s message-view


### PR DESCRIPTION
I think I found a comment line in the Mu4e Info manual that is not meant to be commented out. I replaced the wrong markers with emphasis ones.