### PR TITLE
fix typo  'we mu uses....'

### DIFF
--- a/man/mu-move.1.org
+++ b/man/mu-move.1.org
@@ -64,7 +64,7 @@ messages, i.e. messages that live in the _cur/_ sub-directory of a Maildir.
 | T    | Trashed; to be deleted later       |
 
 New messages (in the _new/_ sub-directory) do not have flags encoded in their
-file-name; but we *mu* uses `N' in the *--flags* to represent that:
+file-name; but *mu* uses `N' in the *--flags* to represent that:
 
 #+ATTR_MAN: :disable-caption t
 | Flag | Meaning |


### PR DESCRIPTION
fix type in man page. 

it said 'we mu uses...' I presume it meant just "mu uses"