### PR TITLE
Fix header buffer mis-alignment line in Emacs 31+

### DIFF
--- a/mu4e/mu4e.texi
+++ b/mu4e/mu4e.texi
@@ -5001,7 +5001,10 @@ headings, you can try something like the following:
         header-line-format)
   ;; Ensure `text-scale-adjust' scales the header line with the headers themselves
   ;; by ensuring the `default' face is in the inheritance hierarchy.
-  (face-remap-add-relative 'header-line '(:inherit (mu4e-header-face default)))
+  (face-remap-add-relative 'header-line '(:inherit (mu4e-header-face default))))
+  ;; In Emacs 31+, use these two lines instead:
+  ;; (face-remap-add-relative 'header-line-active '(:inherit (mu4e-header-face default)))
+  ;; (face-remap-add-relative 'header-line-inactive '(:inherit (mu4e-header-face default))))
 @end lisp
 
 This does not solve all possible issues; that would require a thorough rework of


### PR DESCRIPTION
Emacs 31 introduced new faces 'header-line-active' and 'header-line-inactive'. The fix to header buffer misalignment suggested in the manual remaps 'header-line' only, so headers are misaligned again when the header buffer is inactive. Added a two-liner in comments for Emacs 31+ compatibility regarding header line face remapping..