### PR TITLE
Remove unnecessary leading white-space in buffer names

### DIFF
--- a/mu4e/mu4e-mime-parts.el
+++ b/mu4e/mu4e-mime-parts.el
@@ -365,7 +365,7 @@ files."
     ;; open in this emacs instance, "raw"
     (:name "raw" :handler (lambda (str)
                             (let ((tmpbuf
-                                   (get-buffer-create " *mu4e-raw-mime*")))
+                                   (get-buffer-create "*mu4e-raw-mime*")))
                               (with-current-buffer tmpbuf
                                 (insert str)
                                 (view-mode)

--- a/mu4e/mu4e-server.el
+++ b/mu4e/mu4e-server.el
@@ -222,7 +222,7 @@ It is the mu4e-version of \"mu find <query> --analyze\"."
 
 (defvar mu4e--server-buf nil
   "Buffer (string) for data received from the backend.")
-(defconst mu4e--server-name " *mu4e-server*"
+(defconst mu4e--server-name "*mu4e-server*"
   "Name of the server process, buffer.")
 (defvar mu4e--server-process nil
   "The mu-server process.")

--- a/mu4e/mu4e-update.el
+++ b/mu4e/mu4e-update.el
@@ -143,7 +143,7 @@ If non-nil, this is a plist of the form:
 Useful for diagnosing update problems.")
 
 ;;; Internal variables / const
-(defconst mu4e--update-name " *mu4e-update*"
+(defconst mu4e--update-name "*mu4e-update*"
   "Name of the process and buffer to update mail.")
 (defvar mu4e--progress-reporter nil
   "Internal, the progress reporter object.")

--- a/mu4e/mu4e-view.el
+++ b/mu4e/mu4e-view.el
@@ -97,7 +97,7 @@ The first letter of NAME is used as a shortcut character."
   :type 'integer
   :group 'mu4e-view)
 
-(defconst mu4e--view-raw-buffer-name " *mu4e-raw-view*"
+(defconst mu4e--view-raw-buffer-name "*mu4e-raw-view*"
   "Name for the raw message view buffer.")
 
 (defun mu4e-view-raw-message ()

--- a/mu4e/mu4e-window.el
+++ b/mu4e/mu4e-window.el
@@ -34,7 +34,7 @@
 (defvar mu4e-main-buffer-name "*mu4e-main*"
   "Name of the mu4e main buffer.")
 
-(defvar mu4e-embedded-buffer-name " *mu4e-embedded*"
+(defvar mu4e-embedded-buffer-name "*mu4e-embedded*"
   "Name for the embedded message view buffer.")
 
 ;; Buffer names for public use


### PR DESCRIPTION
I noticed there are leading white-space in buffer names which is probably unintended so I removed them.