### PR TITLE
Remove unnecessary eager loads of ido

### DIFF
--- a/mu4e/mu4e-actions.el
+++ b/mu4e/mu4e-actions.el
@@ -27,7 +27,6 @@
 
 ;;; Code:
 
-(require 'ido)
 (require 'browse-url)
 
 (require 'mu4e-helpers)

--- a/mu4e/mu4e-helpers.el
+++ b/mu4e/mu4e-helpers.el
@@ -28,7 +28,6 @@
 ;;; Code:
 
 (require 'seq)
-(require 'ido)
 (require 'cl-lib)
 (require 'bookmark)
 (require 'message)


### PR DESCRIPTION
To save a bit of time on startup.

mu4e-actions.el doesn't mention ido.

mu4e-helpers.el does, but `ido-completing-read` is autoloaded anyway.