### PR TITLE
mu4e-notification: ignore dbus errors

### DIFF
--- a/mu4e/mu4e-notification.el
+++ b/mu4e/mu4e-notification.el
@@ -73,9 +73,11 @@ zero."
   (when-let* ((fav (mu4e-bookmark-favorite))
               (delta-unread (plist-get fav :delta-unread)))
     (when (and (fboundp 'notifications-close-notification)
+               (fboundp 'dbus-ignore-errors)
                mu4e--notification-id
                (zerop delta-unread))
-      (notifications-close-notification mu4e--notification-id)
+      (dbus-ignore-errors
+        (notifications-close-notification mu4e--notification-id))
       (setq mu4e--notification-id nil))
     (when (and (> delta-unread 0)
                (not (= delta-unread mu4e--last-delta-unread)))


### PR DESCRIPTION
notifications protocol says that an empty dbus error message is sent back when the notification to close no longer exists: https://specifications.freedesktop.org/notification-spec/latest/protocol.html#command-close-notification

Some notification daemons don't signal errors, but others do (e.g. EDNC). Adjust the code to be conformant to the spec.

Extends #2835 logic.