### PR TITLE
mu4e: propertize headers before hiding them

### DIFF
--- a/mu4e/mu4e-helpers.el
+++ b/mu4e/mu4e-helpers.el
@@ -713,6 +713,9 @@ which we need to avoid #2661."
                   (save-excursion
                     (goto-char end-of-headers)
                     (insert-before-markers header))))))))
+      ;; `syntax-propertize' can't widen, so make sure it won't need to
+      ;; (Emacs bug#81035).
+      (syntax-propertize end-of-headers)
       (narrow-to-region end-of-headers (point-max)))))
 
 (defun mu4e-key-description (cmd)


### PR DESCRIPTION
Fix for error: 

```
Cannot syntax-propertize 1..349 because of narrowing!
```

on every compose new message.

Emacs hit the same thing in its own `message-hide-headers` and fixed it in [bug#81035](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=81035) (reported for `C-u m` in a Gnus Group buffer, fixed by Stefan Monnier, commit `cc68545f`). Since mu4e carries its own copy, it never picked up that fix.

This fix is basically the same; propertize up to `end-of-headers` while the buffer is still wide.

Verified with `mu4e-compose-new` as well, on mu 1.14.4-pre2 with Emacs 32.0.50.
