### PR TITLE
Refresh timer being disabled due to an error during mail/index update

### DIFF
--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -147,8 +147,10 @@ Invoke FUNC if non-nil."
       (setq mu4e--update-timer
             (run-at-time 0 mu4e-update-interval
                          (defun mu4e--refresh-timer ()
-                           (mu4e-update-mail-and-index
-                            mu4e-index-update-in-background)))))))
+                           (condition-case err
+                               (mu4e-update-mail-and-index
+                                mu4e-index-update-in-background)
+                             (error (mu4e-warn "Error during mu4e automatic update: %s" err)))))))))
 
 (defun mu4e--start (&optional func)
   "Start mu4e.

--- a/mu4e/mu4e.el
+++ b/mu4e/mu4e.el
@@ -150,7 +150,7 @@ Invoke FUNC if non-nil."
                            (condition-case err
                                (mu4e-update-mail-and-index
                                 mu4e-index-update-in-background)
-                             (error (mu4e-warn "Error during mu4e automatic update: %s" err)))))))))
+                             (error (message "[mu4e] error during automatic update: %s" (error-message-string err))))))))))
 
 (defun mu4e--start (&optional func)
   "Start mu4e.


### PR DESCRIPTION
At least once a week, the refresh timer used to automatically check for new emails somehow gets disturbed if an error happens during mail/index update. Since this happens silently, I would only find out hours later that my emails are not up-to-date.

Wrapping the call in `condition-case' better protects against this issue.