### PR TITLE
Trivial typo fixes

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,7 +1,7 @@
 #+STARTUP:showall
 * NEWS (user visible changes & bigger non-visible ones)
 
-* 1.4 (released on January 24, 2026)
+* 1.14 (released on January 24, 2026)
 
   The 1.14 series continues where the 1.12 series left off, with just some
   version updates & depreciations.
@@ -14,7 +14,7 @@
 
    - ~mu4e-main-hide-personal-addresses~ can now also be a number, which
      is the maximum number of addresses to show. This can be useful if you have
-     some many personal addresses that the clutter up the main view. (1.14.0)
+     so many personal addresses that they clutter up the main view. (1.14.0)
 
    - ~mu4e-compose-reply-include-mime-types~ specifies the mime-types for message
      attachments that should be included in replies, with the default set to


### PR DESCRIPTION
The `1.4` -> `1.14` typo fix is possibly meaningful, the other ones not so much.