### PR TITLE
mu4e: guard modeline truncate-string-to-width against NS DnD crash

### DIFF
--- a/mu4e/mu4e-modeline.el
+++ b/mu4e/mu4e-modeline.el
@@ -80,7 +80,9 @@ The string is truncated to fit if its length exceeds
 `mu4e-modeline-max-width'."
   (replace-regexp-in-string
    "%" "%%"
-   (truncate-string-to-width str mu4e-modeline-max-width 0 nil t)))
+   (if (> (string-width str) mu4e-modeline-max-width)
+       (truncate-string-to-width str mu4e-modeline-max-width 0 nil t)
+     str)))
 
 (defvar mu4e--modeline-item nil
   "Mu4e item for the global-mode-line.")


### PR DESCRIPTION
This apparently pointless fix guards against an insta-crash occasioned by `mu4e-modeline` during drag-and-drop on Darwin.

The control flow in `truncate-string-to-width` involves raising and catching an exception whenever the string is shorter than the target (i.e., the function has nothing to do). Which is generally fine, except that drag-and-drop on Darwin (NS) invokes a re-render while Emacs is idling with `waiting_for_input` set. In particular, this re-renders the modeline installed by `mu4e`, whereupon `truncate-string-to-width` raises an exception, and an exception raised during `waiting_for_input` goes straight to a hard crash. 

This is not really `mu4e`'s problem, but the fix is harmless enough that it seems worth doing: ensure that `truncate-string-to-width` is only called
when it is actually needed.
