### PR TITLE
Support dash when autocompleting maildirs

### DIFF
--- a/mu4e/mu4e-search.el
+++ b/mu4e/mu4e-search.el
@@ -412,7 +412,7 @@ status, STATUS."
           '("attach" "draft" "flagged" "list" "new" "passed" "replied"
             "seen" "trashed" "unread" "encrypted" "signed" "personal"
             "calendar")))
-   ((looking-back "maildir:\\([a-zA-Z0-9/.]*\\)" nil)
+   ((looking-back "maildir:\\([a-zA-Z0-9/.-]*\\)" nil)
     (list (match-beginning 1)
           (match-end 1)
           (mapcar (lambda (dir)


### PR DESCRIPTION
From: https://groups.google.com/g/mu-discuss/c/5tPfTirmiws/m/T-X9nLQcBwAJ

`mu4e-search` autocompletion seems to not support the dash, example for
`/mydomain/box/.lists.emacs-`

I don't get suggestions for
`/mydomain/box/.lists.emacs-orgmode`
`/mydomain/box/.lists.emacs-users`

This small patch seems to fix the issue. I intentionally didn't touch anything else to keep the scope at minimum.

Thanks for a review!